### PR TITLE
meta-hpe: smbios-mdr: skip broken type 0 tables

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr/0001-Skip-undersized-SMBIOS-entries-in-getSMBIOSTypePtr.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr/0001-Skip-undersized-SMBIOS-entries-in-getSMBIOSTypePtr.patch
@@ -1,0 +1,103 @@
+From ad3c12a864b4e95a50e8e3f17020bd6dbea8ece3 Mon Sep 17 00:00:00 2001
+From: Marcello Sylvester Bauer <marcello.bauer@9elements.com>
+Date: Tue, 24 Mar 2026 13:18:18 +0100
+Subject: [PATCH] Skip undersized SMBIOS entries in getSMBIOSTypePtr
+
+getSMBIOSTypePtr aborts the entire search when a matching entry
+has length < size. Change to skip the entry instead.
+
+Upstream-Status: Pending
+Change-Id: Id4131bd1919602c22d515b98e1fc01330ae94024
+Signed-off-by: Marcello Sylvester Bauer <marcello.bauer@9elements.com>
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ include/smbios_mdrv2.hpp | 31 +++++++++++++++++--------------
+ src/system.cpp           |  4 ++--
+ 2 files changed, 19 insertions(+), 16 deletions(-)
+
+diff --git a/include/smbios_mdrv2.hpp b/include/smbios_mdrv2.hpp
+index 1bf7733..46b9584 100644
+--- a/include/smbios_mdrv2.hpp
++++ b/include/smbios_mdrv2.hpp
+@@ -17,6 +17,7 @@
+ #pragma once
+ 
+ #include <phosphor-logging/elog-errors.hpp>
++#include <phosphor-logging/lg2.hpp>
+ 
+ #include <array>
+ #include <string>
+@@ -241,32 +242,34 @@ static inline uint8_t* getSMBIOSTypePtr(uint8_t* smbiosDataIn, uint8_t typeId,
+     {
+         return nullptr;
+     }
+-    char* smbiosData = reinterpret_cast<char*>(smbiosDataIn);
++    uint8_t* smbiosData = smbiosDataIn;
+     while ((*smbiosData != '\0') || (*(smbiosData + 1) != '\0'))
+     {
+         uint32_t len = *(smbiosData + 1);
+         if (*smbiosData != typeId)
+         {
+-            smbiosData += len;
+-            while ((*smbiosData != '\0') || (*(smbiosData + 1) != '\0'))
++            smbiosData = smbiosNextPtr(smbiosData);
++            if (smbiosData == nullptr)
+             {
+-                smbiosData++;
+-                len++;
+-                if (len >= mdrSMBIOSSize) // To avoid endless loop
+-                {
+-                    return nullptr;
+-                }
++                return nullptr;
+             }
+-            smbiosData += separateLen;
+             continue;
+         }
+         if (len < size)
+         {
+-            phosphor::logging::log<phosphor::logging::level::ERR>(
+-                "Record size mismatch!");
+-            return nullptr;
++            // Skip undersized entry, same as type-mismatch path above
++            lg2::warning(
++                "SMBIOS type {TYPE} entry too short ({LEN} < {MIN}), skipping",
++                "TYPE", static_cast<uint8_t>(*smbiosData), "LEN", len, "MIN",
++                size);
++            smbiosData = smbiosNextPtr(smbiosData);
++            if (smbiosData == nullptr)
++            {
++                return nullptr;
++            }
++            continue;
+         }
+-        return reinterpret_cast<uint8_t*>(smbiosData);
++        return smbiosData;
+     }
+     return nullptr;
+ }
+diff --git a/src/system.cpp b/src/system.cpp
+index b3e58bd..fa6f1d4 100644
+--- a/src/system.cpp
++++ b/src/system.cpp
+@@ -37,7 +37,7 @@ namespace smbios
+ std::string System::uuid(std::string /* value */)
+ {
+     uint8_t* dataIn = storage;
+-    dataIn = getSMBIOSTypePtr(dataIn, systemType);
++    dataIn = getSMBIOSTypePtr(dataIn, systemType, sizeof(SystemInfo));
+     if (dataIn != nullptr)
+     {
+         auto systemInfo = reinterpret_cast<struct SystemInfo*>(dataIn);
+@@ -124,7 +124,7 @@ std::string System::version(std::string /* value */)
+ {
+     std::string result = "No BIOS Version";
+     uint8_t* dataIn = storage;
+-    dataIn = getSMBIOSTypePtr(dataIn, biosType);
++    dataIn = getSMBIOSTypePtr(dataIn, biosType, sizeof(BIOSInfo));
+     if (dataIn != nullptr)
+     {
+         auto biosInfo = reinterpret_cast<struct BIOSInfo*>(dataIn);
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/smbios/smbios-mdr_%.bbappend
@@ -1,3 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+        file://0001-Skip-undersized-SMBIOS-entries-in-getSMBIOSTypePtr.patch \
+        "
+
 # Enable CPU information and firmware inventory D-Bus interfaces
 # for Redfish Memory, Processors, and System population.
 #


### PR DESCRIPTION
Some UEFI firmwares tend to send more than one Type 0 table, though the SMBIOS spec requires only one BIOS table to be included, as stated in section 6.2, Table 4 "Required structures and data". On HPE AMD SP5 systems (specifically, the DL365 and DL385 Gen11), there are two Type 0 tables, and the first one does not have any information.

Workaround the broken SMBIOS dump by skipping all Type 0 tables that are less than 7 bytes. A fix in the firmware must be done by HPE.

Tested: Ensure that the BIOS version is being reported on the DL365
        Gen11 and DL360 Gen11 (sanity check).

Link: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf

Closes #110 