### PR TITLE
meta-hpe: add CHIF service for SMBIOS inventory via Redfish

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
@@ -26,6 +26,17 @@ install_data(
     install_dir: systemd_system_unit_dir,
 )
 
+udev_dep = dependency('udev')
+udev_rules_dir = udev_dep.get_variable(
+    'udev_dir',
+    pkgconfig_define: ['prefix', get_option('prefix')],
+) / 'rules.d'
+
+install_data(
+    'service_files/90-gxp-chif.rules',
+    install_dir: udev_rules_dir,
+)
+
 src_files = files(
     'src/main.cpp',
     'src/chif_daemon.cpp',

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
@@ -1,0 +1,105 @@
+project(
+    'gxp-chif-svc',
+    'cpp',
+    version: '1.0.0',
+    license: 'Apache-2.0',
+    default_options: [
+        'cpp_std=c++23',
+        'warning_level=3',
+        'werror=true',
+    ],
+    meson_version: '>=0.63.0',
+)
+
+systemd_dep = dependency('systemd')
+sdbusplus_dep = dependency('sdbusplus')
+phosphor_dbus_dep = dependency('phosphor-dbus-interfaces')
+phosphor_logging_dep = dependency('phosphor-logging')
+
+systemd_system_unit_dir = systemd_dep.get_variable(
+    'systemdsystemunitdir',
+    pkgconfig_define: ['prefix', get_option('prefix')],
+)
+
+install_data(
+    'service_files/xyz.openbmc_project.GxpChif.service',
+    install_dir: systemd_system_unit_dir,
+)
+
+src_files = files(
+    'src/main.cpp',
+    'src/chif_daemon.cpp',
+    'src/rom_service.cpp',
+    'src/smbios_writer.cpp',
+    'src/mdr_bridge.cpp',
+)
+
+executable(
+    'chif',
+    src_files,
+    dependencies: [
+        sdbusplus_dep,
+        phosphor_dbus_dep,
+        phosphor_logging_dep,
+        systemd_dep,
+    ],
+    install: true,
+    install_dir: get_option('bindir'),
+)
+
+if get_option('tests').enabled()
+    gtest_dep = dependency('gtest', main: true)
+    gtest_main_dep = dependency('gtest_main')
+
+    test_src_common = files(
+        'src/rom_service.cpp',
+        'src/smbios_writer.cpp',
+        'src/mdr_bridge.cpp',
+        'src/chif_daemon.cpp',
+    )
+
+    test_packet = executable(
+        'test_packet',
+        'test/test_packet.cpp',
+        test_src_common,
+        dependencies: [
+            gtest_dep,
+            gtest_main_dep,
+            sdbusplus_dep,
+            phosphor_dbus_dep,
+            phosphor_logging_dep,
+            systemd_dep,
+        ],
+    )
+    test('packet', test_packet)
+
+    test_smbios_writer = executable(
+        'test_smbios_writer',
+        'test/test_smbios_writer.cpp',
+        test_src_common,
+        dependencies: [
+            gtest_dep,
+            gtest_main_dep,
+            sdbusplus_dep,
+            phosphor_dbus_dep,
+            phosphor_logging_dep,
+            systemd_dep,
+        ],
+    )
+    test('smbios_writer', test_smbios_writer)
+
+    test_rom_service = executable(
+        'test_rom_service',
+        'test/test_rom_service.cpp',
+        test_src_common,
+        dependencies: [
+            gtest_dep,
+            gtest_main_dep,
+            sdbusplus_dep,
+            phosphor_dbus_dep,
+            phosphor_logging_dep,
+            systemd_dep,
+        ],
+    )
+    test('rom_service', test_rom_service)
+endif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.options
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.options
@@ -1,0 +1,1 @@
+option('tests', type: 'feature', value: 'enabled', description: 'Build unit tests')

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/90-gxp-chif.rules
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/90-gxp-chif.rules
@@ -1,0 +1,4 @@
+# Tag GXP CHIF devices for systemd device unit activation.
+# The gxp-soc subsystem is not tagged by default systemd udev rules,
+# so without this rule BindsTo=dev-chifNN.device will never activate.
+SUBSYSTEM=="gxp-soc", KERNEL=="chif*", TAG+="systemd"

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/xyz.openbmc_project.GxpChif.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/xyz.openbmc_project.GxpChif.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=GXP CHIF Service
+After=dbus.service
+Requires=dbus.service
+
+[Service]
+ExecStartPre=/bin/mkdir -p /var/lib/smbios
+ExecStart=/usr/bin/chif
+Restart=always
+RestartSec=5
+Type=dbus
+BusName=xyz.openbmc_project.GxpChif
+
+# Security hardening
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/smbios
+DeviceAllow=/dev/chif24 rw
+PrivateTmp=yes
+NoNewPrivileges=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX
+SystemCallFilter=@system-service
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/xyz.openbmc_project.GxpChif.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/xyz.openbmc_project.GxpChif.service
@@ -1,20 +1,20 @@
 [Unit]
 Description=GXP CHIF Service
-After=dbus.service
+After=dbus.service dev-chif24.device
 Requires=dbus.service
+BindsTo=dev-chif24.device
 
 [Service]
-ExecStartPre=/bin/mkdir -p /var/lib/smbios
 ExecStart=/usr/bin/chif
-Restart=always
+Restart=on-failure
 RestartSec=5
 Type=dbus
 BusName=xyz.openbmc_project.GxpChif
+StateDirectory=smbios
 
 # Security hardening
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/var/lib/smbios
 DeviceAllow=/dev/chif24 rw
 PrivateTmp=yes
 NoNewPrivileges=yes

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "chif_daemon.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace chif
+{
+
+ChifDaemon::ChifDaemon(std::unique_ptr<Channel> channel) :
+    channel_(std::move(channel))
+{}
+
+void ChifDaemon::registerHandler(std::unique_ptr<ServiceHandler> handler)
+{
+    uint8_t id = handler->serviceId();
+    handlers_[id] = std::move(handler);
+}
+
+void ChifDaemon::run()
+{
+    running_ = true;
+    lg2::info("CHIF daemon starting");
+
+    while (running_)
+    {
+        auto n = channel_->read(recvBuf_);
+        if (n <= 0)
+        {
+            continue;
+        }
+
+        if (static_cast<size_t>(n) < sizeof(ChifPktHeader))
+        {
+            lg2::warning("Short packet received: {SIZE} bytes", "SIZE", n);
+            continue;
+        }
+
+        auto hdr = parseHeader(
+            std::span<const uint8_t>(recvBuf_.data(), static_cast<size_t>(n)));
+
+        // Copy packed fields to locals — packed fields cannot bind to
+        // references, which lg2 requires.
+        uint8_t svcId = hdr.serviceId;
+        uint16_t cmd = hdr.command;
+        uint16_t seq = hdr.sequence;
+
+        lg2::info(
+            "CHIF RX: svc=0x{SVC:02x} cmd=0x{CMD:04x} seq={SEQ} size={SZ}",
+            "SVC", svcId, "CMD", cmd, "SEQ", seq, "SZ", n);
+
+        auto it = handlers_.find(hdr.serviceId);
+        if (it == handlers_.end())
+        {
+            lg2::warning(
+                "CHIF DROP: no handler for svc=0x{SVC:02x} cmd=0x{CMD:04x}",
+                "SVC", svcId, "CMD", cmd);
+            continue;
+        }
+
+        auto reqSpan = std::span<const uint8_t>(recvBuf_.data(),
+                                                static_cast<size_t>(n));
+        auto respSpan = std::span<uint8_t>(respBuf_);
+
+        int respSize = it->second->handle(reqSpan, respSpan);
+        if (respSize > 0)
+        {
+            auto rspHdr = parseHeader(
+                std::span<const uint8_t>(respBuf_.data(),
+                                         static_cast<size_t>(respSize)));
+            uint8_t rspSvc = rspHdr.serviceId;
+            uint16_t rspCmd = rspHdr.command;
+            uint16_t rspSeq = rspHdr.sequence;
+            lg2::info(
+                "CHIF TX: svc=0x{SVC:02x} cmd=0x{CMD:04x} seq={SEQ} size={SZ}",
+                "SVC", rspSvc, "CMD", rspCmd, "SEQ", rspSeq, "SZ", respSize);
+            channel_->write(
+                std::span<const uint8_t>(respBuf_.data(),
+                                         static_cast<size_t>(respSize)));
+        }
+        else
+        {
+            lg2::info("CHIF: handler returned no response for cmd=0x{CMD:04x}",
+                      "CMD", cmd);
+        }
+    }
+
+    lg2::info("CHIF daemon stopped");
+}
+
+void ChifDaemon::stop()
+{
+    running_ = false;
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include "packet.hpp"
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <unordered_map>
+
+namespace chif
+{
+
+class ChifDaemon
+{
+  public:
+    explicit ChifDaemon(std::unique_ptr<Channel> channel);
+
+    // Register a service handler. Overwrites any prior handler for the
+    // same service_id.
+    void registerHandler(std::unique_ptr<ServiceHandler> handler);
+
+    // Run the main packet loop. Blocks until stop() is called.
+    void run();
+
+    // Request the daemon to stop (thread-safe).
+    void stop();
+
+  private:
+    std::unique_ptr<Channel> channel_;
+    std::unordered_map<uint8_t, std::unique_ptr<ServiceHandler>> handlers_;
+    std::atomic<bool> running_{false};
+
+    std::array<uint8_t, maxPacketSize> recvBuf_{};
+    std::array<uint8_t, maxPacketSize> respBuf_{};
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+#include "chif_daemon.hpp"
+#include "mdr_bridge.hpp"
+#include "rom_service.hpp"
+#include "smif_service.hpp"
+#include "smbios_writer.hpp"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <memory>
+
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace
+{
+constexpr auto chifDevice = "/dev/chif24";
+constexpr auto dbusName = "xyz.openbmc_project.GxpChif";
+
+// Global daemon pointer for signal handler
+chif::ChifDaemon* gDaemon = nullptr; // NOLINT
+
+void signalHandler(int /*sig*/)
+{
+    if (gDaemon)
+    {
+        gDaemon->stop();
+    }
+}
+
+// Real device channel wrapping /dev/chif24
+class DeviceChannel : public chif::Channel
+{
+  public:
+    explicit DeviceChannel(int fd) : fd_(fd) {}
+
+    ~DeviceChannel() override
+    {
+        if (fd_ >= 0)
+        {
+            close(fd_);
+        }
+    }
+
+    DeviceChannel(const DeviceChannel&) = delete;
+    DeviceChannel& operator=(const DeviceChannel&) = delete;
+
+    ssize_t read(std::span<uint8_t> buf) override
+    {
+        return ::read(fd_, buf.data(), buf.size());
+    }
+
+    ssize_t write(std::span<const uint8_t> buf) override
+    {
+        return ::write(fd_, buf.data(), buf.size());
+    }
+
+  private:
+    int fd_;
+};
+
+} // namespace
+
+int main()
+{
+    lg2::info("GXP CHIF service starting, version 1.0.0");
+
+    // Open the CHIF device
+    int fd = open(chifDevice, O_RDWR);
+    if (fd < 0)
+    {
+        lg2::error("Failed to open {DEV}: {ERR}", "DEV", chifDevice, "ERR",
+                   strerror(errno));
+        return 1;
+    }
+
+    auto channel = std::make_unique<DeviceChannel>(fd);
+
+    // Connect to D-Bus and request our well-known name
+    auto bus = sdbusplus::bus::new_default();
+    bus.request_name(dbusName);
+
+    // Create service components
+    chif::SmbiosWriter smbiosWriter;
+    chif::MdrBridge mdrBridge(bus);
+
+    // Build daemon and register handlers
+    chif::ChifDaemon daemon(std::move(channel));
+    daemon.registerHandler(
+        std::make_unique<chif::RomService>(smbiosWriter, &mdrBridge));
+    daemon.registerHandler(std::make_unique<chif::SmifService>());
+    daemon.registerHandler(std::make_unique<chif::HealthService>());
+
+    // Install signal handlers for graceful shutdown
+    gDaemon = &daemon;
+    struct sigaction sa{};
+    sa.sa_handler = signalHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGTERM, &sa, nullptr);
+    sigaction(SIGINT, &sa, nullptr);
+
+    // Run the main event loop (blocks until stopped)
+    daemon.run();
+
+    lg2::info("GXP CHIF service exiting");
+    return 0;
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/mdr_bridge.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/mdr_bridge.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "mdr_bridge.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+namespace chif
+{
+
+namespace
+{
+constexpr auto mdrService = "xyz.openbmc_project.Smbios.MDR_V2";
+constexpr auto mdrPath = "/xyz/openbmc_project/Smbios/MDR_V2";
+constexpr auto mdrInterface = "xyz.openbmc_project.Smbios.MDR_V2";
+} // namespace
+
+MdrBridge::MdrBridge(sdbusplus::bus_t& bus) : bus_(bus) {}
+
+bool MdrBridge::synchronize()
+{
+    try
+    {
+        auto method = bus_.new_method_call(mdrService, mdrPath, mdrInterface,
+                                           "AgentSynchronizeData");
+
+        bus_.call_noreply(method);
+        lg2::info("MDR AgentSynchronizeData called successfully");
+        return true;
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::error("MDR AgentSynchronizeData failed: {ERR}", "ERR", e.what());
+        return false;
+    }
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/mdr_bridge.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/mdr_bridge.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <sdbusplus/bus.hpp>
+
+namespace chif
+{
+
+// Calls AgentSynchronizeData() on the smbios-mdr service to trigger
+// parsing of the SMBIOS data file.
+class MdrBridge
+{
+  public:
+    explicit MdrBridge(sdbusplus::bus_t& bus);
+
+    // Trigger smbios-mdr to re-read /var/lib/smbios/smbios2.
+    // Returns true if the D-Bus call succeeded.
+    bool synchronize();
+
+  private:
+    sdbusplus::bus_t& bus_;
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/packet.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/packet.hpp
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <sys/types.h>
+
+namespace chif
+{
+
+// CHIF packet header — 8 bytes, little-endian, packed.
+// All multi-byte fields are stored in host byte order (LE on GXP).
+struct ChifPktHeader
+{
+    uint16_t pktSize;
+    uint16_t sequence;
+    uint16_t command;
+    uint8_t serviceId;
+    uint8_t version;
+} __attribute__((packed));
+
+static_assert(sizeof(ChifPktHeader) == 8, "ChifPktHeader must be 8 bytes");
+
+// Maximum CHIF packet size (kernel driver limit)
+inline constexpr size_t maxPacketSize = 4096;
+
+// Maximum payload size (packet minus header)
+inline constexpr size_t maxPayloadSize = maxPacketSize - sizeof(ChifPktHeader);
+
+// Response command bit — responses have bit 15 set
+inline constexpr uint16_t responseBit = 0x8000;
+
+// Service IDs
+inline constexpr uint8_t smifServiceId = 0x00;
+inline constexpr uint8_t romServiceId = 0x02;
+inline constexpr uint8_t healthServiceId = 0x10;
+
+// Parse a CHIF header from raw bytes. Caller must ensure buf.size() >= 8.
+inline ChifPktHeader parseHeader(std::span<const uint8_t> buf)
+{
+    ChifPktHeader hdr{};
+    std::memcpy(&hdr, buf.data(), sizeof(hdr));
+    return hdr;
+}
+
+// Get a pointer to the payload portion of a packet buffer.
+inline std::span<const uint8_t> payload(std::span<const uint8_t> pkt)
+{
+    if (pkt.size() <= sizeof(ChifPktHeader))
+    {
+        return {};
+    }
+    return pkt.subspan(sizeof(ChifPktHeader));
+}
+
+// Initialize a response header by echoing sequence, setting cmd|0x8000,
+// and copying service_id and version from the request.
+inline void initResponse(std::span<uint8_t> resp,
+                         const ChifPktHeader& reqHdr, uint16_t respSize)
+{
+    ChifPktHeader rspHdr{};
+    rspHdr.pktSize = respSize;
+    rspHdr.sequence = reqHdr.sequence;
+    rspHdr.command = reqHdr.command | responseBit;
+    rspHdr.serviceId = reqHdr.serviceId;
+    rspHdr.version = reqHdr.version;
+    std::memcpy(resp.data(), &rspHdr, sizeof(rspHdr));
+}
+
+// Initialize a ROM response header — ROM service does NOT set the response
+// bit (0x8000). The HPE reference echoes the command value unchanged.
+inline void initRomResponse(std::span<uint8_t> resp,
+                            const ChifPktHeader& reqHdr, uint16_t respSize)
+{
+    ChifPktHeader rspHdr{};
+    rspHdr.pktSize = respSize;
+    rspHdr.sequence = reqHdr.sequence;
+    rspHdr.command = reqHdr.command; // NO response bit for ROM
+    rspHdr.serviceId = reqHdr.serviceId;
+    rspHdr.version = reqHdr.version;
+    std::memcpy(resp.data(), &rspHdr, sizeof(rspHdr));
+}
+
+// Get mutable span to response payload (after header).
+inline std::span<uint8_t> responsePayload(std::span<uint8_t> resp)
+{
+    if (resp.size() <= sizeof(ChifPktHeader))
+    {
+        return {};
+    }
+    return resp.subspan(sizeof(ChifPktHeader));
+}
+
+// Abstract channel for reading/writing CHIF packets.
+// DeviceChannel wraps /dev/chif24; MockChannel is for testing.
+class Channel
+{
+  public:
+    virtual ~Channel() = default;
+    virtual ssize_t read(std::span<uint8_t> buf) = 0;
+    virtual ssize_t write(std::span<const uint8_t> buf) = 0;
+};
+
+// Service handler interface — one per service_id.
+class ServiceHandler
+{
+  public:
+    virtual ~ServiceHandler() = default;
+
+    // Process a request packet and produce a response.
+    // Returns the total response size (including header), or -1 for
+    // "no response" (silently drop).
+    virtual int handle(std::span<const uint8_t> request,
+                       std::span<uint8_t> response) = 0;
+
+    virtual uint8_t serviceId() const = 0;
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/rom_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/rom_service.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "rom_service.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <cstring>
+
+namespace chif
+{
+
+RomService::RomService(SmbiosWriter& writer, MdrBridge* mdrBridge) :
+    writer_(writer), mdrBridge_(mdrBridge)
+{}
+
+int RomService::handle(std::span<const uint8_t> request,
+                       std::span<uint8_t> response)
+{
+    if (request.size() < sizeof(ChifPktHeader))
+    {
+        return -1;
+    }
+
+    auto hdr = parseHeader(request);
+
+    switch (hdr.command)
+    {
+        case romCmdBegin:
+            return handleBegin(hdr, response);
+        case romCmdRecord:
+            return handleRecord(hdr, request, response);
+        case romCmdEnd:
+            return handleEnd(hdr, response);
+        case romCmdPowerData:
+            lg2::info("ROM: power data received (ack only)");
+            return buildHeaderOnlyResponse(hdr, response);
+        case romCmdThermal:
+            lg2::info("ROM: thermal data received (ack only)");
+            return buildHeaderOnlyResponse(hdr, response);
+        case romCmdBlob:
+            return handleBlob(hdr, request, response);
+        default:
+            lg2::warning("ROM: unknown command 0x{CMD:04x}, dropping",
+                         "CMD", static_cast<uint16_t>(hdr.command));
+            return -1;
+    }
+}
+
+int RomService::handleBegin(const ChifPktHeader& reqHdr,
+                            std::span<uint8_t> response)
+{
+    lg2::info("ROM: begin SMBIOS reception");
+    writer_.begin();
+    // HPE reference: header-only response (8 bytes), no payload, no response bit
+    return buildHeaderOnlyResponse(reqHdr, response);
+}
+
+int RomService::handleRecord(const ChifPktHeader& reqHdr,
+                             std::span<const uint8_t> request,
+                             std::span<uint8_t> response)
+{
+    auto data = payload(request);
+    if (data.empty())
+    {
+        lg2::warning("ROM: empty record received");
+        return buildHeaderOnlyResponse(reqHdr, response);
+    }
+
+    writer_.addRecord(data);
+    // HPE framework: default 8-byte header response for all ROM commands
+    return buildHeaderOnlyResponse(reqHdr, response);
+}
+
+int RomService::handleEnd(const ChifPktHeader& reqHdr,
+                          std::span<uint8_t> response)
+{
+    lg2::info("ROM: end SMBIOS reception, {SIZE} bytes accumulated", "SIZE",
+              writer_.dataSize());
+
+    bool ok = writer_.finalize();
+    if (!ok)
+    {
+        lg2::error("ROM: SMBIOS finalization failed");
+    }
+
+    // HPE reference: send header-only response first, then finalize
+    int respSize = buildHeaderOnlyResponse(reqHdr, response);
+
+    // Trigger smbios-mdr to parse the new data
+    if (ok && mdrBridge_)
+    {
+        mdrBridge_->synchronize();
+    }
+
+    return respSize;
+}
+
+int RomService::handleBlob(const ChifPktHeader& reqHdr,
+                           std::span<const uint8_t> request,
+                           std::span<uint8_t> response)
+{
+    // Blob command sends multiple SMBIOS records in a single packet.
+    auto data = payload(request);
+    if (data.empty())
+    {
+        lg2::warning("ROM: empty blob received");
+        return buildHeaderOnlyResponse(reqHdr, response);
+    }
+
+    lg2::info("ROM: blob received, {SIZE} bytes", "SIZE", data.size());
+    writer_.addRecord(data);
+    // HPE framework: default 8-byte header response for all ROM commands
+    return buildHeaderOnlyResponse(reqHdr, response);
+}
+
+int RomService::buildHeaderOnlyResponse(const ChifPktHeader& reqHdr,
+                                        std::span<uint8_t> response)
+{
+    // ROM responses: 8-byte header only, no payload, no response bit.
+    // This matches the HPE reference romchf_submit() behavior.
+    constexpr uint16_t respSize = static_cast<uint16_t>(sizeof(ChifPktHeader));
+
+    if (response.size() < respSize)
+    {
+        return -1;
+    }
+
+    initRomResponse(response, reqHdr, respSize);
+    return respSize;
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/rom_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/rom_service.hpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include "mdr_bridge.hpp"
+#include "packet.hpp"
+#include "smbios_writer.hpp"
+
+#include <memory>
+
+namespace chif
+{
+
+// ROM command codes (within service_id 0x02)
+inline constexpr uint16_t romCmdBegin = 0x0003;
+inline constexpr uint16_t romCmdRecord = 0x0004;
+inline constexpr uint16_t romCmdEnd = 0x0005;
+inline constexpr uint16_t romCmdPowerData = 0x0006;
+inline constexpr uint16_t romCmdThermal = 0x0007;
+inline constexpr uint16_t romCmdBlob = 0x000C;
+
+// ROM service handler — processes SMBIOS data from BIOS.
+//
+// Protocol flow (matching HPE reference behavior):
+//   1. Host sends cmd 0x03 (begin) — we respond with header-only (8B, no
+//      response bit), then clear accumulated records
+//   2. Host sends cmd 0x04 (record) or 0x0C (blob) — we append data and
+//      respond with header-only (8B, no response bit)
+//   3. Host sends cmd 0x05 (end) — we respond with header-only (8B),
+//      then finalize and trigger smbios-mdr
+//
+// Key differences from standard CHIF responses:
+//   - ROM responses do NOT set the response bit (0x8000) in the command field
+//   - ROM responses are header-only (8 bytes, no ErrorCode payload)
+class RomService : public ServiceHandler
+{
+  public:
+    // mdrBridge may be nullptr (for testing without D-Bus).
+    RomService(SmbiosWriter& writer, MdrBridge* mdrBridge);
+
+    int handle(std::span<const uint8_t> request,
+               std::span<uint8_t> response) override;
+
+    uint8_t serviceId() const override
+    {
+        return romServiceId;
+    }
+
+  private:
+    SmbiosWriter& writer_;
+    MdrBridge* mdrBridge_;
+
+    int handleBegin(const ChifPktHeader& reqHdr,
+                    std::span<uint8_t> response);
+
+    int handleRecord(const ChifPktHeader& reqHdr,
+                     std::span<const uint8_t> request,
+                     std::span<uint8_t> response);
+
+    int handleEnd(const ChifPktHeader& reqHdr,
+                  std::span<uint8_t> response);
+
+    int handleBlob(const ChifPktHeader& reqHdr,
+                   std::span<const uint8_t> request,
+                   std::span<uint8_t> response);
+
+    // Build a ROM-style response: 8-byte header only, no payload,
+    // no response bit. Matches HPE romchf_submit() default behavior.
+    static int buildHeaderOnlyResponse(const ChifPktHeader& reqHdr,
+                                       std::span<uint8_t> response);
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smbios_writer.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smbios_writer.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "smbios_writer.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <chrono>
+#include <cstring>
+#include <fstream>
+
+namespace chif
+{
+
+SmbiosWriter::SmbiosWriter(std::filesystem::path dir) : dir_(std::move(dir)) {}
+
+void SmbiosWriter::begin()
+{
+    records_.clear();
+    lg2::info("SMBIOS reception started");
+}
+
+void SmbiosWriter::addRecord(std::span<const uint8_t> record)
+{
+    // HPE ROM blob format: uint32 count, then count × (uint16 size + SMBIOS record).
+    // Strip the wrapper and extract raw SMBIOS records for smbios-mdr.
+    if (record.size() < 6)
+    {
+        return; // too small for even one record
+    }
+
+    uint32_t count = 0;
+    std::memcpy(&count, record.data(), sizeof(count));
+
+    if (count > maxRecordsPerBlob)
+    {
+        lg2::warning("Blob record count {CNT} exceeds limit {MAX}, capping",
+                     "CNT", count, "MAX", maxRecordsPerBlob);
+        count = maxRecordsPerBlob;
+    }
+
+    size_t offset = sizeof(count);
+    for (uint32_t i = 0; i < count && offset + 2 <= record.size(); i++)
+    {
+        uint16_t recSize = 0;
+        std::memcpy(&recSize, record.data() + offset, sizeof(recSize));
+        offset += sizeof(recSize);
+
+        if (recSize == 0 || offset + recSize > record.size())
+        {
+            break;
+        }
+
+        if (records_.size() + recSize > maxSmbiosDataSize)
+        {
+            lg2::warning(
+                "SMBIOS data limit reached ({MAX} bytes), "
+                "discarding further records",
+                "MAX", maxSmbiosDataSize);
+            break;
+        }
+
+        records_.insert(records_.end(), record.data() + offset,
+                        record.data() + offset + recSize);
+        offset += recSize;
+    }
+}
+
+size_t SmbiosWriter::dataSize() const
+{
+    return records_.size();
+}
+
+std::filesystem::path SmbiosWriter::outputPath() const
+{
+    return dir_ / "smbios2";
+}
+
+uint8_t SmbiosWriter::computeChecksum(const Smbios3EntryPoint& ep)
+{
+    // Checksum: all bytes of the EP must sum to zero (mod 256).
+    // We compute the checksum field as -(sum of all other bytes).
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&ep);
+    uint8_t sum = 0;
+    for (size_t i = 0; i < sizeof(ep); i++)
+    {
+        if (i == offsetof(Smbios3EntryPoint, checksum))
+        {
+            continue; // skip the checksum field itself
+        }
+        sum += bytes[i];
+    }
+    return static_cast<uint8_t>(-sum);
+}
+
+bool SmbiosWriter::finalize()
+{
+    if (records_.empty())
+    {
+        lg2::warning("SMBIOS finalize called with no records");
+        return false;
+    }
+
+    // Ensure the output directory exists
+    std::error_code ec;
+    std::filesystem::create_directories(dir_, ec);
+    if (ec)
+    {
+        lg2::error("Failed to create SMBIOS directory {DIR}: {ERR}", "DIR",
+                   dir_.string(), "ERR", ec.message());
+        return false;
+    }
+
+    // Build SMBIOS 3.0 Entry Point
+    Smbios3EntryPoint ep{};
+    ep.anchorString[0] = '_';
+    ep.anchorString[1] = 'S';
+    ep.anchorString[2] = 'M';
+    ep.anchorString[3] = '3';
+    ep.anchorString[4] = '_';
+    ep.entryPointLength = sizeof(Smbios3EntryPoint); // 0x18
+    ep.smbiosMajor = 3;
+    ep.smbiosMinor = 3;
+    ep.smbiosDocrev = 0;
+    ep.entryPointRevision = 0x01;
+    ep.reserved = 0;
+    ep.structureTableMaxSize = static_cast<uint32_t>(records_.size());
+    ep.structureTableAddress = 0; // not used by smbios-mdr (file-based)
+    ep.checksum = computeChecksum(ep);
+
+    // Build MDR header
+    directoryVersion_++;
+    auto now = std::chrono::system_clock::now();
+    auto epoch = std::chrono::duration_cast<std::chrono::seconds>(
+                     now.time_since_epoch())
+                     .count();
+
+    MdrHeader mdr{};
+    mdr.dirVer = directoryVersion_;
+    mdr.mdrType = 2;
+    mdr.timestamp = static_cast<uint32_t>(epoch);
+    mdr.dataSize =
+        static_cast<uint32_t>(sizeof(Smbios3EntryPoint) + records_.size());
+
+    // Write to temp file, then atomic rename
+    auto tempPath = dir_ / "smbios_temp";
+    auto finalPath = outputPath();
+
+    {
+        std::ofstream out(tempPath, std::ios::binary | std::ios::trunc);
+        if (!out)
+        {
+            lg2::error("Failed to open temp file {PATH}", "PATH",
+                       tempPath.string());
+            return false;
+        }
+
+        out.write(reinterpret_cast<const char*>(&mdr), sizeof(mdr));
+        out.write(reinterpret_cast<const char*>(&ep), sizeof(ep));
+        out.write(reinterpret_cast<const char*>(records_.data()),
+                  static_cast<std::streamsize>(records_.size()));
+
+        if (!out)
+        {
+            lg2::error("Failed to write SMBIOS data to {PATH}", "PATH",
+                       tempPath.string());
+            return false;
+        }
+    }
+
+    // Atomic rename
+    std::filesystem::rename(tempPath, finalPath, ec);
+    if (ec)
+    {
+        lg2::error("Failed to rename {SRC} to {DST}: {ERR}", "SRC",
+                   tempPath.string(), "DST", finalPath.string(), "ERR",
+                   ec.message());
+        return false;
+    }
+
+    lg2::info(
+        "SMBIOS data written: {SIZE} bytes, dir_version={VER}", "SIZE",
+        sizeof(mdr) + sizeof(ep) + records_.size(), "VER", directoryVersion_);
+
+    return true;
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smbios_writer.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smbios_writer.hpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace chif
+{
+
+// MDR V2 header written at the start of /var/lib/smbios/smbios2.
+// Must match smbios-mdr's MDRSMBIOSHeader exactly (10 bytes).
+struct MdrHeader
+{
+    uint8_t dirVer;
+    uint8_t mdrType;
+    uint32_t timestamp;
+    uint32_t dataSize;
+} __attribute__((packed));
+
+static_assert(sizeof(MdrHeader) == 10, "MdrHeader must be 10 bytes");
+
+// SMBIOS 3.0 Entry Point (24 bytes), placed immediately after MDR header.
+struct Smbios3EntryPoint
+{
+    uint8_t anchorString[5]; // "_SM3_"
+    uint8_t checksum;
+    uint8_t entryPointLength;
+    uint8_t smbiosMajor;
+    uint8_t smbiosMinor;
+    uint8_t smbiosDocrev;
+    uint8_t entryPointRevision;
+    uint8_t reserved;
+    uint32_t structureTableMaxSize;
+    uint64_t structureTableAddress;
+} __attribute__((packed));
+
+static_assert(sizeof(Smbios3EntryPoint) == 24,
+              "Smbios3EntryPoint must be 24 bytes");
+
+// Safety limits for host-provided data
+inline constexpr size_t maxSmbiosDataSize = 1024 * 1024; // 1 MiB
+inline constexpr uint32_t maxRecordsPerBlob = 1000;
+
+// Accumulates SMBIOS records and writes the final smbios2 file
+// with MDR header + SMBIOS 3.0 Entry Point + raw records.
+class SmbiosWriter
+{
+  public:
+    // Directory where smbios files live (default: /var/lib/smbios/)
+    explicit SmbiosWriter(
+        std::filesystem::path dir = "/var/lib/smbios");
+
+    // Begin a new SMBIOS session — clears any accumulated records.
+    void begin();
+
+    // Append a single SMBIOS record (raw bytes including type/length/handle
+    // header and trailing double-null terminator).
+    void addRecord(std::span<const uint8_t> record);
+
+    // Finalize: construct SMBIOS 3.0 EP + MDR header, write the smbios2
+    // file atomically (write temp, rename). Returns true on success.
+    bool finalize();
+
+    // Get the total accumulated data size (all records).
+    size_t dataSize() const;
+
+    // Get the path to the final smbios2 file.
+    std::filesystem::path outputPath() const;
+
+  private:
+    std::filesystem::path dir_;
+    std::vector<uint8_t> records_;
+    uint8_t directoryVersion_{0};
+
+    // Compute the SMBIOS 3.0 EP checksum.
+    static uint8_t computeChecksum(const Smbios3EntryPoint& ep);
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include "packet.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <cstring>
+
+namespace chif
+{
+
+// SMIF service handler — responds to BIOS commands.
+//
+// Most commands return ErrorCode=1 (not implemented). Only the BIOS
+// readiness command (0x0008) and boot progress acknowledgements return
+// success, because the BIOS gates SMBIOS transfer on BMC readiness.
+class SmifService : public ServiceHandler
+{
+  public:
+    int handle(std::span<const uint8_t> request,
+               std::span<uint8_t> response) override
+    {
+        if (request.size() < sizeof(ChifPktHeader))
+        {
+            return -1;
+        }
+
+        auto hdr = parseHeader(request);
+
+        switch (hdr.command)
+        {
+            // --- Commands that MUST return error to avoid infinite loops ---
+            case 0x012b: // EV get by index — must return "not found"
+            case 0x012d: // EV get related — must return "not found"
+            case 0x0130: // EV get by name — must return "not found"
+                return buildSimpleResponse(hdr, response, 1);
+
+            // --- Commands that return success ---
+            case 0x0008: // BIOS readiness
+                lg2::info("SMIF: BIOS readiness query — responding ready");
+                return buildSimpleResponse(hdr, response, 0);
+            default:
+                // Accept all other commands with success.
+                // This lets the BIOS proceed through its full POST flow
+                // including UEFI var store uploads (0x0203-0x0207) and
+                // other non-enumeration commands.
+                return buildSimpleResponse(hdr, response, 0);
+        }
+    }
+
+    uint8_t serviceId() const override
+    {
+        return smifServiceId;
+    }
+
+  private:
+    static int buildSimpleResponse(const ChifPktHeader& reqHdr,
+                                   std::span<uint8_t> response,
+                                   uint32_t errorCode)
+    {
+        constexpr uint16_t respSize =
+            static_cast<uint16_t>(sizeof(ChifPktHeader) + sizeof(uint32_t));
+
+        if (response.size() < respSize)
+        {
+            return -1;
+        }
+
+        initResponse(response, reqHdr, respSize);
+
+        auto resp = responsePayload(response);
+        std::memcpy(resp.data(), &errorCode, sizeof(errorCode));
+
+        return respSize;
+    }
+};
+
+// Minimal Health service handler (SVC=0x10) — BIOS checks BMC health.
+// Responds with success (ErrorCode=0) to all commands.
+class HealthService : public ServiceHandler
+{
+  public:
+    int handle(std::span<const uint8_t> request,
+               std::span<uint8_t> response) override
+    {
+        if (request.size() < sizeof(ChifPktHeader))
+        {
+            return -1;
+        }
+
+        auto hdr = parseHeader(request);
+
+        constexpr uint16_t respSize =
+            static_cast<uint16_t>(sizeof(ChifPktHeader) + sizeof(uint32_t));
+
+        if (response.size() < respSize)
+        {
+            return -1;
+        }
+
+        initResponse(response, hdr, respSize);
+
+        uint32_t errorCode = 0;
+        auto resp = responsePayload(response);
+        std::memcpy(resp.data(), &errorCode, sizeof(errorCode));
+
+        return respSize;
+    }
+
+    uint8_t serviceId() const override
+    {
+        return healthServiceId;
+    }
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/mock_channel.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/mock_channel.hpp
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include "../src/packet.hpp"
+
+#include <cstring>
+#include <deque>
+#include <vector>
+
+namespace chif::test
+{
+
+// In-memory channel for unit testing. Packets are queued for reading,
+// and written packets are captured for inspection.
+class MockChannel : public Channel
+{
+  public:
+    // Queue a packet for the daemon to read.
+    void enqueuePacket(std::span<const uint8_t> pkt)
+    {
+        pendingReads_.emplace_back(pkt.begin(), pkt.end());
+    }
+
+    // Build and enqueue a CHIF packet with the given header fields and payload.
+    void enqueuePacket(uint16_t command, uint8_t serviceId,
+                       uint16_t sequence, std::span<const uint8_t> payload)
+    {
+        std::vector<uint8_t> pkt(sizeof(ChifPktHeader) + payload.size());
+        ChifPktHeader hdr{};
+        hdr.pktSize = static_cast<uint16_t>(pkt.size());
+        hdr.sequence = sequence;
+        hdr.command = command;
+        hdr.serviceId = serviceId;
+        hdr.version = 0x01;
+        std::memcpy(pkt.data(), &hdr, sizeof(hdr));
+        if (!payload.empty())
+        {
+            std::memcpy(pkt.data() + sizeof(hdr), payload.data(),
+                        payload.size());
+        }
+        pendingReads_.push_back(std::move(pkt));
+    }
+
+    // Convenience: enqueue a header-only packet (no payload).
+    void enqueuePacket(uint16_t command, uint8_t serviceId,
+                       uint16_t sequence = 1)
+    {
+        enqueuePacket(command, serviceId, sequence,
+                      std::span<const uint8_t>{});
+    }
+
+    ssize_t read(std::span<uint8_t> buf) override
+    {
+        if (pendingReads_.empty())
+        {
+            return 0; // signal end-of-data
+        }
+        auto& pkt = pendingReads_.front();
+        size_t n = std::min(buf.size(), pkt.size());
+        std::memcpy(buf.data(), pkt.data(), n);
+        pendingReads_.pop_front();
+        return static_cast<ssize_t>(n);
+    }
+
+    ssize_t write(std::span<const uint8_t> buf) override
+    {
+        writtenPackets_.emplace_back(buf.begin(), buf.end());
+        return static_cast<ssize_t>(buf.size());
+    }
+
+    // Access captured responses.
+    const std::vector<std::vector<uint8_t>>& writtenPackets() const
+    {
+        return writtenPackets_;
+    }
+
+    // Get the last written response header (convenience).
+    ChifPktHeader lastResponseHeader() const
+    {
+        if (writtenPackets_.empty())
+        {
+            return {};
+        }
+        return parseHeader(writtenPackets_.back());
+    }
+
+    // Get the last written response payload (after header).
+    std::vector<uint8_t> lastResponsePayload() const
+    {
+        if (writtenPackets_.empty())
+        {
+            return {};
+        }
+        auto& pkt = writtenPackets_.back();
+        if (pkt.size() <= sizeof(ChifPktHeader))
+        {
+            return {};
+        }
+        return {pkt.begin() + sizeof(ChifPktHeader), pkt.end()};
+    }
+
+    void clearWritten()
+    {
+        writtenPackets_.clear();
+    }
+
+  private:
+    std::deque<std::vector<uint8_t>> pendingReads_;
+    std::vector<std::vector<uint8_t>> writtenPackets_;
+};
+
+} // namespace chif::test

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_packet.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_packet.cpp
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+#include "../src/packet.hpp"
+#include "mock_channel.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+
+using namespace chif;
+
+TEST(PacketTest, HeaderSize)
+{
+    EXPECT_EQ(sizeof(ChifPktHeader), 8u);
+}
+
+TEST(PacketTest, ParseHeader)
+{
+    // Construct a raw header: pktSize=0x0010, seq=0x0042, cmd=0x0003,
+    // service=0x02, version=0x01
+    std::array<uint8_t, 8> raw = {
+        0x10, 0x00, // pktSize = 16
+        0x42, 0x00, // sequence = 0x42
+        0x03, 0x00, // command = 0x03
+        0x02,       // serviceId = 0x02 (ROM)
+        0x01,       // version = 1
+    };
+
+    auto hdr = parseHeader(raw);
+    EXPECT_EQ(hdr.pktSize, 0x0010);
+    EXPECT_EQ(hdr.sequence, 0x0042);
+    EXPECT_EQ(hdr.command, 0x0003);
+    EXPECT_EQ(hdr.serviceId, 0x02);
+    EXPECT_EQ(hdr.version, 0x01);
+}
+
+TEST(PacketTest, ResponseCommandBit)
+{
+    // Response command should be request | 0x8000
+    EXPECT_EQ(uint16_t(0x0003 | responseBit), 0x8003);
+    EXPECT_EQ(uint16_t(0x0072 | responseBit), 0x8072);
+    EXPECT_EQ(uint16_t(0x0002 | responseBit), 0x8002);
+}
+
+TEST(PacketTest, InitResponse)
+{
+    ChifPktHeader reqHdr{};
+    reqHdr.pktSize = 8;
+    reqHdr.sequence = 0x1234;
+    reqHdr.command = 0x0003;
+    reqHdr.serviceId = 0x02;
+    reqHdr.version = 0x01;
+
+    std::array<uint8_t, 16> resp{};
+    initResponse(resp, reqHdr, 12);
+
+    auto rspHdr = parseHeader(resp);
+    EXPECT_EQ(rspHdr.pktSize, 12);
+    EXPECT_EQ(rspHdr.sequence, 0x1234);
+    EXPECT_EQ(rspHdr.command, 0x8003);
+    EXPECT_EQ(rspHdr.serviceId, 0x02);
+    EXPECT_EQ(rspHdr.version, 0x01);
+}
+
+TEST(PacketTest, PayloadExtraction)
+{
+    std::array<uint8_t, 12> pkt{};
+    // Fill header
+    ChifPktHeader hdr{};
+    hdr.pktSize = 12;
+    std::memcpy(pkt.data(), &hdr, sizeof(hdr));
+    // Fill payload with known bytes
+    pkt[8] = 0xAA;
+    pkt[9] = 0xBB;
+    pkt[10] = 0xCC;
+    pkt[11] = 0xDD;
+
+    auto p = payload(std::span<const uint8_t>(pkt));
+    ASSERT_EQ(p.size(), 4u);
+    EXPECT_EQ(p[0], 0xAA);
+    EXPECT_EQ(p[1], 0xBB);
+    EXPECT_EQ(p[2], 0xCC);
+    EXPECT_EQ(p[3], 0xDD);
+}
+
+TEST(PacketTest, EmptyPayload)
+{
+    // A header-only packet has no payload
+    std::array<uint8_t, 8> pkt{};
+    auto p = payload(std::span<const uint8_t>(pkt));
+    EXPECT_TRUE(p.empty());
+}
+
+TEST(PacketTest, MockChannelRoundtrip)
+{
+    test::MockChannel ch;
+
+    // Enqueue a packet
+    std::array<uint8_t, 4> data = {0x01, 0x02, 0x03, 0x04};
+    ch.enqueuePacket(0x0003, 0x02, 1, data);
+
+    // Read it back
+    std::array<uint8_t, maxPacketSize> buf{};
+    auto n = ch.read(buf);
+    ASSERT_EQ(n, static_cast<ssize_t>(sizeof(ChifPktHeader) + 4));
+
+    auto hdr = parseHeader(std::span<const uint8_t>(buf.data(), n));
+    EXPECT_EQ(hdr.command, 0x0003);
+    EXPECT_EQ(hdr.serviceId, 0x02);
+
+    // Write a response
+    std::array<uint8_t, 12> resp{};
+    initResponse(resp, hdr, 12);
+    ch.write(resp);
+
+    EXPECT_EQ(ch.writtenPackets().size(), 1u);
+    auto rspHdr = ch.lastResponseHeader();
+    EXPECT_EQ(rspHdr.command, 0x8003);
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_rom_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_rom_service.cpp
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+#include "../src/rom_service.hpp"
+#include "../src/smbios_writer.hpp"
+#include "mock_channel.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+using namespace chif;
+
+class RomServiceTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        testDir_ = std::filesystem::temp_directory_path() / "chif_test_rom";
+        std::filesystem::create_directories(testDir_);
+        writer_ = std::make_unique<SmbiosWriter>(testDir_);
+        // nullptr MdrBridge — no D-Bus in tests
+        service_ = std::make_unique<RomService>(*writer_, nullptr);
+    }
+
+    void TearDown() override
+    {
+        std::filesystem::remove_all(testDir_);
+    }
+
+    // Build a raw request packet
+    std::vector<uint8_t> makeRequest(uint16_t command,
+                                     std::span<const uint8_t> payload = {},
+                                     uint16_t seq = 1)
+    {
+        std::vector<uint8_t> pkt(sizeof(ChifPktHeader) + payload.size());
+        ChifPktHeader hdr{};
+        hdr.pktSize = static_cast<uint16_t>(pkt.size());
+        hdr.sequence = seq;
+        hdr.command = command;
+        hdr.serviceId = romServiceId;
+        hdr.version = 0x01;
+        std::memcpy(pkt.data(), &hdr, sizeof(hdr));
+        if (!payload.empty())
+        {
+            std::memcpy(pkt.data() + sizeof(hdr), payload.data(),
+                        payload.size());
+        }
+        return pkt;
+    }
+
+    // Wrap raw SMBIOS records in HPE ROM blob format.
+    // Format: uint32_t count, then count x (uint16_t size + raw record).
+    static std::vector<uint8_t> wrapInBlob(
+        const std::vector<std::vector<uint8_t>>& records)
+    {
+        std::vector<uint8_t> blob;
+        uint32_t count = static_cast<uint32_t>(records.size());
+        blob.insert(blob.end(), reinterpret_cast<const uint8_t*>(&count),
+                    reinterpret_cast<const uint8_t*>(&count) + sizeof(count));
+        for (const auto& rec : records)
+        {
+            uint16_t size = static_cast<uint16_t>(rec.size());
+            blob.insert(
+                blob.end(), reinterpret_cast<const uint8_t*>(&size),
+                reinterpret_cast<const uint8_t*>(&size) + sizeof(size));
+            blob.insert(blob.end(), rec.begin(), rec.end());
+        }
+        return blob;
+    }
+
+    std::filesystem::path testDir_;
+    std::unique_ptr<SmbiosWriter> writer_;
+    std::unique_ptr<RomService> service_;
+    std::array<uint8_t, maxPacketSize> respBuf_{};
+};
+
+TEST_F(RomServiceTest, ServiceId)
+{
+    EXPECT_EQ(service_->serviceId(), romServiceId);
+}
+
+TEST_F(RomServiceTest, BeginCommand)
+{
+    auto req = makeRequest(romCmdBegin);
+    int n = service_->handle(req, respBuf_);
+
+    // ROM responses are header-only (8 bytes) with no response bit
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    auto rspHdr = parseHeader(
+        std::span<const uint8_t>(respBuf_.data(), static_cast<size_t>(n)));
+    EXPECT_EQ(rspHdr.command, romCmdBegin); // no response bit for ROM
+    EXPECT_EQ(rspHdr.sequence, 1);
+}
+
+TEST_F(RomServiceTest, RecordCommand)
+{
+    // Begin first
+    auto beginReq = makeRequest(romCmdBegin);
+    service_->handle(beginReq, respBuf_);
+
+    // Send a record wrapped in HPE blob format
+    std::vector<uint8_t> rawRecord = {
+        0x01, 0x1B, 0x01, 0x00, // Type 1, length 27, handle 1
+    };
+    rawRecord.resize(0x1B, 0x00);
+    rawRecord.push_back(0x00);
+    rawRecord.push_back(0x00); // double-null terminator
+
+    auto blob = wrapInBlob({rawRecord});
+    auto req = makeRequest(romCmdRecord, blob, 2);
+    int n = service_->handle(req, respBuf_);
+
+    // ROM responses are header-only (8 bytes)
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    auto rspHdr = parseHeader(
+        std::span<const uint8_t>(respBuf_.data(), static_cast<size_t>(n)));
+    EXPECT_EQ(rspHdr.command, romCmdRecord); // no response bit for ROM
+    EXPECT_EQ(rspHdr.sequence, 2);
+
+    // Verify data was accumulated (raw record size, not blob size)
+    EXPECT_EQ(writer_->dataSize(), rawRecord.size());
+}
+
+TEST_F(RomServiceTest, EmptyRecordHandledGracefully)
+{
+    auto beginReq = makeRequest(romCmdBegin);
+    service_->handle(beginReq, respBuf_);
+
+    // Send header-only (no payload)
+    auto req = makeRequest(romCmdRecord);
+    int n = service_->handle(req, respBuf_);
+
+    // Still get a header-only response
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    // No data should have been accumulated
+    EXPECT_EQ(writer_->dataSize(), 0u);
+}
+
+TEST_F(RomServiceTest, EndCommandFinalizesFile)
+{
+    auto beginReq = makeRequest(romCmdBegin);
+    service_->handle(beginReq, respBuf_);
+
+    // Add a record in blob format
+    std::vector<uint8_t> rec = {0x01, 0x04, 0x01, 0x00, 0x00, 0x00};
+    auto blob = wrapInBlob({rec});
+    auto recReq = makeRequest(romCmdRecord, blob, 2);
+    service_->handle(recReq, respBuf_);
+
+    // End
+    auto endReq = makeRequest(romCmdEnd, {}, 3);
+    int n = service_->handle(endReq, respBuf_);
+
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+    auto rspHdr = parseHeader(
+        std::span<const uint8_t>(respBuf_.data(), static_cast<size_t>(n)));
+    EXPECT_EQ(rspHdr.command, romCmdEnd); // no response bit for ROM
+    EXPECT_EQ(rspHdr.sequence, 3);
+
+    // Verify the smbios2 file was created
+    EXPECT_TRUE(std::filesystem::exists(writer_->outputPath()));
+}
+
+TEST_F(RomServiceTest, FullSequence)
+{
+    // Simulate the full BIOS sequence: begin -> record -> record -> end
+
+    // Begin
+    auto beginReq = makeRequest(romCmdBegin, {}, 1);
+    int n = service_->handle(beginReq, respBuf_);
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    // Record 1: Type 1 (System Information)
+    std::vector<uint8_t> rec1 = {0x01, 0x1B, 0x01, 0x00};
+    rec1.resize(0x1B, 0x00);
+    rec1.push_back('H');
+    rec1.push_back('P');
+    rec1.push_back('E');
+    rec1.push_back(0x00);
+    rec1.push_back(0x00);
+
+    auto blob1 = wrapInBlob({rec1});
+    auto recReq1 = makeRequest(romCmdRecord, blob1, 2);
+    n = service_->handle(recReq1, respBuf_);
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    // Record 2: Type 17 (Memory Device)
+    std::vector<uint8_t> rec17 = {0x11, 0x54, 0x11, 0x00};
+    rec17.resize(0x54, 0x00);
+    rec17.push_back('D');
+    rec17.push_back('I');
+    rec17.push_back('M');
+    rec17.push_back('M');
+    rec17.push_back(0x00);
+    rec17.push_back(0x00);
+
+    auto blob17 = wrapInBlob({rec17});
+    auto recReq2 = makeRequest(romCmdRecord, blob17, 3);
+    n = service_->handle(recReq2, respBuf_);
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    // End
+    auto endReq = makeRequest(romCmdEnd, {}, 4);
+    n = service_->handle(endReq, respBuf_);
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    // Verify output file
+    ASSERT_TRUE(std::filesystem::exists(writer_->outputPath()));
+
+    // Read and verify the SMBIOS 3.0 EP
+    std::ifstream in(writer_->outputPath(), std::ios::binary);
+    in.seekg(sizeof(MdrHeader));
+
+    Smbios3EntryPoint ep{};
+    in.read(reinterpret_cast<char*>(&ep), sizeof(ep));
+
+    EXPECT_EQ(ep.anchorString[0], '_');
+    EXPECT_EQ(ep.anchorString[1], 'S');
+    EXPECT_EQ(ep.anchorString[2], 'M');
+    EXPECT_EQ(ep.anchorString[3], '3');
+    EXPECT_EQ(ep.anchorString[4], '_');
+    EXPECT_EQ(ep.smbiosMajor, 3);
+    EXPECT_EQ(ep.smbiosMinor, 3);
+    EXPECT_EQ(ep.structureTableMaxSize,
+              static_cast<uint32_t>(rec1.size() + rec17.size()));
+}
+
+TEST_F(RomServiceTest, BlobCommand)
+{
+    // Begin
+    auto beginReq = makeRequest(romCmdBegin, {}, 1);
+    service_->handle(beginReq, respBuf_);
+
+    // Blob: multiple records in a single blob-formatted payload
+    std::vector<uint8_t> r1 = {0x01, 0x04, 0x01, 0x00, 0x00, 0x00};
+    std::vector<uint8_t> r4 = {0x04, 0x04, 0x04, 0x00, 0x00, 0x00};
+    auto blob = wrapInBlob({r1, r4});
+
+    auto blobReq = makeRequest(romCmdBlob, blob, 2);
+    int n = service_->handle(blobReq, respBuf_);
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    // Verify data size matches raw records (blob wrapper stripped)
+    EXPECT_EQ(writer_->dataSize(), r1.size() + r4.size());
+
+    // End
+    auto endReq = makeRequest(romCmdEnd, {}, 3);
+    n = service_->handle(endReq, respBuf_);
+    ASSERT_EQ(static_cast<size_t>(n), sizeof(ChifPktHeader));
+
+    EXPECT_TRUE(std::filesystem::exists(writer_->outputPath()));
+}
+
+TEST_F(RomServiceTest, UnknownCommandDropped)
+{
+    // Unknown ROM command should return -1 (no response)
+    auto req = makeRequest(0x00FF);
+    int n = service_->handle(req, respBuf_);
+    EXPECT_EQ(n, -1);
+}
+
+TEST_F(RomServiceTest, ResponseEchoesSequence)
+{
+    // Verify response echoes the request's sequence number
+    auto req = makeRequest(romCmdBegin, {}, 0xABCD);
+    int n = service_->handle(req, respBuf_);
+
+    ASSERT_GT(n, 0);
+    auto rspHdr = parseHeader(
+        std::span<const uint8_t>(respBuf_.data(), static_cast<size_t>(n)));
+    EXPECT_EQ(rspHdr.sequence, 0xABCD);
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_smbios_writer.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_smbios_writer.cpp
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+#include "../src/smbios_writer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+using namespace chif;
+
+class SmbiosWriterTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        // Use a temporary directory for test output
+        testDir_ = std::filesystem::temp_directory_path() / "chif_test_smbios";
+        std::filesystem::create_directories(testDir_);
+        writer_ = std::make_unique<SmbiosWriter>(testDir_);
+    }
+
+    void TearDown() override
+    {
+        std::filesystem::remove_all(testDir_);
+    }
+
+    std::filesystem::path testDir_;
+    std::unique_ptr<SmbiosWriter> writer_;
+
+    // Create a minimal SMBIOS Type 1 record (System Information)
+    // with proper double-null terminator
+    static std::vector<uint8_t> makeType1Record()
+    {
+        // Minimal Type 1: 4-byte header (type, length, handle) +
+        // enough data to be valid + double-null string terminator
+        std::vector<uint8_t> rec = {
+            0x01,       // type = 1 (System Information)
+            0x1B,       // length = 27 (min for type 1 v2.4)
+            0x01, 0x00, // handle = 0x0001
+        };
+        // Fill formatted area with zeros to reach length
+        rec.resize(0x1B, 0x00);
+        // String table: manufacturer string + double null
+        rec.push_back('T');
+        rec.push_back('e');
+        rec.push_back('s');
+        rec.push_back('t');
+        rec.push_back(0x00); // end of string
+        rec.push_back(0x00); // end of string table (double null)
+        return rec;
+    }
+
+    // Create a minimal SMBIOS Type 17 record (Memory Device)
+    static std::vector<uint8_t> makeType17Record()
+    {
+        std::vector<uint8_t> rec = {
+            0x11,       // type = 17 (Memory Device)
+            0x54,       // length = 84 (v3.3+)
+            0x11, 0x00, // handle = 0x0011
+        };
+        rec.resize(0x54, 0x00);
+        // String: part number
+        rec.push_back('D');
+        rec.push_back('I');
+        rec.push_back('M');
+        rec.push_back('M');
+        rec.push_back(0x00);
+        rec.push_back(0x00);
+        return rec;
+    }
+
+    // Wrap raw SMBIOS records in HPE ROM blob format for addRecord().
+    // Format: uint32_t count, then count x (uint16_t size + raw record).
+    static std::vector<uint8_t> wrapInBlob(
+        const std::vector<std::vector<uint8_t>>& records)
+    {
+        std::vector<uint8_t> blob;
+        uint32_t count = static_cast<uint32_t>(records.size());
+        blob.insert(blob.end(), reinterpret_cast<const uint8_t*>(&count),
+                    reinterpret_cast<const uint8_t*>(&count) + sizeof(count));
+        for (const auto& rec : records)
+        {
+            uint16_t size = static_cast<uint16_t>(rec.size());
+            blob.insert(
+                blob.end(), reinterpret_cast<const uint8_t*>(&size),
+                reinterpret_cast<const uint8_t*>(&size) + sizeof(size));
+            blob.insert(blob.end(), rec.begin(), rec.end());
+        }
+        return blob;
+    }
+};
+
+TEST_F(SmbiosWriterTest, EmptyFinalize)
+{
+    writer_->begin();
+    // Finalize with no records should fail
+    EXPECT_FALSE(writer_->finalize());
+}
+
+TEST_F(SmbiosWriterTest, SingleRecord)
+{
+    writer_->begin();
+    auto rec = makeType1Record();
+    auto blob = wrapInBlob({rec});
+    writer_->addRecord(blob);
+    EXPECT_EQ(writer_->dataSize(), rec.size());
+
+    ASSERT_TRUE(writer_->finalize());
+
+    // Verify the output file exists
+    auto path = writer_->outputPath();
+    ASSERT_TRUE(std::filesystem::exists(path));
+
+    // Read back the file
+    std::ifstream in(path, std::ios::binary);
+    std::vector<uint8_t> data((std::istreambuf_iterator<char>(in)),
+                              std::istreambuf_iterator<char>());
+
+    // File = MDR header (10) + SMBIOS 3.0 EP (24) + record data
+    ASSERT_EQ(data.size(), sizeof(MdrHeader) + sizeof(Smbios3EntryPoint) +
+                               rec.size());
+}
+
+TEST_F(SmbiosWriterTest, MdrHeaderFields)
+{
+    writer_->begin();
+    auto rec = makeType1Record();
+    auto blob = wrapInBlob({rec});
+    writer_->addRecord(blob);
+    ASSERT_TRUE(writer_->finalize());
+
+    std::ifstream in(writer_->outputPath(), std::ios::binary);
+    MdrHeader mdr{};
+    in.read(reinterpret_cast<char*>(&mdr), sizeof(mdr));
+
+    EXPECT_EQ(mdr.dirVer, 1u); // first finalize
+    EXPECT_EQ(mdr.mdrType, 2u);
+    EXPECT_GT(mdr.timestamp, 0u);
+    EXPECT_EQ(mdr.dataSize,
+              static_cast<uint32_t>(sizeof(Smbios3EntryPoint) + rec.size()));
+}
+
+TEST_F(SmbiosWriterTest, Smbios3EntryPointAnchor)
+{
+    writer_->begin();
+    auto rec = makeType1Record();
+    auto blob = wrapInBlob({rec});
+    writer_->addRecord(blob);
+    ASSERT_TRUE(writer_->finalize());
+
+    std::ifstream in(writer_->outputPath(), std::ios::binary);
+    // Skip MDR header
+    in.seekg(sizeof(MdrHeader));
+
+    Smbios3EntryPoint ep{};
+    in.read(reinterpret_cast<char*>(&ep), sizeof(ep));
+
+    // Verify anchor string "_SM3_"
+    EXPECT_EQ(ep.anchorString[0], '_');
+    EXPECT_EQ(ep.anchorString[1], 'S');
+    EXPECT_EQ(ep.anchorString[2], 'M');
+    EXPECT_EQ(ep.anchorString[3], '3');
+    EXPECT_EQ(ep.anchorString[4], '_');
+
+    // Version 3.3
+    EXPECT_EQ(ep.smbiosMajor, 3);
+    EXPECT_EQ(ep.smbiosMinor, 3);
+
+    // Entry point length
+    EXPECT_EQ(ep.entryPointLength, sizeof(Smbios3EntryPoint));
+
+    // Entry point revision
+    EXPECT_EQ(ep.entryPointRevision, 0x01);
+
+    // Structure table max size = record data size
+    EXPECT_EQ(ep.structureTableMaxSize, static_cast<uint32_t>(rec.size()));
+}
+
+TEST_F(SmbiosWriterTest, Smbios3Checksum)
+{
+    writer_->begin();
+    auto blob = wrapInBlob({makeType1Record()});
+    writer_->addRecord(blob);
+    ASSERT_TRUE(writer_->finalize());
+
+    std::ifstream in(writer_->outputPath(), std::ios::binary);
+    in.seekg(sizeof(MdrHeader));
+
+    Smbios3EntryPoint ep{};
+    in.read(reinterpret_cast<char*>(&ep), sizeof(ep));
+
+    // Verify checksum: all bytes of EP must sum to zero
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&ep);
+    uint8_t sum = 0;
+    for (size_t i = 0; i < sizeof(ep); i++)
+    {
+        sum += bytes[i];
+    }
+    EXPECT_EQ(sum, 0u) << "SMBIOS 3.0 EP checksum verification failed";
+}
+
+TEST_F(SmbiosWriterTest, MultipleRecords)
+{
+    writer_->begin();
+    auto rec1 = makeType1Record();
+    auto rec17 = makeType17Record();
+    auto blob1 = wrapInBlob({rec1});
+    auto blob17 = wrapInBlob({rec17});
+    writer_->addRecord(blob1);
+    writer_->addRecord(blob17);
+
+    EXPECT_EQ(writer_->dataSize(), rec1.size() + rec17.size());
+    ASSERT_TRUE(writer_->finalize());
+
+    std::ifstream in(writer_->outputPath(), std::ios::binary);
+    std::vector<uint8_t> data((std::istreambuf_iterator<char>(in)),
+                              std::istreambuf_iterator<char>());
+
+    size_t expected = sizeof(MdrHeader) + sizeof(Smbios3EntryPoint) +
+                      rec1.size() + rec17.size();
+    EXPECT_EQ(data.size(), expected);
+}
+
+TEST_F(SmbiosWriterTest, DirectoryVersionIncrements)
+{
+    // First write
+    writer_->begin();
+    auto blob1 = wrapInBlob({makeType1Record()});
+    writer_->addRecord(blob1);
+    ASSERT_TRUE(writer_->finalize());
+
+    std::ifstream in1(writer_->outputPath(), std::ios::binary);
+    MdrHeader mdr1{};
+    in1.read(reinterpret_cast<char*>(&mdr1), sizeof(mdr1));
+    in1.close();
+
+    // Second write
+    writer_->begin();
+    auto blob2 = wrapInBlob({makeType17Record()});
+    writer_->addRecord(blob2);
+    ASSERT_TRUE(writer_->finalize());
+
+    std::ifstream in2(writer_->outputPath(), std::ios::binary);
+    MdrHeader mdr2{};
+    in2.read(reinterpret_cast<char*>(&mdr2), sizeof(mdr2));
+
+    EXPECT_EQ(mdr2.dirVer, mdr1.dirVer + 1);
+}
+
+TEST_F(SmbiosWriterTest, AtomicWrite)
+{
+    writer_->begin();
+    auto blob = wrapInBlob({makeType1Record()});
+    writer_->addRecord(blob);
+    ASSERT_TRUE(writer_->finalize());
+
+    // The temp file should not exist after finalize
+    auto tempPath = testDir_ / "smbios_temp";
+    EXPECT_FALSE(std::filesystem::exists(tempPath));
+
+    // The final file should exist
+    EXPECT_TRUE(std::filesystem::exists(writer_->outputPath()));
+}
+
+TEST_F(SmbiosWriterTest, RecordDataPreserved)
+{
+    writer_->begin();
+    auto rec = makeType1Record();
+    auto blob = wrapInBlob({rec});
+    writer_->addRecord(blob);
+    ASSERT_TRUE(writer_->finalize());
+
+    std::ifstream in(writer_->outputPath(), std::ios::binary);
+
+    // Skip MDR header + EP
+    in.seekg(sizeof(MdrHeader) + sizeof(Smbios3EntryPoint));
+
+    std::vector<uint8_t> readBack(rec.size());
+    in.read(reinterpret_cast<char*>(readBack.data()),
+            static_cast<std::streamsize>(rec.size()));
+
+    EXPECT_EQ(readBack, rec) << "Record data not preserved in output file";
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service_1.0.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service_1.0.bb
@@ -30,4 +30,6 @@ DEPENDS += " \
 
 RDEPENDS:${PN} += "smbios-mdr"
 
+FILES:${PN} += "${nonarch_base_libdir}/udev/rules.d"
+
 EXTRA_OEMESON = "-Dtests=disabled"

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service_1.0.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service_1.0.bb
@@ -1,0 +1,33 @@
+SUMMARY = "GXP CHIF Service"
+DESCRIPTION = "CHIF (Channel Interface) service for HPE GXP BMC. \
+Receives SMBIOS data from host BIOS via /dev/chif24 and triggers \
+smbios-mdr for Redfish inventory population."
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+# Local source — will be replaced with a git:// URI once the repo is published
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI = "file://src;subdir=${BP} \
+           file://test;subdir=${BP} \
+           file://service_files;subdir=${BP} \
+           file://meson.build;subdir=${BP} \
+           file://meson.options;subdir=${BP} \
+           "
+
+S = "${WORKDIR}/${BP}"
+
+inherit meson pkgconfig systemd
+
+SYSTEMD_SERVICE:${PN} = "xyz.openbmc_project.GxpChif.service"
+
+DEPENDS += " \
+    systemd \
+    sdbusplus \
+    phosphor-dbus-interfaces \
+    phosphor-logging \
+    "
+
+RDEPENDS:${PN} += "smbios-mdr"
+
+EXTRA_OEMESON = "-Dtests=disabled"

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
@@ -40,4 +40,6 @@ SUMMARY:${PN}-system = "HPE System"
 RDEPENDS:${PN}-system = " \
         entity-manager \
         dbus-sensors \
+        gxp-chif-service \
+        smbios-mdr \
         "

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr_%.bbappend
@@ -1,0 +1,7 @@
+# Enable CPU information and firmware inventory D-Bus interfaces
+# for Redfish Memory, Processors, and System population.
+#
+# cpuinfo: enables xyz.openbmc_project.cpuinfo.service (CPU inventory via I2C)
+# firmware-inventory-dbus: exposes firmware version info on D-Bus
+# tpm-dbus: exposes TPM information on D-Bus
+PACKAGECONFIG:append = " cpuinfo firmware-inventory-dbus tpm-dbus"

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-gxp/gxp.dts
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-gxp/gxp.dts
@@ -486,6 +486,7 @@
       chif {
         compatible = "hpe,gxp-chif";
         interrupts = <12>;
+        interrupt-parent = <&vic1>;
       };
     };
 

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable-6.18/0028-ARM-dts-hpe-gxp-add-CHIF-node.patch
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable-6.18/0028-ARM-dts-hpe-gxp-add-CHIF-node.patch
@@ -23,7 +23,7 @@ index 210b6900512d..f591685921f1 100644
 +			chif: chif {
 +				compatible = "hpe,gxp-chif";
 +				interrupts = <12>;
-+				interrupt-parent = <&vic0>;
++				interrupt-parent = <&vic1>;
 +			};
  		};
  


### PR DESCRIPTION
Implement the GXP CHIF (Channel Interface) service that receives SMBIOS data from the host BIOS over /dev/chif24 and populates Redfish inventory.

The BIOS sends SMBIOS records through ROM blob commands (0x03 begin, 0x0C blob, 0x05 end) over the CHIF shared-memory channel. The service unwraps HPE's ROM blob format (4-byte record count + size-prefixed records), constructs a valid SMBIOS 3.0 Entry Point with MDR V2 header, and triggers smbios-mdr to parse the data into D-Bus inventory objects.

Key protocol details discovered through hardware testing:
- ROM responses must NOT set the response bit (0x8000)
- ROM responses are 8-byte header-only (no ErrorCode payload)
- All ROM commands (including blob/record) require a response
- SMIF EV enumeration commands (0x012b/0x012d/0x0130) must return error to prevent BIOS infinite loops
- MDR header dirVer field is uint8_t (not uint32_t)

Verified on HPE ProLiant DL360 Gen11 hardware:
- 272 SMBIOS records (Type 0-43 + HPE OEM) received from BIOS
- 2x Intel Xeon Silver 4510 processors detected
- 32 DIMM slots with 64 GiB total memory
- Redfish /Systems/system/Memory and /Processors fully populated