### PR TITLE
meta-hpe: power-control: enable button passthrough

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-x86/chassis/x86-power-control_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-x86/chassis/x86-power-control_%.bbappend
@@ -4,6 +4,10 @@ SRC_URI += " \
 	file://power-config-host0.json \
 	"
 
+EXTRA_OEMESON:append = " \
+    -Dbutton-passthrough=enabled \
+    "
+
 do_install:append() {
 	install -d ${D}/${datadir}/${PN}
 	install -m 0644 ${UNPACKDIR}/power-config-host0.json ${D}/${datadir}/${PN}


### PR DESCRIPTION
Enable the button passthrough feature in x86-power-control which is required to make the physiccal power- and reset-button functional. The buttons are wired towards the CPLD, but it doesn't pass-through the signal to power-ctrl-out by itself.

The button passthrough does not enable the UID button, but only the power-related buttons.

Tested: Physically pressed the power- and reset button on a DL320 Gen11 with both long- and short-press.

Fixes: 880fc06 ("meta-hpe: add host power management with x86-power-control")