### PR TITLE
fix: remove CHIF check from Power Control Test

### DIFF
--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
@@ -86,15 +86,6 @@ stages:
         parameters:
           command: "grep -qi 'Memory' /var/log/obmc-console.log"
 
-      - cmd: shell
-        name: Console contains CHIF output
-        transport: *bmc_ssh
-        options:
-          timeout: 5s
-          on-error: continue
-        parameters:
-          command: "grep -qi 'CHIF' /var/log/obmc-console.log"
-
       - cmd: cmd
         name: PowerState is On via Redfish
         transport: *local


### PR DESCRIPTION
Grepping for the CHIF messages is actually counter-productive. These will only show up when CHIF is not correctly enabled and BIOS detects errors. Thus the whole check does not make sense once we fully implemented CHIF.