### PR TITLE
HPE Proliant Gen11: fix the host boot-up

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/leds/phosphor-led-manager/led-group-config.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/leds/phosphor-led-manager/led-group-config.json
@@ -1,0 +1,14 @@
+{
+    "leds": [
+        {
+            "group": "enclosure_identify",
+            "members": [
+                {
+                    "Name": "identify_platform",
+                    "Action": "On",
+                    "Priority": "On"
+                }
+            ]
+        }
+    ]
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/leds/phosphor-led-manager_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/leds/phosphor-led-manager_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " file://led-group-config.json"
+
+do_install:append() {
+        install -m 0644 ${UNPACKDIR}/led-group-config.json ${D}${datadir}/phosphor-led-manager/
+}
+
+# Power and chassis LEDs are handled by CPLD
+CHASSIS_TARGETS = ""

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 KBRANCH = "v6.18-hpe-gxp"
-SRCREV = "0c6de5aa0cb69522c13813352918e1082cf43b0c"
+SRCREV = "9c48ad66ee2f0aaf99b948c5e3c0495c22130e3e"
 
 KBUILD_DEFCONFIG = "gxp_defconfig"
 KERNEL_DEVICETREE = "hpe/hpe-gxp.dtb"


### PR DESCRIPTION
Update the Linux kernel to address the following:
- Add support for host warm reset.
  - https://github.com/canopybmc/linux/commit/08105c98c28322996cb27275bbcb76458df3c437
- Fix startup instability. #36
  - https://github.com/canopybmc/linux/commit/0d9184f392c710ab7427bdd6345ec99282a704ae
- Add the CHIF driver to support OS boot. #38
  - https://github.com/canopybmc/linux/commit/a37692371e1eed822568a6be047568195a4ac605
- Initial phosphor-led-manager configuration.
  - Support "System identify LED"
Note: Currently, we have only added the CHIF kernel driver to prevent Dxe errors during firmware runtime. The CHIF requires a usespace service to be functional.