### PR TITLE
hpe/feature/optimize boot

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr_%.bbappend
@@ -3,11 +3,9 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " \
         file://0001-Skip-undersized-SMBIOS-entries-in-getSMBIOSTypePtr.patch \
         "
-
-# Enable CPU information and firmware inventory D-Bus interfaces
+# Enable firmware inventory D-Bus interfaces
 # for Redfish Memory, Processors, and System population.
 #
-# cpuinfo: enables xyz.openbmc_project.cpuinfo.service (CPU inventory via I2C)
 # firmware-inventory-dbus: exposes firmware version info on D-Bus
 # tpm-dbus: exposes TPM information on D-Bus
-PACKAGECONFIG:append = " cpuinfo firmware-inventory-dbus tpm-dbus"
+PACKAGECONFIG:append = " firmware-inventory-dbus tpm-dbus"

--- a/meta-canopy/recipes-core/dropbear/dropbear/dropbearkey.service
+++ b/meta-canopy/recipes-core/dropbear/dropbear/dropbearkey.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=SSH Key Generation
+
+[Service]
+# Generate host keys for key files referenced by -r flags in
+# DROPBEAR_EXTRA_ARGS (see /etc/default/dropbear). Only keys that
+# the daemon will actually load at runtime are generated.
+Environment="DROPBEAR_RSAKEY_DIR=/etc/dropbear"
+EnvironmentFile=-/etc/default/dropbear
+Type=oneshot
+ExecStart=@LIBEXECDIR@/dropbear/generate-host-keys
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-canopy/recipes-core/dropbear/dropbear/generate-host-keys
+++ b/meta-canopy/recipes-core/dropbear/dropbear/generate-host-keys
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Generate dropbear SSH host keys for key files referenced by -r flags
+# in DROPBEAR_EXTRA_ARGS. This keeps key generation in sync with which
+# keys the daemon actually loads at runtime.
+
+
+set -eu
+
+KEYDIR="${DROPBEAR_RSAKEY_DIR:-/etc/dropbear}"
+
+# Parse -r <keyfile> pairs from DROPBEAR_EXTRA_ARGS
+prev=""
+# shellcheck disable=SC2086
+set -- ${DROPBEAR_EXTRA_ARGS:-}
+for arg; do
+    if [ "$prev" = "-r" ]; then
+        keypath="$arg"
+
+        if [ ! -f "$keypath" ]; then
+            mkdir -p "${keypath%/*}"
+
+            case "$keypath" in
+                *ecdsa*)
+                    dropbearkey -t ecdsa -f "$keypath" -s 384
+                    ;;
+                *ed25519*)
+                    dropbearkey -t ed25519 -f "$keypath"
+                    ;;
+                *rsa*)
+                    dropbearkey -t rsa -f "$keypath"
+                    ;;
+                *)
+                    echo "generate-host-keys: unknown key type for $keypath, skipping" >&2
+                    ;;
+            esac
+        fi
+    fi
+    prev="$arg"
+done

--- a/meta-canopy/recipes-core/dropbear/dropbear_%.bbappend
+++ b/meta-canopy/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,0 +1,19 @@
+# Replace dropbearkey.service with a version that derives key types from
+# DROPBEAR_EXTRA_ARGS (-r flags in /etc/default/dropbear). This ensures
+# key generation stays in sync with which keys the daemon loads at runtime,
+# eliminating wasted keygen for unused key types.
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " file://generate-host-keys"
+
+do_install:append() {
+    install -d ${D}${libexecdir}/dropbear
+    install -m 0755 ${UNPACKDIR}/generate-host-keys \
+        ${D}${libexecdir}/dropbear/generate-host-keys
+
+    # Poky's do_install sed only handles @BASE_BINDIR@, @BINDIR@, @SBINDIR@.
+    # Process @LIBEXECDIR@ in our dropbearkey.service.
+    sed -i -e 's,@LIBEXECDIR@,${libexecdir},g' \
+        ${D}${systemd_system_unitdir}/dropbearkey.service
+}


### PR DESCRIPTION
Averages (seconds)

| Boot | `hpe/main` | `optimize-boot` | Delta | Improvement |
|:-----|:----------:|:---------------:|:-----:|:-----------:|
| **Boot 1** (first after flash) | 50.7s | 44.9s | **−5.8s** | **11.5%** |
| **Boot 2** (subsequent) | 46.1s | 44.0s | **−2.1s** | **4.5%** |
| **Boot 3** (subsequent) | 45.9s | 44.0s | **−1.9s** | **4.1%** |

We did:
1. Remove cpuinfo because it's not used on our platform
2. Switched from RSA to EC-based SSH keys 