### PR TITLE
meta-hpe: add UID button handling via phosphor-multi-gpio-monitor

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
@@ -23,6 +23,7 @@ RPROVIDES:${PN}-system += "virtual-obmc-system-mgmt"
 
 SUMMARY:${PN}-chassis = "HPE Chassis"
 RDEPENDS:${PN}-chassis = " \
+        phosphor-gpio-monitor-monitor \
         x86-power-control \
         "
 

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor/phosphor-multi-gpio-monitor.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor/phosphor-multi-gpio-monitor.json
@@ -1,0 +1,9 @@
+[
+    {
+        "Name": "UidButton",
+        "LineName": "uid-button",
+        "EventMon": "FALLING",
+        "Target": "uid-button-toggle.service",
+        "Continue": true
+    }
+]

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor/uid-button-toggle.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor/uid-button-toggle.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Toggle UID identify LED
+After=xyz.openbmc_project.LED.GroupManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/uid-button-toggle.sh

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor/uid-button-toggle.sh
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor/uid-button-toggle.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+led_service=$(mapper get-service /xyz/openbmc_project/led/groups/enclosure_identify)
+uid_state=$(busctl get-property "${led_service}" /xyz/openbmc_project/led/groups/enclosure_identify xyz.openbmc_project.Led.Group Asserted | cut -d " " -f 2)
+if [ "${uid_state}" = "true" ]; then
+    busctl set-property "${led_service}" /xyz/openbmc_project/led/groups/enclosure_identify xyz.openbmc_project.Led.Group Asserted b false
+else
+    busctl set-property "${led_service}" /xyz/openbmc_project/led/groups/enclosure_identify xyz.openbmc_project.Led.Group Asserted b true
+fi

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/gpio/phosphor-gpio-monitor_%.bbappend
@@ -1,0 +1,24 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/phosphor-gpio-monitor:"
+
+SRC_URI += " \
+    file://phosphor-multi-gpio-monitor.json \
+    file://uid-button-toggle.sh \
+    file://uid-button-toggle.service \
+    "
+
+SYSTEMD_LINK:${PN}-monitor += " \
+    ../phosphor-multi-gpio-monitor.service:multi-user.target.requires/phosphor-multi-gpio-monitor.service \
+    "
+
+FILES:${PN}-monitor += "${bindir}/uid-button-toggle.sh ${systemd_system_unitdir}/uid-button-toggle.service"
+
+do_install:append() {
+    install -d ${D}${datadir}/${BPN}
+    install -m 0644 ${UNPACKDIR}/phosphor-multi-gpio-monitor.json ${D}${datadir}/${BPN}/phosphor-multi-gpio-monitor.json
+
+    install -d ${D}${bindir}
+    install -m 0755 ${UNPACKDIR}/uid-button-toggle.sh ${D}${bindir}/uid-button-toggle.sh
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/uid-button-toggle.service ${D}${systemd_system_unitdir}/uid-button-toggle.service
+}


### PR DESCRIPTION
Configure phosphor-multi-gpio-monitor to watch the uid-button GPIO (line 60, active-high input) and toggle the enclosure_identify LED group on each button press.

Components:
- phosphor-multi-gpio-monitor.json: monitors uid-button GPIO on FALLING edge, triggers uid-button-toggle.service
- uid-button-toggle.sh: reads current enclosure_identify LED state via D-Bus and flips it
- uid-button-toggle.service: oneshot systemd unit to run the script
- phosphor-multi-gpio-monitor.service: override upstream service to add [Install] WantedBy=multi-user.target for auto-start
- bbappend: installs config, scripts, and services; adds script and service to the -monitor package
- packagegroup: adds phosphor-gpio-monitor-monitor to chassis deps

This needs testing in the lab if the button actually works now.