### PR TITLE
meta-hpe: add serial console and SOL support

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/80-gxp-obmc-console-uart.rules
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/80-gxp-obmc-console-uart.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="tty", ATTRS{iomem_base}=="0xC00000E0", SYMLINK+="ttyHostS0", TAG+="systemd"
+SUBSYSTEM=="tty", ATTRS{iomem_base}=="0x80FD0218", ENV{SYSTEMD_WANTS}="obmc-console@ttyVUART0", SYMLINK+="ttyVUART0", TAG+="systemd"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/server.ttyS0.conf
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/server.ttyS0.conf
@@ -1,0 +1,3 @@
+console-id = ttyS0
+local-tty = ttyS0
+local-tty-baud = 115200

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/server.ttyVUART0.conf
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/server.ttyVUART0.conf
@@ -1,0 +1,2 @@
+local-tty = ttyVUART0
+local-tty-baud = 115200

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console_%.bbappend
@@ -1,0 +1,16 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+    file://80-gxp-obmc-console-uart.rules \
+    file://server.ttyS0.conf \
+    file://server.ttyVUART0.conf \
+"
+
+OBMC_CONSOLE_HOST_TTY = "ttyVUART0"
+OBMC_CONSOLE_TTYS = "ttyS0 ttyVUART0"
+
+do_install:append() {
+    install -d ${D}${nonarch_base_libdir}/udev/rules.d
+    install -m 0644 ${UNPACKDIR}/80-gxp-obmc-console-uart.rules \
+        ${D}${nonarch_base_libdir}/udev/rules.d/
+}

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 KBRANCH = "v6.18-hpe-gxp"
-SRCREV = "daad8146de8a53d1fe4294e10401381a5da587ef"
+SRCREV = "0c6de5aa0cb69522c13813352918e1082cf43b0c"
 
 KBUILD_DEFCONFIG = "gxp_defconfig"
 KERNEL_DEVICETREE = "hpe/hpe-gxp.dtb"


### PR DESCRIPTION
Addresses #37

Add obmc-console configuration for host serial console access via the GXP Virtual UART (ttyVUART0) and physical host UART (ttyS0). Includes udev rules, per-port server configs, and a kernel SRCREV bump for the VUART driver.

Drop socket-id and console-id from the VUART server config. This version of obmc-console ignores socket-id entirely, and console-id caused a socket name mismatch: the server listened on @obmc-console.ttyVUART0 while the SSH client connected to @obmc-console.default. Without either key, both default to "default".

Tested-on: HPE ProLiant DL320 Gen11