### PR TITLE
meta-hpe: add total system power virtual sensor

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
@@ -38,6 +38,7 @@ RDEPENDS:${PN}-flash = " \
 
 SUMMARY:${PN}-system = "HPE System"
 RDEPENDS:${PN}-system = " \
+        phosphor-virtual-sensor \
         entity-manager \
         dbus-sensors \
         "

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0001-devicetree-vpd-parser-add-baseboard-PCA-VPD-support.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0001-devicetree-vpd-parser-add-baseboard-PCA-VPD-support.patch
@@ -1,0 +1,167 @@
+From 9d1b3e4fc8655791bd0b3b02a18c7465c806a561 Mon Sep 17 00:00:00 2001
+From: Christian Walter <christian.walter@9elements.com>
+Date: Fri, 13 Feb 2026 11:33:03 +0100
+Upstream-Status: Pending
+Subject: [PATCH] devicetree-vpd-parser: add baseboard (PCA) VPD support
+
+Expose baseboard-level Vital Product Data (PCA serial number and PCA
+part number) on D-Bus at /xyz/openbmc_project/MachineContext/Baseboard.
+
+U-Boot's ft_board_setup() populates a /baseboard subnode in the Linux
+device tree with PCA serial-number and part-number properties. This
+change makes the devicetree-vpd-parser read those properties and
+expose them via the Inventory.Decorator.Asset D-Bus interface.
+
+The MachineContext class is updated to accept a configurable device
+tree base path, allowing multiple instances: one for system-level VPD
+(root node) and one for baseboard-level PCA VPD (/baseboard subnode).
+
+The baseboard object is only created when the DT node exists, so this
+is backward-compatible with systems that lack PCA data.
+
+Signed-off-by: Christian Walter <christian.walter@9elements.com>
+---
+ .../devicetree_vpd_parser.cpp                 | 25 +++++++++++++++----
+ src/devicetree_vpd_parser/machine_context.cpp | 18 ++++++-------
+ src/devicetree_vpd_parser/machine_context.hpp | 12 ++++++---
+ 3 files changed, 36 insertions(+), 19 deletions(-)
+
+diff --git a/src/devicetree_vpd_parser/devicetree_vpd_parser.cpp b/src/devicetree_vpd_parser/devicetree_vpd_parser.cpp
+index 87bd2d7..1cf0d0c 100644
+--- a/src/devicetree_vpd_parser/devicetree_vpd_parser.cpp
++++ b/src/devicetree_vpd_parser/devicetree_vpd_parser.cpp
+@@ -1,11 +1,16 @@
+ #include "machine_context.hpp"
+ 
+ #include <memory>
++#include <string>
+ 
+ int main()
+ {
+     static constexpr auto reqDBusPath = "/xyz/openbmc_project/MachineContext";
+     static constexpr auto reqDBusName = "xyz.openbmc_project.MachineContext";
++    static constexpr auto bbDBusPath =
++        "/xyz/openbmc_project/MachineContext/Baseboard";
++    static constexpr auto systemDtPath = "/proc/device-tree/";
++    static constexpr auto baseboardDtPath = "/proc/device-tree/baseboard/";
+ 
+     /*Note: OpenBMC convention typically has service name = bus name,
+     where the bus name is representative of the underlying hardware.
+@@ -25,11 +30,21 @@ int main()
+     sdbusplus::async::context ctx;
+     sdbusplus::server::manager_t manager{ctx, reqDBusPath};
+ 
+-    std::unique_ptr<MachineContext> mc = nullptr;
+-    if (MachineContext::keyNodeExists())
++    std::unique_ptr<MachineContext> system = nullptr;
++    if (MachineContext::nodeExists(std::string(systemDtPath) + "model"))
+     {
+-        mc = std::make_unique<MachineContext>(ctx, reqDBusPath);
+-        mc->populateFromDeviceTree();
++        system = std::make_unique<MachineContext>(ctx, reqDBusPath,
++                                                  systemDtPath);
++        system->populateFromDeviceTree();
++    }
++
++    std::unique_ptr<MachineContext> baseboard = nullptr;
++    if (MachineContext::nodeExists(
++            std::string(baseboardDtPath) + "serial-number"))
++    {
++        baseboard = std::make_unique<MachineContext>(ctx, bbDBusPath,
++                                                     baseboardDtPath);
++        baseboard->populateFromDeviceTree();
+     }
+ 
+     // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+@@ -41,4 +56,4 @@ int main()
+     ctx.run();
+ 
+     return 0;
+-};
++}
+diff --git a/src/devicetree_vpd_parser/machine_context.cpp b/src/devicetree_vpd_parser/machine_context.cpp
+index 34358eb..660258b 100644
+--- a/src/devicetree_vpd_parser/machine_context.cpp
++++ b/src/devicetree_vpd_parser/machine_context.cpp
+@@ -9,38 +9,36 @@
+ void MachineContext::populateFromDeviceTree()
+ {
+     std::string nodeVal;
+-    std::ifstream vpdStream(nodeBasePath + std::string("model"));
++    std::ifstream vpdStream(dtBasePath + "model");
+     if (vpdStream && std::getline(vpdStream, nodeVal))
+     {
+         MachineContext::Asset::model(nodeVal);
+         vpdStream.close();
+     }
+ 
+-    vpdStream.open(nodeBasePath + std::string("serial-number"));
++    vpdStream.open(dtBasePath + "serial-number");
+     if (vpdStream && std::getline(vpdStream, nodeVal))
+     {
+         MachineContext::Asset::serial_number(nodeVal);
+         vpdStream.close();
+     }
+ 
+-    vpdStream.open(nodeBasePath + std::string("part-number"));
++    vpdStream.open(dtBasePath + "part-number");
+     if (vpdStream && std::getline(vpdStream, nodeVal))
+     {
+         MachineContext::Asset::part_number(nodeVal);
+         vpdStream.close();
+     }
+ 
+-    vpdStream.open(nodeBasePath + std::string("manufacturer"));
++    vpdStream.open(dtBasePath + "manufacturer");
+     if (vpdStream && std::getline(vpdStream, nodeVal))
+     {
+         MachineContext::Asset::manufacturer(nodeVal);
+         vpdStream.close();
+     }
+-};
++}
+ 
+-bool MachineContext::keyNodeExists()
++bool MachineContext::nodeExists(const std::string& path)
+ {
+-    std::filesystem::path nodePath{nodeBasePath + std::string("model")};
+-
+-    return std::filesystem::exists(nodePath);
+-};
++    return std::filesystem::exists(std::filesystem::path{path});
++}
+diff --git a/src/devicetree_vpd_parser/machine_context.hpp b/src/devicetree_vpd_parser/machine_context.hpp
+index 3945b58..cedf22d 100644
+--- a/src/devicetree_vpd_parser/machine_context.hpp
++++ b/src/devicetree_vpd_parser/machine_context.hpp
+@@ -6,19 +6,23 @@
+ #include <sdbusplus/async.hpp>
+ #include <xyz/openbmc_project/Inventory/Decorator/Asset/aserver.hpp>
+ 
++#include <string>
++
+ class MachineContext :
+     public sdbusplus::aserver::xyz::openbmc_project::inventory::decorator::
+         Asset<MachineContext>
+ {
+   public:
+-    explicit MachineContext(sdbusplus::async::context& ctx, auto path) :
++    explicit MachineContext(sdbusplus::async::context& ctx, auto path,
++                           std::string dtBasePath) :
+         sdbusplus::aserver::xyz::openbmc_project::inventory::decorator::Asset<
+-            MachineContext>(ctx, path) {};
++            MachineContext>(ctx, path),
++        dtBasePath(std::move(dtBasePath)) {};
+ 
+     void populateFromDeviceTree();
+ 
+-    static bool keyNodeExists();
++    static bool nodeExists(const std::string& path);
+ 
+   private:
+-    static constexpr auto nodeBasePath = "/proc/device-tree/";
++    std::string dtBasePath;
+ };
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
@@ -278,6 +278,16 @@
                 }
             ],
             "Type": "XeonCPU"
+        },
+        {
+            "Name": "GenericPowerPort",
+            "PortType": "powered_by",
+            "Type": "Port"
+        },
+        {
+            "Name": "GenericContainPort",
+            "PortType": "containing",
+            "Type": "Port"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/hpe_psu.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/hpe_psu.json
@@ -2,6 +2,16 @@
     {
         "Exposes": [
             {
+                "Name": "GenericPowerPort",
+                "PortType": "powering",
+                "Type": "Port"
+            },
+            {
+                "Name": "GenericContainPort",
+                "PortType": "contained_by",
+                "Type": "Port"
+            },
+            {
                 "Address": "$ADDRESS",
                 "Bus": "$BUS",
                 "CurrScaleFactor": 64,
@@ -13,12 +23,8 @@
                     "power2",
                     "curr1",
                     "curr2",
-                    "iout1",
-                    "vout1",
-                    "pout1",
-                    "vin1",
-                    "in1",
-                    "in2"
+                    "in0",
+                    "in1"
                 ],
                 "Name": "PSU_$ADDRESS - 87",
                 "PollRate": 10,
@@ -33,63 +39,63 @@
                 "Thresholds": [
                     {
                         "Direction": "greater than",
-                        "Label": "vin1",
+                        "Label": "in0",
                         "Name": "upper critical",
                         "Severity": 1,
                         "Value": 240
                     },
                     {
                         "Direction": "less than",
-                        "Label": "vin1",
+                        "Label": "in0",
                         "Name": "lower critical",
                         "Severity": 1,
                         "Value": 90
                     },
                     {
                         "Direction": "greater than",
-                        "Label": "iout1",
+                        "Label": "curr2",
                         "Name": "upper critical",
                         "Severity": 1,
                         "Value": 66.7
                     },
                     {
                         "Direction": "greater than",
-                        "Label": "iout1",
+                        "Label": "curr2",
                         "Name": "upper non critical",
                         "Severity": 0,
                         "Value": 60
                     },
                     {
                         "Direction": "greater than",
-                        "Label": "pout1",
+                        "Label": "power2",
                         "Name": "upper critical",
                         "Severity": 1,
                         "Value": 800
                     },
                     {
                         "Direction": "greater than",
-                        "Label": "pout1",
+                        "Label": "power2",
                         "Name": "upper non critical",
                         "Severity": 0,
                         "Value": 720
                     },
                     {
                         "Direction": "greater than",
-                        "Label": "vout1",
+                        "Label": "in1",
                         "Name": "upper critical",
                         "Severity": 1,
                         "Value": 14
                     },
                     {
                         "Direction": "less than",
-                        "Label": "vout1",
+                        "Label": "in1",
                         "Name": "lower non critical",
                         "Severity": 0,
                         "Value": 11.5
                     },
                     {
                         "Direction": "less than",
-                        "Label": "vout1",
+                        "Label": "in1",
                         "Name": "lower critical",
                         "Severity": 1,
                         "Value": 11
@@ -130,19 +136,19 @@
                         "Value": 20300
                     }
                 ],
-                "Type": "PowerSupply",
+                "Type": "gxp_psu",
                 "curr1_Name": "IINPUT_PSU$ADDRESS - 87",
                 "curr2_Name": "IOUTPUT_PSU$ADDRESS - 87",
                 "fan1_Name": "FAN1_PSU$ADDRESS - 87",
-                "in1_Name": "VINPUT_PSU$ADDRESS - 87",
-                "in2_Name": "VOUTPUT_PSU$ADDRESS - 87",
+                "in0_Name": "VINPUT_PSU$ADDRESS - 87",
+                "in1_Name": "VOUTPUT_PSU$ADDRESS - 87",
                 "power1_Name": "PINPUT_PSU$ADDRESS - 87",
                 "power2_Name": "POUTPUT_PSU$ADDRESS - 87",
                 "temp1_Name": "TEMP1_PSU$ADDRESS - 87"
             }
         ],
         "Name": "HPE POWER SUPPLY $ADDRESS - 87",
-        "Probe": "xyz.openbmc_project.FruDevice({'PRODUCT_PRODUCT_NAME': 'HPE POWER SUPPLY          '})",
+        "Probe": "xyz.openbmc_project.FruDevice({'PRODUCT_PRODUCT_NAME': 'HPE POWER SUPPLY*'})",
         "Type": "PowerSupply",
         "xyz.openbmc_project.Inventory.Decorator.Asset": {
             "Manufacturer": "$PRODUCT_MANUFACTURER",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
@@ -26,6 +26,7 @@ SRC_URI += " \
     file://dl385g11_baseboard.json \
     file://dl560g11_baseboard.json \
     file://rl300g11_baseboard.json \
+    file://hpe_psu.json \
 "
 
 do_install:append() {
@@ -42,4 +43,5 @@ do_install:append() {
     install -D ${UNPACKDIR}/dl385g11_baseboard.json ${D}${datadir}/${BPN}/configurations/hpe/dl385g11_baseboard.json
     install -D ${UNPACKDIR}/dl560g11_baseboard.json ${D}${datadir}/${BPN}/configurations/hpe/dl560g11_baseboard.json
     install -D ${UNPACKDIR}/rl300g11_baseboard.json ${D}${datadir}/${BPN}/configurations/hpe/rl300g11_baseboard.json
+    install -D ${UNPACKDIR}/hpe_psu.json ${D}${datadir}/${BPN}/configurations/hpe/hpe_psu.json
 }

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
@@ -7,6 +7,9 @@ SRCREV = "330c0d82ef0a3122eb1d83f3af7379aeedfb49bb"
 # Enable devicetree VPD parser for platform identification
 PACKAGECONFIG:append = " dts-vpd"
 
+# Baseboard (PCA) VPD support for devicetree-vpd-parser
+SRC_URI += "file://0001-devicetree-vpd-parser-add-baseboard-PCA-VPD-support.patch"
+
 # HPE ProLiant Gen11 baseboard configurations
 SRC_URI += " \
     file://blocklist.json \

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " redfish-allow-deprecated-power-thermal"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/dbus-sensors/0001-psusensor-add-gxp_psu-to-sensorTypes-whitelist.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/dbus-sensors/0001-psusensor-add-gxp_psu-to-sensorTypes-whitelist.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Canopy BMC <canopy@canopybmc.com>
+Date: Thu, 13 Feb 2026 12:00:00 +0000
+Subject: [PATCH] psusensor: add gxp_psu to sensorTypes whitelist
+
+Add the HPE GXP PSU hwmon driver ("gxp_psu") to psusensor's
+sensorTypes map so that it discovers hwmon sensors exported by the
+gxp-psu kernel driver. The driver is not PMBus-based.
+
+Upstream-Status: Pending
+Signed-off-by: Canopy BMC <canopy@canopybmc.com>
+---
+ src/psu/PSUSensorMain.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/psu/PSUSensorMain.cpp b/src/psu/PSUSensorMain.cpp
+index 1234567..abcdefg 100644
+--- a/src/psu/PSUSensorMain.cpp
++++ b/src/psu/PSUSensorMain.cpp
+@@ -79,6 +79,7 @@ static const I2CDeviceTypeMap sensorTypes{
+     {"CRPS185", I2CDeviceType{"crps185", true}},
+     {"DPS800", I2CDeviceType{"dps800", true}},
+     {"INA219", I2CDeviceType{"ina219", true}},
++    {"gxp_psu", I2CDeviceType{"gxp_psu", false}},
+     {"INA226", I2CDeviceType{"ina226", true}},
+     {"INA230", I2CDeviceType{"ina230", true}},
+     {"INA233", I2CDeviceType{"ina233", true}},
+--
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-psusensor-add-gxp_psu-to-sensorTypes-whitelist.patch"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/phosphor-virtual-sensor/virtual_sensor_config.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/phosphor-virtual-sensor/virtual_sensor_config.json
@@ -1,0 +1,50 @@
+[
+    {
+        "Desc":
+        {
+            "Name": "total_power",
+            "SensorType": "power",
+            "MinValue": 0,
+            "MaxValue": 1200
+        },
+        "Threshold":
+        {
+        },
+        "Associations":
+        [
+            [
+                "chassis",
+                "all_sensors",
+                "/xyz/openbmc_project/inventory/system/chassis/chassis"
+            ],
+            [
+                "inventory",
+                "sensors",
+                "/xyz/openbmc_project/inventory/system/chassis/chassis"
+            ]
+        ],
+        "Params":
+        {
+            "DbusParam":
+            [
+                {
+                    "ParamName": "P0",
+                    "Desc":
+                    {
+                        "Name": "PINPUT_PSU1",
+                        "SensorType": "power"
+                    }
+                },
+                {
+                    "ParamName": "P1",
+                    "Desc":
+                    {
+                        "Name": "PINPUT_PSU2",
+                        "SensorType": "power"
+                    }
+                }
+            ]
+        },
+        "Expression": "( P0 == P0 ) ? (P1 == P1) ? (P0 + P1) : P0 : (P1 == P1) ? P1 : NULL"
+    }
+]

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/phosphor-virtual-sensor_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/sensors/phosphor-virtual-sensor_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/phosphor-virtual-sensor:"
+
+SRC_URI += "file://virtual_sensor_config.json"
+
+do_install:append() {
+    install -d ${D}${datadir}/phosphor-virtual-sensor
+    install -m 0644 ${UNPACKDIR}/virtual_sensor_config.json ${D}${datadir}/phosphor-virtual-sensor/virtual_sensor_config.json
+}

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy/0001-ARM-dts-hpe-gxp-split-xreg-reg-range-for-i2c-mux.patch
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy/0001-ARM-dts-hpe-gxp-split-xreg-reg-range-for-i2c-mux.patch
@@ -1,0 +1,37 @@
+From: Christian Walter <christian.walter@9elements.com>
+Date: Thu, 13 Feb 2026 00:00:00 +0000
+Subject: [PATCH] ARM: dts: hpe-gxp: split xreg reg range for i2c mux
+ registers
+
+The xreg node claims a single contiguous region at 0xd1000000 size
+0x11c, which covers the i2c mux select registers at offsets 0x84-0x93.
+This prevents i2c-mux-reg from requesting those addresses, causing all
+four i2c mux instances to fail probe with -EBUSY.
+
+Split the xreg reg property into two ranges with a gap at 0x84-0x93
+so that i2c-mux-reg can claim the mux select registers:
+  0xd1000000-0xd1000083 (0x84 bytes)
+  0xd1000094-0xd10000ff (0x6c bytes)
+
+Upstream-Status: Pending
+Signed-off-by: Christian Walter <christian.walter@9elements.com>
+---
+ arch/arm/boot/dts/hpe/hpe-gxp.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/hpe/hpe-gxp.dts b/arch/arm/boot/dts/hpe/hpe-gxp.dts
+index 1234567..abcdefg 100644
+--- a/arch/arm/boot/dts/hpe/hpe-gxp.dts
++++ b/arch/arm/boot/dts/hpe/hpe-gxp.dts
+@@ -105,7 +105,8 @@
+
+ 		xreg: xreg@d1000000 {
+ 			compatible = "hpe,gxp-xreg", "simple-mfd", "syscon";
+-			reg = <0xd1000000 0x11c>;
++			/* gap at 0x84-0x93 reserved for i2c mux select registers */
++			reg = <0xd1000000 0x84>, <0xd1000094 0x6c>;
+ 			interrupts = <26>;
+ 			interrupt-parent = <&vic0>;
+ 			interrupt-controller;
+--
+2.43.0

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy/0002-hwmon-add-HPE-GXP-PSU-driver.patch
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy/0002-hwmon-add-HPE-GXP-PSU-driver.patch
@@ -1,0 +1,469 @@
+From de50238ee22638f32a2baed04e6423cc5f37e414 Mon Sep 17 00:00:00 2001
+From: Christian Walter <christian.walter@9elements.com>
+Date: Fri, 13 Feb 2026 20:12:17 +0100
+Subject: [PATCH] hwmon: add HPE GXP PSU driver
+
+Add a hardware monitoring driver for HPE GXP Power Supply Units. The
+driver communicates with PSUs over I2C using a proprietary command-based
+protocol with byte-sum checksums, and exposes sensor readings (input/
+output voltage, current, power, temperature, fan speed) via the hwmon
+subsystem.
+
+A read-only binary sysfs attribute "eeprom" provides access to the 256-
+byte FRU EEPROM contents using the PSU's proprietary read command (0x22).
+
+The driver uses the modern devm_hwmon_device_register_with_info() API
+with hwmon_ops callbacks.
+
+Upstream-Status: Pending
+Signed-off-by: Christian Walter <christian.walter@9elements.com>
+---
+ arch/arm/configs/gxp_defconfig |   1 +
+ drivers/hwmon/Kconfig          |   8 +
+ drivers/hwmon/Makefile         |   1 +
+ drivers/hwmon/gxp-psu.c        | 390 +++++++++++++++++++++++++++++++++
+ 4 files changed, 400 insertions(+)
+ create mode 100644 drivers/hwmon/gxp-psu.c
+
+diff --git a/arch/arm/configs/gxp_defconfig b/arch/arm/configs/gxp_defconfig
+index f07f4bb8082f..a164e64d4cfc 100644
+--- a/arch/arm/configs/gxp_defconfig
++++ b/arch/arm/configs/gxp_defconfig
+@@ -63,6 +63,7 @@ CONFIG_SPI_GXP=y
+ CONFIG_GPIOLIB=y
+ CONFIG_GPIO_GXP=y
+ CONFIG_SENSORS_GXP_FAN_CTRL=y
++CONFIG_SENSORS_GXP_PSU=m
+ CONFIG_WATCHDOG=y
+ CONFIG_GXP_WATCHDOG=y
+ CONFIG_REGULATOR=y
+diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
+index 18d5d4d9589c..05a45d6d1898 100644
+--- a/drivers/hwmon/Kconfig
++++ b/drivers/hwmon/Kconfig
+@@ -821,6 +821,14 @@ config SENSORS_GXP_FAN_CTRL
+ 	  The GXP controls fan function via the CPLD through the use of PWM
+ 	  registers. This driver reports status and pwm setting of the fans.
+ 
++config SENSORS_GXP_PSU
++	tristate "HPE GXP PSU driver"
++	depends on I2C
++	depends on ARCH_HPE_GXP || COMPILE_TEST
++	help
++	  If you say yes here you get support for HPE GXP power supply unit
++	  monitoring via I2C including sensor readings and FRU EEPROM access.
++
+ config SENSORS_HIH6130
+ 	tristate "Honeywell Humidicon HIH-6130 humidity/temperature sensor"
+ 	depends on I2C
+diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
+index 73b2abdcc6dd..2bf83cfe864e 100644
+--- a/drivers/hwmon/Makefile
++++ b/drivers/hwmon/Makefile
+@@ -91,6 +91,7 @@ obj-$(CONFIG_SENSORS_GSC)	+= gsc-hwmon.o
+ obj-$(CONFIG_SENSORS_GPD)	+= gpd-fan.o
+ obj-$(CONFIG_SENSORS_GPIO_FAN)	+= gpio-fan.o
+ obj-$(CONFIG_SENSORS_GXP_FAN_CTRL) += gxp-fan-ctrl.o
++obj-$(CONFIG_SENSORS_GXP_PSU)	+= gxp-psu.o
+ obj-$(CONFIG_SENSORS_HIH6130)	+= hih6130.o
+ obj-$(CONFIG_SENSORS_HS3001)	+= hs3001.o
+ obj-$(CONFIG_SENSORS_HTU31)	+= htu31.o
+diff --git a/drivers/hwmon/gxp-psu.c b/drivers/hwmon/gxp-psu.c
+new file mode 100644
+index 000000000000..e3c77e73ec6a
+--- /dev/null
++++ b/drivers/hwmon/gxp-psu.c
+@@ -0,0 +1,390 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * HPE GXP PSU (Power Supply Unit) hwmon driver
++ *
++ * Copyright (C) 2019 Hewlett-Packard Development Company, L.P.
++ *
++ * This driver communicates with HPE power supply units over I2C using a
++ * proprietary command-based protocol with byte-sum checksums. It exposes
++ * sensor readings (voltage, current, power, temperature, fan speed) via
++ * the hwmon subsystem and FRU EEPROM contents via a binary sysfs attribute.
++ *
++ * Protocol overview:
++ *   Register read: TX [0x00, reg, checksum] -> RX [lo, hi, checksum]
++ *   FRU read:      TX [0x22, offset, length, checksum] -> RX [data...]
++ *   Checksum:      byte-sum of all bytes in the message equals zero
++ */
++
++#include <linux/module.h>
++#include <linux/mod_devicetable.h>
++#include <linux/i2c.h>
++#include <linux/hwmon.h>
++#include <linux/err.h>
++#include <linux/mutex.h>
++#include <linux/sysfs.h>
++
++#define GXP_PSU_FRU_CMD		0x22
++#define GXP_PSU_FRU_SIZE	256
++
++/* Sensor register addresses */
++#define GXP_PSU_REG_IN_VOL	0x10
++#define GXP_PSU_REG_IN_CUR	0x11
++#define GXP_PSU_REG_IN_PWR	0x12
++#define GXP_PSU_REG_OUT_VOL	0x20
++#define GXP_PSU_REG_OUT_CUR	0x21
++#define GXP_PSU_REG_OUT_PWR	0x22
++#define GXP_PSU_REG_FAN	0x40
++#define GXP_PSU_REG_TEMP	0x42
++
++struct gxp_psu_drvdata {
++	struct i2c_client *client;
++	struct mutex lock; /* protects I2C transactions */
++};
++
++static u8 gxp_psu_checksum(const u8 *buf, size_t len)
++{
++	u8 sum = 0;
++	size_t i;
++
++	for (i = 0; i < len; i++)
++		sum += buf[i];
++	return sum;
++}
++
++/**
++ * gxp_psu_read_reg() - Read a 16-bit sensor register from the PSU.
++ * @drvdata: driver private data
++ * @reg: register address
++ * @val: output value
++ *
++ * Protocol: TX [0x00, reg, checksum] -> RX [lo, hi, checksum]
++ * Both TX and RX checksums are chosen so that the byte-sum of
++ * [slave_addr_byte, payload...] equals zero.
++ *
++ * Return: 0 on success, negative errno on failure.
++ */
++static int gxp_psu_read_reg(struct gxp_psu_drvdata *drvdata, u8 reg, u16 *val)
++{
++	struct i2c_client *client = drvdata->client;
++	u8 tx_chk[3] = { client->addr << 1, 0x00, reg };
++	u8 tx[3] = { 0x00, reg, 0 };
++	u8 rx[3] = {};
++	struct i2c_msg msgs[2] = {
++		{
++			.addr = client->addr,
++			.flags = 0,
++			.buf = tx,
++			.len = sizeof(tx),
++		},
++		{
++			.addr = client->addr,
++			.flags = I2C_M_RD,
++			.buf = rx,
++			.len = sizeof(rx),
++		},
++	};
++	int ret;
++
++	tx[2] = -gxp_psu_checksum(tx_chk, sizeof(tx_chk));
++
++	guard(mutex)(&drvdata->lock);
++
++	ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
++	if (ret < 0)
++		return ret;
++	if (ret != ARRAY_SIZE(msgs))
++		return -EIO;
++
++	if (gxp_psu_checksum(rx, sizeof(rx)) != 0) {
++		dev_dbg(&client->dev,
++			"checksum fail reg:0x%02x data:%02x %02x %02x\n",
++			reg, rx[0], rx[1], rx[2]);
++		return -EIO;
++	}
++
++	*val = rx[0] | (rx[1] << 8);
++	return 0;
++}
++
++/**
++ * gxp_psu_read_fru() - Read FRU EEPROM data from the PSU.
++ * @drvdata: driver private data
++ * @offset: byte offset into the FRU EEPROM
++ * @buf: output buffer
++ * @count: number of bytes to read
++ *
++ * Protocol: TX [0x22, offset, length, checksum] -> RX [data...]
++ * The TX checksum is computed over [slave_addr_byte, 0x22, offset, length].
++ *
++ * Return: number of bytes read on success, negative errno on failure.
++ */
++static int gxp_psu_read_fru(struct gxp_psu_drvdata *drvdata,
++			     u8 offset, u8 count, u8 *buf)
++{
++	struct i2c_client *client = drvdata->client;
++	u8 chk_buf[4] = { client->addr << 1, GXP_PSU_FRU_CMD, offset, count };
++	u8 tx[4] = { GXP_PSU_FRU_CMD, offset, count, 0 };
++	struct i2c_msg msgs[2] = {
++		{
++			.addr = client->addr,
++			.flags = 0,
++			.buf = tx,
++			.len = sizeof(tx),
++		},
++		{
++			.addr = client->addr,
++			.flags = I2C_M_RD,
++			.buf = buf,
++			.len = count,
++		},
++	};
++	int ret;
++
++	tx[3] = -gxp_psu_checksum(chk_buf, sizeof(chk_buf));
++
++	guard(mutex)(&drvdata->lock);
++
++	ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
++	if (ret < 0)
++		return ret;
++	if (ret != ARRAY_SIZE(msgs))
++		return -EIO;
++
++	return count;
++}
++
++/* hwmon channel definitions */
++
++static const u32 gxp_psu_in_config[] = {
++	HWMON_I_INPUT,	/* vin */
++	HWMON_I_INPUT,	/* vout */
++	0,
++};
++
++static const u32 gxp_psu_curr_config[] = {
++	HWMON_I_INPUT,	/* iin */
++	HWMON_I_INPUT,	/* iout */
++	0,
++};
++
++static const u32 gxp_psu_power_config[] = {
++	HWMON_P_INPUT,	/* pin */
++	HWMON_P_INPUT,	/* pout */
++	0,
++};
++
++static const u32 gxp_psu_temp_config[] = {
++	HWMON_T_INPUT,
++	0,
++};
++
++static const u32 gxp_psu_fan_config[] = {
++	HWMON_F_INPUT,
++	0,
++};
++
++static const struct hwmon_channel_info gxp_psu_in = {
++	.type = hwmon_in,
++	.config = gxp_psu_in_config,
++};
++
++static const struct hwmon_channel_info gxp_psu_curr = {
++	.type = hwmon_curr,
++	.config = gxp_psu_curr_config,
++};
++
++static const struct hwmon_channel_info gxp_psu_power = {
++	.type = hwmon_power,
++	.config = gxp_psu_power_config,
++};
++
++static const struct hwmon_channel_info gxp_psu_temp = {
++	.type = hwmon_temp,
++	.config = gxp_psu_temp_config,
++};
++
++static const struct hwmon_channel_info gxp_psu_fan = {
++	.type = hwmon_fan,
++	.config = gxp_psu_fan_config,
++};
++
++static const struct hwmon_channel_info * const gxp_psu_info[] = {
++	&gxp_psu_in,
++	&gxp_psu_curr,
++	&gxp_psu_power,
++	&gxp_psu_temp,
++	&gxp_psu_fan,
++	NULL,
++};
++
++static umode_t gxp_psu_is_visible(const void *data,
++				   enum hwmon_sensor_types type,
++				   u32 attr, int channel)
++{
++	return 0444;
++}
++
++static int gxp_psu_read(struct device *dev, enum hwmon_sensor_types type,
++			u32 attr, int channel, long *val)
++{
++	struct gxp_psu_drvdata *drvdata = dev_get_drvdata(dev);
++	u16 raw;
++	u8 reg;
++	int ret;
++
++	switch (type) {
++	case hwmon_in:
++		reg = channel == 0 ? GXP_PSU_REG_IN_VOL : GXP_PSU_REG_OUT_VOL;
++		break;
++	case hwmon_curr:
++		reg = channel == 0 ? GXP_PSU_REG_IN_CUR : GXP_PSU_REG_OUT_CUR;
++		break;
++	case hwmon_power:
++		reg = channel == 0 ? GXP_PSU_REG_IN_PWR : GXP_PSU_REG_OUT_PWR;
++		break;
++	case hwmon_temp:
++		reg = GXP_PSU_REG_TEMP;
++		break;
++	case hwmon_fan:
++		reg = GXP_PSU_REG_FAN;
++		break;
++	default:
++		return -EOPNOTSUPP;
++	}
++
++	ret = gxp_psu_read_reg(drvdata, reg, &raw);
++	if (ret)
++		return ret;
++
++	/*
++	 * Return raw register values; psusensor applies ScaleFactors
++	 * from entity-manager config to convert to display units:
++	 *   voltage:     raw units 1/32 V   (InScaleFactor: 32)
++	 *   output volt: raw units 1/256 V, normalized to 1/32 V by /8
++	 *   current:     raw units 1/64 A   (CurrScaleFactor: 64)
++	 *   power:       raw units 1 W      (PowerScaleFactor: 1)
++	 *   temperature: raw units 1/64 C   (TempScaleFactor: 64)
++	 *   fan:         raw RPM
++	 */
++	switch (type) {
++	case hwmon_in:
++		if (channel == 0)
++			*val = raw;
++		else
++			*val = raw / 8; /* normalize 1/256 V to 1/32 V */
++		break;
++	case hwmon_curr:
++	case hwmon_power:
++	case hwmon_fan:
++		*val = raw;
++		break;
++	case hwmon_temp:
++		*val = (s16)raw;
++		break;
++	default:
++		return -EOPNOTSUPP;
++	}
++
++	return 0;
++}
++
++static const struct hwmon_ops gxp_psu_hwmon_ops = {
++	.is_visible = gxp_psu_is_visible,
++	.read = gxp_psu_read,
++};
++
++static const struct hwmon_chip_info gxp_psu_chip_info = {
++	.ops = &gxp_psu_hwmon_ops,
++	.info = gxp_psu_info,
++};
++
++/* FRU EEPROM binary attribute */
++
++static ssize_t gxp_psu_eeprom_read(struct file *filp, struct kobject *kobj,
++				    const struct bin_attribute *attr, char *buf,
++				    loff_t off, size_t count)
++{
++	struct device *dev = kobj_to_dev(kobj);
++	struct gxp_psu_drvdata *drvdata = dev_get_drvdata(dev);
++
++	if (off >= GXP_PSU_FRU_SIZE)
++		return 0;
++
++	if (off + count > GXP_PSU_FRU_SIZE)
++		count = GXP_PSU_FRU_SIZE - off;
++
++	/* FRU protocol uses u8 count; cap to avoid overflow (256 -> 0) */
++	if (count > 255)
++		count = 255;
++
++	return gxp_psu_read_fru(drvdata, off, count, buf);
++}
++
++static const struct bin_attribute gxp_psu_eeprom_attr = {
++	.attr = {
++		.name = "eeprom",
++		.mode = 0444,
++	},
++	.size = GXP_PSU_FRU_SIZE,
++	.read = gxp_psu_eeprom_read,
++};
++
++static void gxp_psu_cleanup_eeprom(void *data)
++{
++	struct i2c_client *client = data;
++
++	device_remove_bin_file(&client->dev, &gxp_psu_eeprom_attr);
++}
++
++static int gxp_psu_probe(struct i2c_client *client)
++{
++	struct gxp_psu_drvdata *drvdata;
++	struct device *hwmon_dev;
++	int ret;
++
++	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C))
++		return -EOPNOTSUPP;
++
++	drvdata = devm_kzalloc(&client->dev, sizeof(*drvdata), GFP_KERNEL);
++	if (!drvdata)
++		return -ENOMEM;
++
++	drvdata->client = client;
++	mutex_init(&drvdata->lock);
++	dev_set_drvdata(&client->dev, drvdata);
++
++	hwmon_dev = devm_hwmon_device_register_with_info(&client->dev,
++							 "gxp_psu", drvdata,
++							 &gxp_psu_chip_info,
++							 NULL);
++	if (IS_ERR(hwmon_dev))
++		return PTR_ERR(hwmon_dev);
++
++	ret = device_create_bin_file(&client->dev, &gxp_psu_eeprom_attr);
++	if (ret)
++		return ret;
++
++	return devm_add_action_or_reset(&client->dev,
++					gxp_psu_cleanup_eeprom, client);
++}
++
++static const struct of_device_id gxp_psu_of_match[] = {
++	{ .compatible = "hpe,gxp-psu" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, gxp_psu_of_match);
++
++static struct i2c_driver gxp_psu_driver = {
++	.probe	= gxp_psu_probe,
++	.driver = {
++		.name		= "gxp-psu",
++		.of_match_table	= gxp_psu_of_match,
++	},
++};
++
++module_i2c_driver(gxp_psu_driver);
++
++MODULE_AUTHOR("Louis Hsu <kai-hsiang.hsu@hpe.com>");
++MODULE_AUTHOR("Jean-Marie Verdun <verdun@hpe.com>");
++MODULE_DESCRIPTION("HPE GXP PSU driver");
++MODULE_LICENSE("GPL");
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
@@ -9,6 +9,7 @@ KERNEL_DTBVENDORED = "1"
 
 SRC_URI:append = " file://gxp.cfg"
 SRC_URI += "file://0001-ARM-dts-hpe-gxp-split-xreg-reg-range-for-i2c-mux.patch"
+SRC_URI += "file://0002-hwmon-add-HPE-GXP-PSU-driver.patch"
 
 require linux-gxp-flash-layout.inc
 require linux-gxp-multi-dtb.inc

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-canopy_6.18.bbappend
@@ -8,6 +8,7 @@ KERNEL_DEVICETREE = "hpe/hpe-gxp.dtb"
 KERNEL_DTBVENDORED = "1"
 
 SRC_URI:append = " file://gxp.cfg"
+SRC_URI += "file://0001-ARM-dts-hpe-gxp-split-xreg-reg-range-for-i2c-mux.patch"
 
 require linux-gxp-flash-layout.inc
 require linux-gxp-multi-dtb.inc


### PR DESCRIPTION
Add phosphor-virtual-sensor to the image with a configuration that computes total system power consumption by summing PSU1 and PSU2 input power readings (PINPUT_PSU1 + PINPUT_PSU2).

The expression handles PSU absence gracefully: if only one PSU reports data, total_power reflects that single PSU; if neither reports, the sensor reads NULL.

This is similar to what HPE has enabled in their openBMC version