### PR TITLE
meta-hpe: update gxp-bootblock to newest upstream version

### DIFF
--- a/meta-canopy/meta-hpe/conf/machine/include/proliant-g11.inc
+++ b/meta-canopy/meta-hpe/conf/machine/include/proliant-g11.inc
@@ -4,6 +4,7 @@ KERNEL_DTBVENDORED ?= "1"
 # bootblock loader variants in use
 HPE_GXP_LOADERS = "\
   GXP2loader-t277-t280-t285-sgn00 \
+  GXP2loader-t282-t288-sgn00 \
   GXP2loader-t26x-sgn00 \
 "
 

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-bsp/images/gxp-bootblock.bb
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-bsp/images/gxp-bootblock.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = ""
 KBRANCH = "gxp2-bootblock"
 
 SRC_URI = "git://github.com/HewlettPackard/gxp-bootblock.git;protocol=https;branch=${KBRANCH}"
-SRCREV = "1714c07e0f6a3ab3888d474e49b818551c09bd93"
+SRCREV = "0ff312da2b91603e31436e1b3c4ae646c6f16c94"
 S = "${WORKDIR}/git"
 
 inherit deploy


### PR DESCRIPTION
HPE updated the `gxp2-bootblock` branch with a new gxp bootblock (`GXP2loader-t282-t288-sgn00`). Update the reference and generate a image also for this bootblock.

Note: No special links for HPE ProLiant versions. Since this is yet unknown how this maps.

resolves #33