### PR TITLE
meta-hpe: entity-manager: add registration loop fix

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0003-entity-manager-move-D-Bus-name-and-path-to-shared-co.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0003-entity-manager-move-D-Bus-name-and-path-to-shared-co.patch
@@ -1,0 +1,69 @@
+From 5e61133f12fe2732e243916993892e4314077f3e Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Mon, 13 Apr 2026 14:06:59 +0200
+Subject: [PATCH] entity-manager: move D-Bus name and path to shared constants
+
+entity-manager's D-Bus name and path may be used across multiple files.
+To prevent accidential typos and to increase the consistency, move those
+strings into shared constants.
+
+Upstream-Status: Pending
+Change-Id: I8e455121efb901dd4b70934cc9889772b605b819
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ src/entity_manager/entity_manager.cpp | 3 +--
+ src/entity_manager/main.cpp           | 3 ++-
+ src/entity_manager/utils.hpp          | 2 ++
+ 3 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/entity_manager/entity_manager.cpp b/src/entity_manager/entity_manager.cpp
+index bc78ad0..b6af3ca 100644
+--- a/src/entity_manager/entity_manager.cpp
++++ b/src/entity_manager/entity_manager.cpp
+@@ -67,8 +67,7 @@ EntityManager::EntityManager(
+     // https://discord.com/channels/775381525260664832/1018929092009144380
+     objServer.add_manager("/xyz/openbmc_project/inventory");
+ 
+-    entityIface = objServer.add_interface("/xyz/openbmc_project/EntityManager",
+-                                          "xyz.openbmc_project.EntityManager");
++    entityIface = objServer.add_interface(emDbusPath, emDbusName);
+     entityIface->register_method("ReScan", [this]() {
+         propertiesChangedCallback();
+     });
+diff --git a/src/entity_manager/main.cpp b/src/entity_manager/main.cpp
+index df1be8c..461ae68 100644
+--- a/src/entity_manager/main.cpp
++++ b/src/entity_manager/main.cpp
+@@ -2,6 +2,7 @@
+ // SPDX-FileCopyrightText: Copyright 2018 Intel Corporation
+ 
+ #include "entity_manager.hpp"
++#include "utils.hpp"
+ 
+ #include <boost/asio/io_context.hpp>
+ #include <boost/asio/post.hpp>
+@@ -17,7 +18,7 @@ int main()
+ 
+     boost::asio::io_context io;
+     auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
+-    systemBus->request_name("xyz.openbmc_project.EntityManager");
++    systemBus->request_name(emDbusName);
+     EntityManager em(systemBus, io, configurationDirectories, schemaDirectory);
+ 
+     boost::asio::post(io, [&]() { em.propertiesChangedCallback(); });
+diff --git a/src/entity_manager/utils.hpp b/src/entity_manager/utils.hpp
+index 8c9e1ae..75e1d7f 100644
+--- a/src/entity_manager/utils.hpp
++++ b/src/entity_manager/utils.hpp
+@@ -7,6 +7,8 @@
+ #include <sdbusplus/asio/connection.hpp>
+ 
+ constexpr const char* configurationOutDir = "/var/configuration/";
++constexpr const char* emDbusName = "xyz.openbmc_project.EntityManager";
++constexpr const char* emDbusPath = "/xyz/openbmc_project/EntityManager";
+ constexpr const char* versionHashFile = "/var/configuration/version";
+ constexpr const char* versionFile = "/etc/os-release";
+ 
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0004-entity-manager-avoid-probing-own-D-Bus-name.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0004-entity-manager-avoid-probing-own-D-Bus-name.patch
@@ -1,0 +1,120 @@
+From 74e4ee8cfaa5e4c919b92117ea1a075a465a4fa0 Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Mon, 13 Apr 2026 14:12:04 +0200
+Subject: [PATCH] entity-manager: avoid probing own D-Bus name
+
+Decorator objects (with `xyz.openbmc_project.Inventory.Decorator.Asset`
+interface) may be provided by devicetree-vpd-parser (via MachineContext)
+and used for probing, but then also get populated to the same decorator
+interface by EM, causing a circular loop in registration of objects as
+visible in `/var/configuration/system.json`:
+
+```
+{
+    "2147618245": {
+        "Exposes": [
+            // Records...
+        ],
+        "Name": "chassis",
+        "Probe": "xyz.openbmc_project.Inventory.Decorator.Asset({'Model': 'HPE ProLiant DL365 Gen11'})",
+        "Type": "Chassis",
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "Manufacturer": "Hewlett Packard Enterprise",
+            "Model": "HPE ProLiant DL365 Gen11",
+            "PartNumber": "P81840-425",
+            "SerialNumber": "reddacted"
+        },
+        "xyz.openbmc_project.Inventory.Decorator.AssetTag": {
+            "AssetTag": "HPE-OBMC-001"
+        },
+        "xyz.openbmc_project.Inventory.Item": {
+            "PrettyName": "ProLiant DL365 Gen11"
+        },
+        "xyz.openbmc_project.Inventory.Item.Board.Motherboard": {
+            "ProductId": 581
+        },
+        "xyz.openbmc_project.Inventory.Item.System": {
+            "PartNumber": "P81840-425",
+            "SerialNumber": "redacted"
+        }
+    },
+    "295462187": {
+        "Exposes": [
+            // Same as above...
+        ],
+        "Probe": "xyz.openbmc_project.Inventory.Decorator.Asset({'Model': 'HPE ProLiant DL365 Gen11'})",
+        "Type": "Chassis",
+        "xyz.openbmc_project.Inventory.Decorator.Asset": {
+            "Manufacturer": "Hewlett Packard Enterprise",
+            "Model": "HPE ProLiant DL365 Gen11",
+            "PartNumber": "P81840-425",
+            "SerialNumber": "redacted"
+        },
+        "xyz.openbmc_project.Inventory.Decorator.AssetTag": {
+            "AssetTag": "HPE-OBMC-001"
+        },
+        "xyz.openbmc_project.Inventory.Item": {
+            "PrettyName": "ProLiant DL365 Gen11"
+        },
+        "xyz.openbmc_project.Inventory.Item.Board.Motherboard": {
+            "ProductId": 581
+        },
+        "xyz.openbmc_project.Inventory.Item.System": {
+            "PartNumber": "P81840-425",
+            "SerialNumber": "redacted"
+        }
+    }
+}
+```
+
+And logs like this:
+```
+entity-manager[257]: Unable to initialize dbus interface : sd_bus_add_object_vtable: org.freedesktop.DBus.Error.FileExists: File exists object Path : /xyz/openbmc_project/inventory/system/chassis/chassis interface name : xyz.openbmc_project.AddObject
+entity-manager[257]: Unable to initialize dbus interface : sd_bus_add_object_vtable: org.freedesktop.DBus.Error.FileExists: File exists object Path : /xyz/openbmc_project/inventory/system/chassis/chassis interface name : xyz.openbmc_project.Inventory.Item.Chassis
+entity-manager[257]: Unable to initialize dbus interface : sd_bus_add_object_vtable: org.freedesktop.DBus.Error.FileExists: File exists object Path : /xyz/openbmc_project/inventory/system/chassis/chassis interface name : xyz.openbmc_project.Inventory.Decorator.Asset
+entity-manager[257]: Unable to initialize dbus interface : sd_bus_add_object_vtable: org.freedesktop.DBus.Error.FileExists: File exists object Path : /xyz/openbmc_project/inventory/system/chassis/chassis interface name : xyz.openbmc_project.Inventory.Decorator.AssetTag
+entity-manager[257]: Unable to initialize dbus interface : sd_bus_add_object_vtable: org.freedesktop.DBus.Error.FileExists: File exists object Path : /xyz/openbmc_project/inventory/system/chassis/chassis interface name : xyz.openbmc_project.Inventory.Item
+entity-manager[257]: Unable to initialize dbus interface : sd_bus_add_object_vtable: org.freedesktop.DBus.Error.FileExists: File exists object Path : /xyz/openbmc_project/inventory/system/chassis/chassis interface name : xyz.openbmc_project.Inventory.Item.Board.Motherboard
+```
+
+Skip probing our own bus under `xyz.openbmc_project.EntityManager` to
+prevent circular probe/registration loops.
+
+Tested: Run on a HPE DL365 Gen11 that utilizes devicetree-vpd-parser
+        and ensure that no duplicate registration happen. The mentioned
+        device is not in upstream yet, but uses the same feature as the
+        HPE DL320 Gen12 in upstream. Downstream config in [1].
+
+References:
+[1] https://github.com/canopybmc/canopybmc/blob/469720b37c74783f52806ef01dac67d880bf6e69/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/entity-manager/+/88817]
+Change-Id: I63567a5b885a4556377078a184f9283f3b7510e4
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ src/entity_manager/perform_scan.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/entity_manager/perform_scan.cpp b/src/entity_manager/perform_scan.cpp
+index 4442b2f..76bb495 100644
+--- a/src/entity_manager/perform_scan.cpp
++++ b/src/entity_manager/perform_scan.cpp
+@@ -94,6 +94,15 @@ static void processDbusObjects(
+ 
+         for (const auto& [busname, ifaces] : object)
+         {
++            // We should skip ourselves for probing to avoid circular
++            // probes / registrations when a configuration probe uses
++            // an interface that's also being populated by EM itself.
++            if (busname == emDbusName)
++            {
++                lg2::debug("processDbusObjects: skipping scan on own object.");
++                continue;
++            }
++
+             for (const std::string& iface : ifaces)
+             {
+                 // The 3 default org.freedeskstop interfaces (Peer,
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
@@ -2,6 +2,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://0001-devicetree-vpd-add-part-number-parsing.patch"
 SRC_URI += "file://0002-devicetree-vpd-add-manufacturer-parsing.patch"
+SRC_URI += "file://0003-entity-manager-move-D-Bus-name-and-path-to-shared-co.patch"
+SRC_URI += "file://0004-entity-manager-avoid-probing-own-D-Bus-name.patch"
 ERROR_QA:remove = "patch-status"
 
 # Enable devicetree VPD parser for platform identification


### PR DESCRIPTION
Decorator objects may be provided by devicetree-vpd-parser (via MachineContext) and used as probe, but then also get populated to the same decorator object, causing a circular loop in registration of objects.

Skip probing interfaces under "xyz.openbmc_project.EntityManager" to prevent circular probe/registration loops.

The patch has been submitted to upstream for review.