### PR TITLE
meta-hpe: enable host BIOS version display in Redfish

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " flash_bios"


### PR DESCRIPTION
Enable flash_bios PACKAGECONFIG in phosphor-software-manager to create the /xyz/openbmc_project/software/bios_active D-Bus object at startup.

smbios-mdr already parses SMBIOS Type 0 and attempts to set the BIOS version on this object, but the SetProperty call fails because the object doesn't exist without host-bios-upgrade enabled. This one-line change creates the object so BiosVersion appears in the Redfish ComputerSystem response.

The obmc-flash-host-bios@.service installed by this flag is a harmless upstream stub — actual BIOS flash support can be added later.

Tested: BiosVersion "2.50" visible at /redfish/v1/Systems/system