### PR TITLE
console: fix VUART data capture by removing self-referencing local-tty

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/server.ttyVUART0.conf
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/console/obmc-console/server.ttyVUART0.conf
@@ -1,2 +1,1 @@
-local-tty = ttyVUART0
-local-tty-baud = 115200
+logsize = 256k


### PR DESCRIPTION
The obmc-console-server config had local-tty = ttyVUART0, which is the same device as the upstream tty passed on the command line. This caused a second fd to be opened on the same tty, creating a data race between the main poll loop and the tty-handler — resulting in 0 bytes captured in /var/log/obmc-console.log during host boot.

Remove the self-referencing local-tty config and add explicit logsize to match IBM reference configs. Every working VUART config in upstream OpenBMC either points local-tty to a different physical UART or omits it entirely.