### PR TITLE
Hpe/feature/platdef extract

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
@@ -44,6 +44,7 @@ src_files = files(
     'src/smif_service.cpp',
     'src/health_service.cpp',
     'src/ev_storage.cpp',
+    'src/uefi_fv.cpp',
     'src/platdef_extract.cpp',
     'src/rom_service.cpp',
     'src/smbios_writer.cpp',

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
@@ -15,6 +15,7 @@ systemd_dep = dependency('systemd')
 sdbusplus_dep = dependency('sdbusplus')
 phosphor_dbus_dep = dependency('phosphor-dbus-interfaces')
 phosphor_logging_dep = dependency('phosphor-logging')
+zlib_dep = dependency('zlib')
 
 systemd_system_unit_dir = systemd_dep.get_variable(
     'systemdsystemunitdir',
@@ -43,6 +44,7 @@ src_files = files(
     'src/smif_service.cpp',
     'src/health_service.cpp',
     'src/ev_storage.cpp',
+    'src/platdef_extract.cpp',
     'src/rom_service.cpp',
     'src/smbios_writer.cpp',
     'src/mdr_bridge.cpp',
@@ -56,6 +58,7 @@ executable(
         phosphor_dbus_dep,
         phosphor_logging_dep,
         systemd_dep,
+        zlib_dep,
     ],
     install: true,
     install_dir: get_option('bindir'),

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -98,12 +98,13 @@ int main()
         lg2::warning("EV storage failed to load, starting with empty store");
     }
 
-    // Extract PlatDef blob from host BIOS SPI flash
+    // Extract PlatDef from host BIOS SPI flash and parse I2C mappings.
+    // TODO: pass i2cSegments to SmifService for I2C proxy routing.
     auto platDefBlob = chif::extractPlatDef();
-    if (platDefBlob.empty())
-    {
-        lg2::info("PlatDef blob not available");
-    }
+    [[maybe_unused]] auto i2cSegments =
+        platDefBlob.empty()
+            ? std::unordered_map<uint8_t, chif::I2cSegmentMapping>{}
+            : chif::parseI2cSegments(platDefBlob);
 
     // Build daemon and register handlers
     chif::ChifDaemon daemon(std::move(channel));

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -98,10 +98,9 @@ int main()
         lg2::warning("EV storage failed to load, starting with empty store");
     }
 
-    // Extract PlatDef from host BIOS SPI flash and build I2C segment→bus map.
-    // TODO: pass segmentBusMap to SmifService for I2C proxy routing.
+    // Extract PlatDef from host BIOS SPI flash and build I2C segment→bus map
     auto platDefBlob = chif::extractPlatDef();
-    [[maybe_unused]] auto segmentBusMap =
+    auto segmentBusMap =
         platDefBlob.empty()
             ? std::unordered_map<uint8_t, int>{}
             : chif::buildSegmentBusMap(chif::parseI2cSegments(platDefBlob));
@@ -110,7 +109,8 @@ int main()
     chif::ChifDaemon daemon(std::move(channel));
     daemon.registerHandler(
         std::make_unique<chif::RomService>(smbiosWriter, &mdrBridge));
-    daemon.registerHandler(std::make_unique<chif::SmifService>(&evStorage));
+    daemon.registerHandler(std::make_unique<chif::SmifService>(
+        &evStorage, std::move(segmentBusMap)));
     daemon.registerHandler(std::make_unique<chif::HealthService>());
 
     // Install signal handlers for graceful shutdown

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -5,6 +5,7 @@
 #include "ev_storage.hpp"
 #include "health_service.hpp"
 #include "mdr_bridge.hpp"
+#include "platdef_extract.hpp"
 #include "rom_service.hpp"
 #include "smif_service.hpp"
 #include "smbios_writer.hpp"
@@ -95,6 +96,13 @@ int main()
     if (evStorage.load() < 0)
     {
         lg2::warning("EV storage failed to load, starting with empty store");
+    }
+
+    // Extract PlatDef blob from host BIOS SPI flash
+    auto platDefBlob = chif::extractPlatDef();
+    if (platDefBlob.empty())
+    {
+        lg2::info("PlatDef blob not available");
     }
 
     // Build daemon and register handlers

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -98,13 +98,13 @@ int main()
         lg2::warning("EV storage failed to load, starting with empty store");
     }
 
-    // Extract PlatDef from host BIOS SPI flash and parse I2C mappings.
-    // TODO: pass i2cSegments to SmifService for I2C proxy routing.
+    // Extract PlatDef from host BIOS SPI flash and build I2C segment→bus map.
+    // TODO: pass segmentBusMap to SmifService for I2C proxy routing.
     auto platDefBlob = chif::extractPlatDef();
-    [[maybe_unused]] auto i2cSegments =
+    [[maybe_unused]] auto segmentBusMap =
         platDefBlob.empty()
-            ? std::unordered_map<uint8_t, chif::I2cSegmentMapping>{}
-            : chif::parseI2cSegments(platDefBlob);
+            ? std::unordered_map<uint8_t, int>{}
+            : chif::buildSegmentBusMap(chif::parseI2cSegments(platDefBlob));
 
     // Build daemon and register handlers
     chif::ChifDaemon daemon(std::move(channel));

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
@@ -117,6 +117,52 @@ struct PlatDefTableData
 
 static constexpr uint16_t tableDataFlagZLib = 0x0010;
 
+// I2C mux control — CPLD variant (muxType == 1)
+struct PlatDefI2CMuxCpld
+{
+    uint8_t muxType;
+    uint8_t byte;        // CPLD register offset
+    uint8_t initMask;
+    uint8_t selectMask;
+};
+
+// I2C mux control union (16 bytes, only CPLD variant used here)
+union PlatDefI2CMux
+{
+    uint8_t rawBytes[16];
+    uint8_t muxType;
+    PlatDefI2CMuxCpld cpld;
+};
+
+struct PlatDefI2CSegment
+{
+    uint32_t flags;
+    uint8_t speed;
+    uint8_t id;          // BIOS segment byte
+    uint8_t parentId;
+    uint8_t gpuRiserNumber;
+    uint8_t reserved[8];
+    PlatDefI2CMux muxControl;
+};
+
+// PlatDefPrimitive is a 16-byte union in HPE's platdef.h
+struct PlatDefPrimitive
+{
+    uint8_t rawBytes[16];
+};
+
+// I2CEngine fixed fields between the record header and the segments array
+struct PlatDefI2CEngineFixed
+{
+    PlatDefPrimitive reset;
+    PlatDefPrimitive alert;
+    uint32_t flags;
+    uint8_t speed;
+    uint8_t id;
+    uint8_t count;
+    uint8_t reserved[9];
+};
+
 #pragma pack(pop)
 
 static_assert(sizeof(PlatDefBundleHeader) == 32,
@@ -125,6 +171,12 @@ static_assert(sizeof(PlatDefRecordHeader) == 32,
               "PlatDefRecordHeader must be 32 bytes (Gen11 layout)");
 static_assert(sizeof(PlatDefTableData) == 112,
               "PlatDefTableData must be 112 bytes");
+static_assert(sizeof(PlatDefI2CSegment) == 32,
+              "PlatDefI2CSegment must be 32 bytes");
+static_assert(sizeof(PlatDefI2CMux) == 16,
+              "PlatDefI2CMux must be 16 bytes");
+static_assert(sizeof(PlatDefI2CEngineFixed) == 48,
+              "PlatDefI2CEngineFixed must be 48 bytes");
 
 static constexpr uint32_t efiFvhSignature = 0x4856465F; // '_FVH'
 static constexpr uint8_t efiFvFileTypeFreeform = 0x02;
@@ -477,6 +529,115 @@ std::vector<uint8_t> extractPlatDef()
 
     lg2::info("PlatDef: APML firmware volume not found in ROM");
     return {};
+}
+
+// ---------------------------------------------------------------------------
+// PlatDef record parser — extract I2C segment→CPLD mappings
+//
+// Records are walked using hdr.size * 16 as the stride (each record's
+// size field is in units of 16 bytes). We only parse RecordType_I2CEngine
+// (type 14) records; all others are skipped.
+// ---------------------------------------------------------------------------
+
+static constexpr uint8_t recordTypeI2CEngine = 14;
+static constexpr uint8_t recordTypeEndOfTable = 255;
+static constexpr uint8_t i2cMuxTypeCpld = 1;
+
+std::unordered_map<uint8_t, I2cSegmentMapping>
+    parseI2cSegments(const std::vector<uint8_t>& platDef)
+{
+    std::unordered_map<uint8_t, I2cSegmentMapping> result;
+
+    if (platDef.size() < sizeof(PlatDefRecordHeader))
+    {
+        return result;
+    }
+
+    // Validate Gen11 record layout: the first record is the table data
+    // header whose stride should match sizeof(PlatDefTableData).
+    PlatDefRecordHeader firstHdr{};
+    std::memcpy(&firstHdr, platDef.data(), sizeof(firstHdr));
+    if (static_cast<size_t>(firstHdr.size) * 16 != sizeof(PlatDefTableData))
+    {
+        lg2::error("PlatDef: unexpected table record size {SZ} "
+                   "(expected {EXP}), layout may not be Gen11",
+                   "SZ", static_cast<size_t>(firstHdr.size) * 16,
+                   "EXP", sizeof(PlatDefTableData));
+        return result;
+    }
+
+    size_t pos = 0;
+
+    while (pos + sizeof(PlatDefRecordHeader) <= platDef.size())
+    {
+        PlatDefRecordHeader hdr{};
+        std::memcpy(&hdr, platDef.data() + pos, sizeof(hdr));
+
+        if (hdr.type == recordTypeEndOfTable || hdr.size == 0)
+        {
+            break;
+        }
+
+        size_t recordBytes = static_cast<size_t>(hdr.size) * 16;
+
+        if (pos + recordBytes > platDef.size())
+        {
+            lg2::warning("PlatDef: record at 0x{OFF} claims {SZ} bytes, "
+                         "only {REM} remain",
+                         "OFF", lg2::hex, pos, "SZ", recordBytes,
+                         "REM", platDef.size() - pos);
+            break;
+        }
+
+        if (hdr.type == recordTypeI2CEngine)
+        {
+            size_t fixedEnd = pos + sizeof(PlatDefRecordHeader) +
+                              sizeof(PlatDefI2CEngineFixed);
+            if (fixedEnd > platDef.size())
+            {
+                break;
+            }
+
+            PlatDefI2CEngineFixed eng{};
+            std::memcpy(&eng, platDef.data() + pos +
+                                  sizeof(PlatDefRecordHeader),
+                        sizeof(eng));
+
+            size_t recordEnd = pos + recordBytes;
+            size_t segStart = fixedEnd;
+
+            for (uint8_t i = 0; i < eng.count; i++)
+            {
+                size_t segOff = segStart + i * sizeof(PlatDefI2CSegment);
+                if (segOff + sizeof(PlatDefI2CSegment) > platDef.size() ||
+                    segOff + sizeof(PlatDefI2CSegment) > recordEnd)
+                {
+                    break;
+                }
+
+                PlatDefI2CSegment seg{};
+                std::memcpy(&seg, platDef.data() + segOff, sizeof(seg));
+
+                if (seg.muxControl.muxType == i2cMuxTypeCpld)
+                {
+                    result[seg.id] = {seg.muxControl.cpld.byte,
+                                      seg.muxControl.cpld.selectMask};
+
+                    lg2::debug("PlatDef I2C: engine={ENG} seg=0x{SEG} "
+                               "cpld=0x{CPLD} chan={CH}",
+                               "ENG", eng.id, "SEG", lg2::hex, seg.id,
+                               "CPLD", lg2::hex, seg.muxControl.cpld.byte,
+                               "CH", seg.muxControl.cpld.selectMask);
+                }
+            }
+        }
+
+        pos += recordBytes;
+    }
+
+    lg2::info("PlatDef: parsed {CNT} I2C segment mappings",
+              "CNT", result.size());
+    return result;
 }
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 9elements GmbH
 
-// Extract the APML Platform Definition blob from the host BIOS SPI flash.
-// The blob is stored inside a UEFI firmware volume as an FFS file,
-// identified by well-known GUIDs. This replaces HPE's standalone
-// hpe-platdef-extract utility with an in-process implementation.
+// Parse the HPE Platform Definition (PlatDef) blob and extract I2C
+// segment-to-bus mappings for the CHIF I2C proxy. The raw blob is
+// extracted from the host BIOS SPI flash via the UEFI FV parser
+// (uefi_fv.hpp), then decompressed and walked for I2CEngine records.
 
 #include "platdef_extract.hpp"
+
+#include "uefi_fv.hpp"
 
 #include <phosphor-logging/lg2.hpp>
 
@@ -21,55 +23,8 @@
 namespace chif
 {
 
-// UEFI packed structures for firmware volume parsing
-#pragma pack(push, 1)
-
-struct EfiGuid
-{
-    uint32_t data1;
-    uint16_t data2;
-    uint16_t data3;
-    uint8_t data4[8];
-};
-
-struct EfiFvHeader
-{
-    uint8_t zeroVector[16];
-    EfiGuid fileSystemGuid;
-    uint64_t fvLength;
-    uint32_t signature; // '_FVH' = 0x4856465F
-    uint32_t attributes;
-    uint16_t headerLength;
-    uint16_t checksum;
-    uint16_t extHeaderOffset;
-    uint8_t reserved;
-    uint8_t revision;
-    // BlockMap follows but we don't need it
-};
-
-struct EfiFvExtHeader
-{
-    EfiGuid fvName;
-    uint32_t extHeaderSize;
-};
-
-struct EfiFfsFileHeader
-{
-    EfiGuid name;
-    uint16_t integrityCheck;
-    uint8_t type;
-    uint8_t attributes;
-    uint8_t size[3];
-    uint8_t state;
-};
-
-struct EfiSectionHeader
-{
-    uint8_t size[3];
-    uint8_t type;
-};
-
 // PlatDef bundle and record structures (from HPE openbmc-chif-svc platdef.h)
+#pragma pack(push, 1)
 
 // From HPE upstream platdef.h
 #define PLATDEF_BUNDLE_SIGNATURE "$PlatdefBundle1$"
@@ -178,47 +133,6 @@ static_assert(sizeof(PlatDefI2CMux) == 16,
 static_assert(sizeof(PlatDefI2CEngineFixed) == 48,
               "PlatDefI2CEngineFixed must be 48 bytes");
 
-static constexpr uint32_t efiFvhSignature = 0x4856465F; // '_FVH'
-static constexpr uint8_t efiFvFileTypeFreeform = 0x02;
-static constexpr uint8_t efiFfsLargeFile = 0x01;
-static constexpr uint8_t efiSectionRaw = 0x19;
-static constexpr uint8_t efiSectionGuidDefined = 0x02;
-
-// APML firmware volume GUID: {7EBF5AB8-525E-417C-9B6B-5EF367856954}
-static constexpr EfiGuid apmlFvGuid = {
-    0x7EBF5AB8, 0x525E, 0x417C,
-    {0x9B, 0x6B, 0x5E, 0xF3, 0x67, 0x85, 0x69, 0x54}};
-
-// APML file GUID: {C5F6001C-39B4-43DD-9B9B-6832F1BB4BE9}
-static constexpr EfiGuid apmlFileGuid = {
-    0xC5F6001C, 0x39B4, 0x43DD,
-    {0x9B, 0x9B, 0x68, 0x32, 0xF1, 0xBB, 0x4B, 0xE9}};
-
-// EFI FFS2 file system GUID: {8C8CE578-8A3D-4F1C-9935-896185C32DD3}
-static constexpr EfiGuid ffs2Guid = {
-    0x8C8CE578, 0x8A3D, 0x4F1C,
-    {0x99, 0x35, 0x89, 0x61, 0x85, 0xC3, 0x2D, 0xD3}};
-
-static bool guidEqual(const EfiGuid& a, const EfiGuid& b)
-{
-    return std::memcmp(&a, &b, sizeof(EfiGuid)) == 0;
-}
-
-static bool guidIsAllFf(const EfiGuid& g)
-{
-    static constexpr EfiGuid allFf = {
-        0xFFFFFFFF, 0xFFFF, 0xFFFF,
-        {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
-    return guidEqual(g, allFf);
-}
-
-static uint32_t ffsFileSize(const EfiFfsFileHeader& hdr)
-{
-    return static_cast<uint32_t>(hdr.size[0]) |
-           (static_cast<uint32_t>(hdr.size[1]) << 8) |
-           (static_cast<uint32_t>(hdr.size[2]) << 16);
-}
-
 // Find the MTD device path for a partition by label
 static std::string findMtdByLabel(const std::string& label)
 {
@@ -251,7 +165,6 @@ static std::string findMtdByLabel(const std::string& label)
         std::getline(nameFile, name);
         if (name == label)
         {
-            // Return /dev/mtdN
             return "/dev/" + entry.path().filename().string();
         }
     }
@@ -307,7 +220,6 @@ static std::vector<uint8_t> decompressPlatDef(const std::vector<uint8_t>& raw)
 
     if (!(tableHdr.flags & tableDataFlagZLib))
     {
-        // Not compressed — return data starting from the table header
         lg2::info("PlatDef: not compressed, returning raw records");
         return std::vector<uint8_t>(raw.begin() + offset, raw.end());
     }
@@ -336,7 +248,6 @@ static std::vector<uint8_t> decompressPlatDef(const std::vector<uint8_t>& raw)
     }
     std::vector<uint8_t> result(sizeof(PlatDefTableData) + decompSize);
 
-    // Copy the table header as-is
     std::memcpy(result.data(), &tableHdr, sizeof(PlatDefTableData));
 
     int rc = ::uncompress(
@@ -354,6 +265,16 @@ static std::vector<uint8_t> decompressPlatDef(const std::vector<uint8_t>& raw)
               "SZ", decompSize, "CNT", tableHdr.recordCount);
     return result;
 }
+
+// APML firmware volume GUID: {7EBF5AB8-525E-417C-9B6B-5EF367856954}
+static constexpr EfiGuid apmlFvGuid = {
+    0x7EBF5AB8, 0x525E, 0x417C,
+    {0x9B, 0x6B, 0x5E, 0xF3, 0x67, 0x85, 0x69, 0x54}};
+
+// APML file GUID: {C5F6001C-39B4-43DD-9B9B-6832F1BB4BE9}
+static constexpr EfiGuid apmlFileGuid = {
+    0xC5F6001C, 0x39B4, 0x43DD,
+    {0x9B, 0x9B, 0x68, 0x32, 0xF1, 0xBB, 0x4B, 0xE9}};
 
 std::vector<uint8_t> extractPlatDef()
 {
@@ -382,153 +303,14 @@ std::vector<uint8_t> extractPlatDef()
     auto romSize = static_cast<size_t>(pos);
     rom.seekg(0);
 
-    // Scan for firmware volumes every 64KB
-    for (size_t fvOffset = 0; fvOffset + sizeof(EfiFvHeader) < romSize;
-         fvOffset += 0x10000)
+    auto raw = extractFfsFile(rom, romSize, apmlFvGuid, apmlFileGuid);
+    if (raw.empty())
     {
-        EfiFvHeader fvHdr{};
-        rom.seekg(static_cast<std::streamoff>(fvOffset));
-        rom.read(reinterpret_cast<char*>(&fvHdr), sizeof(fvHdr));
-        if (!rom.good())
-        {
-            break;
-        }
-
-        if (fvHdr.signature != efiFvhSignature)
-        {
-            continue;
-        }
-
-        if (!guidEqual(fvHdr.fileSystemGuid, ffs2Guid))
-        {
-            continue;
-        }
-
-        if (fvHdr.extHeaderOffset == 0)
-        {
-            continue;
-        }
-
-        // Read extended header to check the volume name GUID
-        EfiFvExtHeader extHdr{};
-        rom.seekg(
-            static_cast<std::streamoff>(fvOffset + fvHdr.extHeaderOffset));
-        rom.read(reinterpret_cast<char*>(&extHdr), sizeof(extHdr));
-        if (!rom.good())
-        {
-            continue;
-        }
-
-        if (!guidEqual(extHdr.fvName, apmlFvGuid))
-        {
-            continue;
-        }
-
-        lg2::info("PlatDef: found APML FV at offset 0x{OFF}",
-                  "OFF", lg2::hex, fvOffset);
-
-        // Walk FFS file entries starting after the extended header
-        size_t fileOffset = fvOffset + fvHdr.extHeaderOffset +
-                            extHdr.extHeaderSize;
-        size_t fvEnd = fvOffset + static_cast<size_t>(fvHdr.fvLength);
-        if (fvEnd > romSize)
-        {
-            fvEnd = romSize;
-        }
-
-        while (fileOffset + sizeof(EfiFfsFileHeader) < fvEnd)
-        {
-            // 8-byte align
-            if (fileOffset & 0x07)
-            {
-                fileOffset = (fileOffset & ~0x07UL) + 0x08;
-            }
-
-            EfiFfsFileHeader fileHdr{};
-            rom.seekg(static_cast<std::streamoff>(fileOffset));
-            rom.read(reinterpret_cast<char*>(&fileHdr), sizeof(fileHdr));
-            if (!rom.good())
-            {
-                break;
-            }
-
-            // End of file list
-            if (guidIsAllFf(fileHdr.name))
-            {
-                break;
-            }
-
-            uint32_t fileSize = ffsFileSize(fileHdr);
-            if (fileSize < sizeof(EfiFfsFileHeader))
-            {
-                break;
-            }
-
-            uint32_t dataSize = fileSize - sizeof(EfiFfsFileHeader);
-            size_t dataOffset = fileOffset + sizeof(EfiFfsFileHeader);
-
-            if (guidEqual(fileHdr.name, apmlFileGuid) &&
-                !(fileHdr.attributes & efiFfsLargeFile))
-            {
-                lg2::info("PlatDef: found APML file, {SZ} bytes at 0x{OFF}",
-                          "SZ", dataSize, "OFF", lg2::hex, dataOffset);
-
-                // Handle section header for FREEFORM files
-                if (fileHdr.type == efiFvFileTypeFreeform &&
-                    dataSize > sizeof(EfiSectionHeader))
-                {
-                    EfiSectionHeader secHdr{};
-                    rom.seekg(static_cast<std::streamoff>(dataOffset));
-                    rom.read(reinterpret_cast<char*>(&secHdr),
-                             sizeof(secHdr));
-                    if (!rom.good())
-                    {
-                        lg2::error("PlatDef: section header read failed");
-                        return {};
-                    }
-
-                    if (secHdr.type == efiSectionRaw)
-                    {
-                        dataOffset += sizeof(EfiSectionHeader);
-                        dataSize -= sizeof(EfiSectionHeader);
-                    }
-                    else if (secHdr.type == efiSectionGuidDefined)
-                    {
-                        constexpr uint32_t guidSecHdrSize = 20;
-                        if (dataSize <= guidSecHdrSize)
-                        {
-                            break;
-                        }
-                        dataOffset += guidSecHdrSize;
-                        dataSize -= guidSecHdrSize;
-                    }
-                }
-
-                // Read the raw APML blob
-                std::vector<uint8_t> raw(dataSize);
-                rom.seekg(static_cast<std::streamoff>(dataOffset));
-                rom.read(reinterpret_cast<char*>(raw.data()),
-                         static_cast<std::streamsize>(dataSize));
-
-                if (!rom.good())
-                {
-                    lg2::error("PlatDef: read failed at offset 0x{OFF}",
-                               "OFF", lg2::hex, dataOffset);
-                    return {};
-                }
-
-                lg2::info("PlatDef: read {SZ} bytes from ROM", "SZ",
-                          raw.size());
-
-                return decompressPlatDef(raw);
-            }
-
-            fileOffset += fileSize;
-        }
+        lg2::info("PlatDef: APML firmware volume not found in ROM");
+        return {};
     }
 
-    lg2::info("PlatDef: APML firmware volume not found in ROM");
-    return {};
+    return decompressPlatDef(raw);
 }
 
 // ---------------------------------------------------------------------------

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+// Extract the APML Platform Definition blob from the host BIOS SPI flash.
+// The blob is stored inside a UEFI firmware volume as an FFS file,
+// identified by well-known GUIDs. This replaces HPE's standalone
+// hpe-platdef-extract utility with an in-process implementation.
+
+#include "platdef_extract.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <zlib.h>
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+namespace chif
+{
+
+// UEFI packed structures for firmware volume parsing
+#pragma pack(push, 1)
+
+struct EfiGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+};
+
+struct EfiFvHeader
+{
+    uint8_t zeroVector[16];
+    EfiGuid fileSystemGuid;
+    uint64_t fvLength;
+    uint32_t signature; // '_FVH' = 0x4856465F
+    uint32_t attributes;
+    uint16_t headerLength;
+    uint16_t checksum;
+    uint16_t extHeaderOffset;
+    uint8_t reserved;
+    uint8_t revision;
+    // BlockMap follows but we don't need it
+};
+
+struct EfiFvExtHeader
+{
+    EfiGuid fvName;
+    uint32_t extHeaderSize;
+};
+
+struct EfiFfsFileHeader
+{
+    EfiGuid name;
+    uint16_t integrityCheck;
+    uint8_t type;
+    uint8_t attributes;
+    uint8_t size[3];
+    uint8_t state;
+};
+
+struct EfiSectionHeader
+{
+    uint8_t size[3];
+    uint8_t type;
+};
+
+// PlatDef bundle and record structures (from HPE openbmc-chif-svc platdef.h)
+
+// From HPE upstream platdef.h
+#define PLATDEF_BUNDLE_SIGNATURE "$PlatdefBundle1$"
+
+struct PlatDefBundleHeader
+{
+    char signature[16]; // PLATDEF_BUNDLE_SIGNATURE
+    uint32_t totalSize;
+    uint16_t flags;
+    uint8_t headerLength;
+    uint8_t count;
+    uint8_t reserved[8];
+};
+
+struct PlatDefRecordHeader
+{
+    uint8_t type;
+    uint8_t size; // record size in 16-byte units
+    uint16_t recordId;
+    uint16_t flags;
+    uint8_t entityId;
+    uint8_t entityInstance;
+    uint8_t featureIndex;
+    uint8_t reserved[3];
+    uint32_t runtimeData;
+    char name[16];
+};
+
+struct PlatDefTableData
+{
+    PlatDefRecordHeader header;
+    char description[32];
+    uint16_t flags;
+    uint8_t majorVersion;
+    uint8_t minorVersion;
+    uint32_t buildTimestamp;
+    uint32_t recordCount;
+    uint32_t totalSize;
+    uint8_t md5Hash[16];
+    uint32_t compressedSize;
+    uint8_t specialVersion;
+    uint8_t buildVersion;
+    uint8_t reserved[10];
+};
+
+static constexpr uint16_t tableDataFlagZLib = 0x0010;
+
+#pragma pack(pop)
+
+static_assert(sizeof(PlatDefBundleHeader) == 32,
+              "PlatDefBundleHeader must be 32 bytes");
+static_assert(sizeof(PlatDefRecordHeader) == 32,
+              "PlatDefRecordHeader must be 32 bytes (Gen11 layout)");
+static_assert(sizeof(PlatDefTableData) == 112,
+              "PlatDefTableData must be 112 bytes");
+
+static constexpr uint32_t efiFvhSignature = 0x4856465F; // '_FVH'
+static constexpr uint8_t efiFvFileTypeFreeform = 0x02;
+static constexpr uint8_t efiFfsLargeFile = 0x01;
+static constexpr uint8_t efiSectionRaw = 0x19;
+static constexpr uint8_t efiSectionGuidDefined = 0x02;
+
+// APML firmware volume GUID: {7EBF5AB8-525E-417C-9B6B-5EF367856954}
+static constexpr EfiGuid apmlFvGuid = {
+    0x7EBF5AB8, 0x525E, 0x417C,
+    {0x9B, 0x6B, 0x5E, 0xF3, 0x67, 0x85, 0x69, 0x54}};
+
+// APML file GUID: {C5F6001C-39B4-43DD-9B9B-6832F1BB4BE9}
+static constexpr EfiGuid apmlFileGuid = {
+    0xC5F6001C, 0x39B4, 0x43DD,
+    {0x9B, 0x9B, 0x68, 0x32, 0xF1, 0xBB, 0x4B, 0xE9}};
+
+// EFI FFS2 file system GUID: {8C8CE578-8A3D-4F1C-9935-896185C32DD3}
+static constexpr EfiGuid ffs2Guid = {
+    0x8C8CE578, 0x8A3D, 0x4F1C,
+    {0x99, 0x35, 0x89, 0x61, 0x85, 0xC3, 0x2D, 0xD3}};
+
+static bool guidEqual(const EfiGuid& a, const EfiGuid& b)
+{
+    return std::memcmp(&a, &b, sizeof(EfiGuid)) == 0;
+}
+
+static bool guidIsAllFf(const EfiGuid& g)
+{
+    static constexpr EfiGuid allFf = {
+        0xFFFFFFFF, 0xFFFF, 0xFFFF,
+        {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+    return guidEqual(g, allFf);
+}
+
+static uint32_t ffsFileSize(const EfiFfsFileHeader& hdr)
+{
+    return static_cast<uint32_t>(hdr.size[0]) |
+           (static_cast<uint32_t>(hdr.size[1]) << 8) |
+           (static_cast<uint32_t>(hdr.size[2]) << 16);
+}
+
+// Find the MTD device path for a partition by label
+static std::string findMtdByLabel(const std::string& label)
+{
+    const std::filesystem::path mtdBase = "/sys/class/mtd";
+    if (!std::filesystem::exists(mtdBase))
+    {
+        return {};
+    }
+
+    for (const auto& entry : std::filesystem::directory_iterator(mtdBase))
+    {
+        // Skip read-only mtdNro entries
+        std::string devName = entry.path().filename().string();
+        if (devName.ends_with("ro"))
+        {
+            continue;
+        }
+
+        auto namePath = entry.path() / "name";
+        if (!std::filesystem::exists(namePath))
+        {
+            continue;
+        }
+        std::ifstream nameFile(namePath);
+        if (!nameFile)
+        {
+            continue;
+        }
+        std::string name;
+        std::getline(nameFile, name);
+        if (name == label)
+        {
+            // Return /dev/mtdN
+            return "/dev/" + entry.path().filename().string();
+        }
+    }
+    return {};
+}
+
+// Decompress the PlatDef blob from the raw APML file.
+// Layout: [PlatDefBundleHeader][PlatDefTableData][zlib compressed records...]
+// Returns: [PlatDefTableData header][decompressed records]
+static std::vector<uint8_t> decompressPlatDef(const std::vector<uint8_t>& raw)
+{
+    // The APML file starts with a PlatDefBundleHeader followed by
+    // a PlatDefTableData record. HPE skips the bundle header to reach
+    // the table data.
+    if (raw.size() < sizeof(PlatDefBundleHeader))
+    {
+        lg2::error("PlatDef: blob too small for bundle header");
+        return {};
+    }
+
+    if (std::memcmp(raw.data(), PLATDEF_BUNDLE_SIGNATURE,
+                    sizeof(PLATDEF_BUNDLE_SIGNATURE) - 1) != 0)
+    {
+        lg2::error("PlatDef: invalid bundle signature");
+        return {};
+    }
+
+    size_t offset = sizeof(PlatDefBundleHeader);
+
+    if (offset + sizeof(PlatDefTableData) > raw.size())
+    {
+        lg2::error("PlatDef: blob too small for table data header");
+        return {};
+    }
+
+    PlatDefTableData tableHdr{};
+    std::memcpy(&tableHdr, raw.data() + offset, sizeof(tableHdr));
+
+    std::string_view desc(tableHdr.description,
+                          sizeof(tableHdr.description));
+    if (auto nul = desc.find('\0'); nul != std::string_view::npos)
+    {
+        desc = desc.substr(0, nul);
+    }
+
+    lg2::info("PlatDef: table \"{DESC}\" v{MAJ}.{MIN}, "
+              "records={CNT}, compressedSize={CSZ}",
+              "DESC", std::string(desc),
+              "MAJ", tableHdr.majorVersion,
+              "MIN", tableHdr.minorVersion,
+              "CNT", tableHdr.recordCount,
+              "CSZ", tableHdr.compressedSize);
+
+    if (!(tableHdr.flags & tableDataFlagZLib))
+    {
+        // Not compressed — return data starting from the table header
+        lg2::info("PlatDef: not compressed, returning raw records");
+        return std::vector<uint8_t>(raw.begin() + offset, raw.end());
+    }
+
+    // Compressed: zlib data starts after the PlatDefTableData header
+    size_t compOffset = offset + sizeof(PlatDefTableData);
+    if (tableHdr.compressedSize < sizeof(PlatDefTableData))
+    {
+        lg2::error("PlatDef: invalid compressedSize {SZ}",
+                   "SZ", tableHdr.compressedSize);
+        return {};
+    }
+    uint32_t compSize = tableHdr.compressedSize - sizeof(PlatDefTableData);
+
+    if (compOffset + compSize > raw.size())
+    {
+        lg2::error("PlatDef: compressed data exceeds blob size");
+        return {};
+    }
+
+    // Decompress into output buffer: [PlatDefTableData][decompressed records]
+    uLong decompSize = tableHdr.totalSize; // uLong: passed by pointer to zlib
+    if (decompSize == 0 || decompSize > 512 * 1024)
+    {
+        decompSize = 256 * 1024; // fallback cap
+    }
+    std::vector<uint8_t> result(sizeof(PlatDefTableData) + decompSize);
+
+    // Copy the table header as-is
+    std::memcpy(result.data(), &tableHdr, sizeof(PlatDefTableData));
+
+    int rc = ::uncompress(
+        result.data() + sizeof(PlatDefTableData), &decompSize,
+        raw.data() + compOffset, compSize);
+
+    if (rc != Z_OK)
+    {
+        lg2::error("PlatDef: zlib decompress failed, rc={RC}", "RC", rc);
+        return {};
+    }
+
+    result.resize(sizeof(PlatDefTableData) + decompSize);
+    lg2::info("PlatDef: decompressed {SZ} bytes ({CNT} records)",
+              "SZ", decompSize, "CNT", tableHdr.recordCount);
+    return result;
+}
+
+std::vector<uint8_t> extractPlatDef()
+{
+    std::string mtdPath = findMtdByLabel("host-prime");
+    if (mtdPath.empty())
+    {
+        lg2::info("PlatDef: host-prime MTD partition not found");
+        return {};
+    }
+
+    lg2::info("PlatDef: reading from {PATH}", "PATH", mtdPath);
+
+    std::ifstream rom(mtdPath, std::ios::binary | std::ios::ate);
+    if (!rom)
+    {
+        lg2::error("PlatDef: failed to open {PATH}", "PATH", mtdPath);
+        return {};
+    }
+
+    auto pos = rom.tellg();
+    if (pos <= 0)
+    {
+        lg2::error("PlatDef: failed to determine ROM size");
+        return {};
+    }
+    auto romSize = static_cast<size_t>(pos);
+    rom.seekg(0);
+
+    // Scan for firmware volumes every 64KB
+    for (size_t fvOffset = 0; fvOffset + sizeof(EfiFvHeader) < romSize;
+         fvOffset += 0x10000)
+    {
+        EfiFvHeader fvHdr{};
+        rom.seekg(static_cast<std::streamoff>(fvOffset));
+        rom.read(reinterpret_cast<char*>(&fvHdr), sizeof(fvHdr));
+        if (!rom.good())
+        {
+            break;
+        }
+
+        if (fvHdr.signature != efiFvhSignature)
+        {
+            continue;
+        }
+
+        if (!guidEqual(fvHdr.fileSystemGuid, ffs2Guid))
+        {
+            continue;
+        }
+
+        if (fvHdr.extHeaderOffset == 0)
+        {
+            continue;
+        }
+
+        // Read extended header to check the volume name GUID
+        EfiFvExtHeader extHdr{};
+        rom.seekg(
+            static_cast<std::streamoff>(fvOffset + fvHdr.extHeaderOffset));
+        rom.read(reinterpret_cast<char*>(&extHdr), sizeof(extHdr));
+        if (!rom.good())
+        {
+            continue;
+        }
+
+        if (!guidEqual(extHdr.fvName, apmlFvGuid))
+        {
+            continue;
+        }
+
+        lg2::info("PlatDef: found APML FV at offset 0x{OFF}",
+                  "OFF", lg2::hex, fvOffset);
+
+        // Walk FFS file entries starting after the extended header
+        size_t fileOffset = fvOffset + fvHdr.extHeaderOffset +
+                            extHdr.extHeaderSize;
+        size_t fvEnd = fvOffset + static_cast<size_t>(fvHdr.fvLength);
+        if (fvEnd > romSize)
+        {
+            fvEnd = romSize;
+        }
+
+        while (fileOffset + sizeof(EfiFfsFileHeader) < fvEnd)
+        {
+            // 8-byte align
+            if (fileOffset & 0x07)
+            {
+                fileOffset = (fileOffset & ~0x07UL) + 0x08;
+            }
+
+            EfiFfsFileHeader fileHdr{};
+            rom.seekg(static_cast<std::streamoff>(fileOffset));
+            rom.read(reinterpret_cast<char*>(&fileHdr), sizeof(fileHdr));
+            if (!rom.good())
+            {
+                break;
+            }
+
+            // End of file list
+            if (guidIsAllFf(fileHdr.name))
+            {
+                break;
+            }
+
+            uint32_t fileSize = ffsFileSize(fileHdr);
+            if (fileSize < sizeof(EfiFfsFileHeader))
+            {
+                break;
+            }
+
+            uint32_t dataSize = fileSize - sizeof(EfiFfsFileHeader);
+            size_t dataOffset = fileOffset + sizeof(EfiFfsFileHeader);
+
+            if (guidEqual(fileHdr.name, apmlFileGuid) &&
+                !(fileHdr.attributes & efiFfsLargeFile))
+            {
+                lg2::info("PlatDef: found APML file, {SZ} bytes at 0x{OFF}",
+                          "SZ", dataSize, "OFF", lg2::hex, dataOffset);
+
+                // Handle section header for FREEFORM files
+                if (fileHdr.type == efiFvFileTypeFreeform &&
+                    dataSize > sizeof(EfiSectionHeader))
+                {
+                    EfiSectionHeader secHdr{};
+                    rom.seekg(static_cast<std::streamoff>(dataOffset));
+                    rom.read(reinterpret_cast<char*>(&secHdr),
+                             sizeof(secHdr));
+                    if (!rom.good())
+                    {
+                        lg2::error("PlatDef: section header read failed");
+                        return {};
+                    }
+
+                    if (secHdr.type == efiSectionRaw)
+                    {
+                        dataOffset += sizeof(EfiSectionHeader);
+                        dataSize -= sizeof(EfiSectionHeader);
+                    }
+                    else if (secHdr.type == efiSectionGuidDefined)
+                    {
+                        constexpr uint32_t guidSecHdrSize = 20;
+                        if (dataSize <= guidSecHdrSize)
+                        {
+                            break;
+                        }
+                        dataOffset += guidSecHdrSize;
+                        dataSize -= guidSecHdrSize;
+                    }
+                }
+
+                // Read the raw APML blob
+                std::vector<uint8_t> raw(dataSize);
+                rom.seekg(static_cast<std::streamoff>(dataOffset));
+                rom.read(reinterpret_cast<char*>(raw.data()),
+                         static_cast<std::streamsize>(dataSize));
+
+                if (!rom.good())
+                {
+                    lg2::error("PlatDef: read failed at offset 0x{OFF}",
+                               "OFF", lg2::hex, dataOffset);
+                    return {};
+                }
+
+                lg2::info("PlatDef: read {SZ} bytes from ROM", "SZ",
+                          raw.size());
+
+                return decompressPlatDef(raw);
+            }
+
+            fileOffset += fileSize;
+        }
+    }
+
+    lg2::info("PlatDef: APML firmware volume not found in ROM");
+    return {};
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
@@ -640,4 +640,163 @@ std::unordered_map<uint8_t, I2cSegmentMapping>
     return result;
 }
 
+// ---------------------------------------------------------------------------
+// Combine PlatDef segment data with sysfs i2cmux topology to build the
+// final segment→kernel bus mapping.
+//
+// PlatDef gives us: segment → (cpldRegister, channelValue)
+// sysfs gives us:   (muxIndex, channelNumber) → kernelBus
+// Correlation:      muxIndex = cpldRegister - cpldRegisterBase
+// ---------------------------------------------------------------------------
+
+// GXP AHB bus path where i2cmux devices appear in sysfs
+static constexpr auto ahbSysfsPath = "/sys/devices/platform/ahb@80000000";
+
+// CPLD register base address for mux index 0. Mux N maps to register
+// base + N. Derived from the device tree mux-reg-masks property.
+static constexpr uint8_t cpldRegisterBase = 0x84;
+
+// Scan sysfs for i2cmux channel→bus mappings.
+// Key: (muxIndex << 8) | channelNumber — valid for channelNumber < 256.
+static std::unordered_map<uint16_t, int> scanMuxTopology()
+{
+    std::unordered_map<uint16_t, int> result;
+    const std::filesystem::path ahbPath = ahbSysfsPath;
+
+    if (!std::filesystem::exists(ahbPath))
+    {
+        return result;
+    }
+
+    try
+    {
+        for (const auto& entry :
+             std::filesystem::directory_iterator(ahbPath))
+        {
+            std::string name = entry.path().filename().string();
+            if (!name.starts_with("ahb@") ||
+                name.find("i2cmux@") == std::string::npos)
+            {
+                continue;
+            }
+
+            auto muxPos = name.find("i2cmux@");
+            unsigned long muxVal = 0;
+            try
+            {
+                muxVal = std::stoul(name.substr(muxPos + 7));
+            }
+            catch (const std::exception&)
+            {
+                continue;
+            }
+            if (muxVal > std::numeric_limits<uint8_t>::max())
+            {
+                continue;
+            }
+            auto muxId = static_cast<uint8_t>(muxVal);
+
+            for (const auto& chanEntry :
+                 std::filesystem::directory_iterator(entry.path()))
+            {
+                std::string chanName =
+                    chanEntry.path().filename().string();
+                if (!chanName.starts_with("channel-"))
+                {
+                    continue;
+                }
+
+                unsigned long chanVal = 0;
+                try
+                {
+                    chanVal = std::stoul(chanName.substr(8));
+                }
+                catch (const std::exception&)
+                {
+                    continue;
+                }
+                if (chanVal > std::numeric_limits<uint8_t>::max())
+                {
+                    continue;
+                }
+                auto chanIdx = static_cast<uint8_t>(chanVal);
+
+                std::error_code ec;
+                auto target =
+                    std::filesystem::read_symlink(chanEntry.path(), ec);
+                if (ec)
+                {
+                    continue;
+                }
+
+                std::string targetName = target.filename().string();
+                if (!targetName.starts_with("i2c-"))
+                {
+                    continue;
+                }
+
+                int busNum = 0;
+                try
+                {
+                    busNum = std::stoi(targetName.substr(4));
+                }
+                catch (const std::exception&)
+                {
+                    continue;
+                }
+
+                uint16_t key =
+                    (static_cast<uint16_t>(muxId) << 8) | chanIdx;
+                result[key] = busNum;
+            }
+        }
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+        lg2::warning("I2C mux scan failed: {ERR}", "ERR", e.what());
+    }
+
+    return result;
+}
+
+std::unordered_map<uint8_t, int> buildSegmentBusMap(
+    const std::unordered_map<uint8_t, I2cSegmentMapping>& segments)
+{
+    auto muxTopology = scanMuxTopology();
+    std::unordered_map<uint8_t, int> result;
+
+    for (const auto& [segId, mapping] : segments)
+    {
+        if (mapping.cpldRegister < cpldRegisterBase)
+        {
+            continue;
+        }
+
+        uint8_t muxIndex = mapping.cpldRegister - cpldRegisterBase;
+        uint16_t key = (static_cast<uint16_t>(muxIndex) << 8) |
+                       mapping.channelValue;
+
+        auto it = muxTopology.find(key);
+        if (it != muxTopology.end())
+        {
+            result[segId] = it->second;
+            lg2::debug("I2C map: seg=0x{SEG} -> mux={MUX} chan={CH} "
+                       "-> i2c-{BUS}",
+                       "SEG", lg2::hex, segId, "MUX", muxIndex,
+                       "CH", mapping.channelValue, "BUS", it->second);
+        }
+        else
+        {
+            lg2::debug("I2C map: seg=0x{SEG} unresolved "
+                       "(mux={MUX} chan={CH})",
+                       "SEG", lg2::hex, segId, "MUX", muxIndex,
+                       "CH", mapping.channelValue);
+        }
+    }
+
+    lg2::info("I2C map: resolved {CNT} of {TOTAL} segments to kernel buses",
+              "CNT", result.size(), "TOTAL", segments.size());
+    return result;
+}
+
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace chif
+{
+
+// Extract and decompress the APML PlatDef blob from the host BIOS SPI flash.
+// Searches the "host-prime" MTD partition for the APML firmware volume,
+// extracts and decompresses the records. Returns empty vector if not found.
+std::vector<uint8_t> extractPlatDef();
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <unordered_map>
 #include <vector>
 
 namespace chif
@@ -12,5 +13,17 @@ namespace chif
 // Searches the "host-prime" MTD partition for the APML firmware volume,
 // extracts and decompresses the records. Returns empty vector if not found.
 std::vector<uint8_t> extractPlatDef();
+
+// I2C segment mapping: BIOS segment ID → CPLD register + select value.
+// Populated from RecordType_I2CEngine (type 14) records in the PlatDef blob.
+struct I2cSegmentMapping
+{
+    uint8_t cpldRegister; // lower byte of CPLD.Byte (mux address: 0x84-0x8B)
+    uint8_t channelValue; // CPLD.SelectMask = mux channel select value
+};
+
+// Parse decompressed PlatDef records and extract I2C segment→CPLD mappings.
+[[nodiscard]] std::unordered_map<uint8_t, I2cSegmentMapping>
+    parseI2cSegments(const std::vector<uint8_t>& platDef);
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
@@ -14,7 +14,7 @@ namespace chif
 // extracts and decompresses the records. Returns empty vector if not found.
 std::vector<uint8_t> extractPlatDef();
 
-// I2C segment mapping: BIOS segment ID → CPLD register + select value.
+// I2C segment mapping: BIOS segment ID → CPLD register + channel value.
 // Populated from RecordType_I2CEngine (type 14) records in the PlatDef blob.
 struct I2cSegmentMapping
 {
@@ -25,5 +25,12 @@ struct I2cSegmentMapping
 // Parse decompressed PlatDef records and extract I2C segment→CPLD mappings.
 [[nodiscard]] std::unordered_map<uint8_t, I2cSegmentMapping>
     parseI2cSegments(const std::vector<uint8_t>& platDef);
+
+// Build the final segment→kernel I2C bus mapping by combining PlatDef
+// segment data with the sysfs i2cmux topology. Returns a map from BIOS
+// segment ID to kernel bus number (e.g., segment 0x33 → i2c-39).
+[[nodiscard]] std::unordered_map<uint8_t, int>
+    buildSegmentBusMap(
+        const std::unordered_map<uint8_t, I2cSegmentMapping>& segments);
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -487,6 +487,36 @@ int SmifService::handleI2cProxy(const ChifPktHeader& hdr,
 }
 
 // ---------------------------------------------------------------------------
+// PlatDef v1 download handler (0x0200)
+// ---------------------------------------------------------------------------
+
+static constexpr uint32_t platDefNoMoreRecords = 6;
+
+// PlatDef v1 download response payload: 4024 bytes per HPE CHIF protocol.
+// Layout: [errorCode u32][recordCount u32][recordData 4016].
+static constexpr size_t platDefPayloadSize = 4024;
+static constexpr auto platDefRespSize =
+    static_cast<uint16_t>(sizeof(ChifPktHeader) + platDefPayloadSize);
+
+int SmifService::handlePlatDefDownload(const ChifPktHeader& hdr,
+                                       std::span<const uint8_t> /*reqPayload*/,
+                                       std::span<uint8_t> response)
+{
+    if (response.size() < platDefRespSize)
+    {
+        return buildSimpleResponse(hdr, response, 1);
+    }
+
+    std::fill_n(response.data(), platDefRespSize, uint8_t{0});
+    initResponse(response, hdr, platDefRespSize);
+
+    auto resp = responsePayload(response);
+    std::memcpy(resp.data(), &platDefNoMoreRecords,
+                sizeof(platDefNoMoreRecords));
+    return platDefRespSize;
+}
+
+// ---------------------------------------------------------------------------
 // SmifService::handle — main dispatch
 // ---------------------------------------------------------------------------
 int SmifService::handle(std::span<const uint8_t> request,
@@ -529,6 +559,10 @@ int SmifService::handle(std::span<const uint8_t> request,
         // ---- I2C proxy ----
         case smifCmdI2cTransaction:
             return handleI2cProxy(hdr, reqPayload, response);
+
+        // ---- PlatDef v1 download ----
+        case smifCmdPlatDefUpload:
+            return handlePlatDefDownload(hdr, reqPayload, response);
 
         // ---- All other commands: stub with ErrorCode=0 ----
         default:

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -4,13 +4,24 @@
 
 #include <phosphor-logging/lg2.hpp>
 
+#include <fcntl.h>
+#include <linux/i2c-dev.h>
+#include <linux/i2c.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
+#include <format>
 
 namespace chif
 {
 
-SmifService::SmifService(EvStorage* evStorage) : evStorage_(evStorage) {}
+SmifService::SmifService(EvStorage* evStorage,
+                         std::unordered_map<uint8_t, int> segmentBusMap) :
+    evStorage_(evStorage), segmentToBus_(std::move(segmentBusMap))
+{}
 
 // ---------------------------------------------------------------------------
 // Response helpers
@@ -297,6 +308,185 @@ int SmifService::handleGetEvAuthStatus(const ChifPktHeader& hdr,
 }
 
 // ---------------------------------------------------------------------------
+// I2C proxy handler (0x0072)
+// ---------------------------------------------------------------------------
+
+// pkt_0072 payload offsets
+static constexpr size_t i2cOffAddress = 12;
+static constexpr size_t i2cOffSegment = 14;
+static constexpr size_t i2cOffWriteLen = 15;
+static constexpr size_t i2cOffReadLen = 16;
+static constexpr size_t i2cOffData = 17;
+static constexpr size_t i2cMinPayload = 17;
+
+// pkt_8072 response layout (matches HPE's packed struct)
+struct I2cResponse
+{
+    uint32_t errcode;
+    uint8_t reserved1[8];
+    uint16_t address;
+    uint8_t engine;
+    uint8_t reserved2;
+    uint8_t readLen;
+    uint8_t data[32];
+} __attribute__((packed));
+
+static_assert(sizeof(I2cResponse) == 49, "I2cResponse must be 49 bytes");
+
+static constexpr auto i2cRespSize =
+    static_cast<uint16_t>(sizeof(ChifPktHeader) + sizeof(I2cResponse));
+static constexpr size_t i2cRespOffError = offsetof(I2cResponse, errcode);
+static constexpr size_t i2cRespOffAddress = offsetof(I2cResponse, address);
+static constexpr size_t i2cRespOffSegment = offsetof(I2cResponse, engine);
+static constexpr size_t i2cRespOffReadLen = offsetof(I2cResponse, readLen);
+static constexpr size_t i2cRespOffData = offsetof(I2cResponse, data);
+
+// I2C error codes (100-series, from HPE i2c_return_codes.hpp)
+static constexpr uint32_t i2cGeneralError = 101;
+static constexpr uint32_t i2cBusTimeout = 105;
+static constexpr uint32_t i2cSegmentNotFound = 108;
+static constexpr uint32_t i2cAddressNack = 116;
+
+static uint32_t i2cErrorFromErrno(int err)
+{
+    switch (err)
+    {
+        case ENXIO:
+            return i2cAddressNack;
+        case ETIMEDOUT:
+            return i2cBusTimeout;
+        default:
+            return i2cGeneralError;
+    }
+}
+
+int SmifService::handleI2cProxy(const ChifPktHeader& hdr,
+                                std::span<const uint8_t> reqPayload,
+                                std::span<uint8_t> response)
+{
+    if (response.size() < i2cRespSize)
+    {
+        return -1;
+    }
+
+    std::fill_n(response.data(), i2cRespSize, uint8_t{0});
+    initResponse(response, hdr, i2cRespSize);
+    auto resp = responsePayload(response);
+
+    if (reqPayload.size() < i2cMinPayload)
+    {
+        uint32_t err = i2cGeneralError;
+        std::memcpy(resp.data() + i2cRespOffError, &err, sizeof(err));
+        return i2cRespSize;
+    }
+
+    uint16_t address = 0;
+    std::memcpy(&address, reqPayload.data() + i2cOffAddress, sizeof(address));
+    uint8_t segment = reqPayload[i2cOffSegment];
+    uint8_t writeLen = reqPayload[i2cOffWriteLen];
+    uint8_t readLen = reqPayload[i2cOffReadLen];
+
+    // Echo address and segment in response
+    std::memcpy(resp.data() + i2cRespOffAddress, &address, sizeof(address));
+    resp[i2cRespOffSegment] = segment;
+
+    if (writeLen == 0 && readLen == 0)
+    {
+        return i2cRespSize;
+    }
+
+    if (writeLen > 32 || readLen > 32)
+    {
+        uint32_t err = i2cGeneralError;
+        std::memcpy(resp.data() + i2cRespOffError, &err, sizeof(err));
+        return i2cRespSize;
+    }
+
+    auto it = segmentToBus_.find(segment);
+    if (it == segmentToBus_.end())
+    {
+        uint32_t err = i2cSegmentNotFound;
+        std::memcpy(resp.data() + i2cRespOffError, &err, sizeof(err));
+        return i2cRespSize;
+    }
+
+    int busNum = it->second;
+    uint8_t i2cAddr = static_cast<uint8_t>(address >> 1);
+
+    auto devPath = std::format("/dev/i2c-{}", busNum);
+
+    int fd = open(devPath.c_str(), O_RDWR);
+    if (fd < 0)
+    {
+        lg2::warning("I2C proxy: failed to open {DEV}: {ERR}",
+                     "DEV", devPath, "ERR", strerror(errno));
+        uint32_t err = i2cGeneralError;
+        std::memcpy(resp.data() + i2cRespOffError, &err, sizeof(err));
+        return i2cRespSize;
+    }
+
+    struct i2c_msg msgs[2];
+    int numMsgs = 0;
+    uint8_t writeBuf[32] = {};
+    uint8_t readBuf[32] = {};
+
+    if (writeLen > 0)
+    {
+        size_t available = reqPayload.size() - i2cOffData;
+        if (static_cast<size_t>(writeLen) > available)
+        {
+            uint32_t err = i2cGeneralError;
+            std::memcpy(resp.data() + i2cRespOffError, &err, sizeof(err));
+            close(fd);
+            return i2cRespSize;
+        }
+        std::memcpy(writeBuf, reqPayload.data() + i2cOffData, writeLen);
+
+        msgs[numMsgs].addr = i2cAddr;
+        msgs[numMsgs].flags = 0;
+        msgs[numMsgs].len = writeLen;
+        msgs[numMsgs].buf = writeBuf;
+        numMsgs++;
+    }
+
+    if (readLen > 0)
+    {
+        msgs[numMsgs].addr = i2cAddr;
+        msgs[numMsgs].flags = I2C_M_RD;
+        msgs[numMsgs].len = readLen;
+        msgs[numMsgs].buf = readBuf;
+        numMsgs++;
+    }
+
+    struct i2c_rdwr_ioctl_data transfer{};
+    transfer.msgs = msgs;
+    transfer.nmsgs = static_cast<uint32_t>(numMsgs);
+
+    int rc = ioctl(fd, I2C_RDWR, &transfer);
+    close(fd);
+
+    if (rc < 0)
+    {
+        int savedErrno = errno;
+        lg2::warning("I2C proxy: ioctl failed seg=0x{SEG} addr=0x{ADDR} "
+                     "bus={BUS}: {ERR}",
+                     "SEG", lg2::hex, segment, "ADDR", lg2::hex, i2cAddr,
+                     "BUS", busNum, "ERR", strerror(savedErrno));
+        uint32_t err = i2cErrorFromErrno(savedErrno);
+        std::memcpy(resp.data() + i2cRespOffError, &err, sizeof(err));
+        return i2cRespSize;
+    }
+
+    resp[i2cRespOffReadLen] = readLen;
+    if (readLen > 0)
+    {
+        std::memcpy(resp.data() + i2cRespOffData, readBuf, readLen);
+    }
+
+    return i2cRespSize;
+}
+
+// ---------------------------------------------------------------------------
 // SmifService::handle — main dispatch
 // ---------------------------------------------------------------------------
 int SmifService::handle(std::span<const uint8_t> request,
@@ -335,6 +525,10 @@ int SmifService::handle(std::span<const uint8_t> request,
         // ---- BIOS image auth status (Secure Start) ----
         case smifCmdGetEvAuthStatus:
             return handleGetEvAuthStatus(hdr, response);
+
+        // ---- I2C proxy ----
+        case smifCmdI2cTransaction:
+            return handleI2cProxy(hdr, reqPayload, response);
 
         // ---- All other commands: stub with ErrorCode=0 ----
         default:

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -107,6 +107,11 @@ class SmifService : public ServiceHandler
                        std::span<const uint8_t> reqPayload,
                        std::span<uint8_t> response);
 
+    // PlatDef v1 download handler
+    int handlePlatDefDownload(const ChifPktHeader& hdr,
+                              std::span<const uint8_t> reqPayload,
+                              std::span<uint8_t> response);
+
     // Response helpers
     static int buildSimpleResponse(const ChifPktHeader& hdr,
                                    std::span<uint8_t> response,

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <span>
+#include <unordered_map>
 
 namespace chif
 {
@@ -72,7 +73,8 @@ inline constexpr uint16_t smifCmdPlatDefV2End = 0x0207;
 class SmifService : public ServiceHandler
 {
   public:
-    explicit SmifService(EvStorage* evStorage = nullptr);
+    explicit SmifService(EvStorage* evStorage = nullptr,
+                        std::unordered_map<uint8_t, int> segmentBusMap = {});
 
     int handle(std::span<const uint8_t> request,
                std::span<uint8_t> response) override;
@@ -100,6 +102,11 @@ class SmifService : public ServiceHandler
     int handleGetEvAuthStatus(const ChifPktHeader& hdr,
                               std::span<uint8_t> response);
 
+    // I2C proxy handler
+    int handleI2cProxy(const ChifPktHeader& hdr,
+                       std::span<const uint8_t> reqPayload,
+                       std::span<uint8_t> response);
+
     // Response helpers
     static int buildSimpleResponse(const ChifPktHeader& hdr,
                                    std::span<uint8_t> response,
@@ -109,6 +116,7 @@ class SmifService : public ServiceHandler
                                    const EvEntry& ev);
 
     EvStorage* evStorage_;
+    std::unordered_map<uint8_t, int> segmentToBus_;
 };
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/uefi_fv.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/uefi_fv.cpp
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+// Minimal UEFI firmware volume parser. Scans a flash image for FFS2
+// firmware volumes and extracts file payloads by GUID. Only handles
+// the subset of UEFI PI structures needed for PlatDef extraction.
+
+#include "uefi_fv.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <cstring>
+
+namespace chif
+{
+
+// Internal UEFI packed structures — not exposed in the header.
+#pragma pack(push, 1)
+
+struct EfiFvHeader
+{
+    uint8_t zeroVector[16];
+    EfiGuid fileSystemGuid;
+    uint64_t fvLength;
+    uint32_t signature; // '_FVH' = 0x4856465F
+    uint32_t attributes;
+    uint16_t headerLength;
+    uint16_t checksum;
+    uint16_t extHeaderOffset;
+    uint8_t reserved;
+    uint8_t revision;
+};
+
+struct EfiFvExtHeader
+{
+    EfiGuid fvName;
+    uint32_t extHeaderSize;
+};
+
+struct EfiFfsFileHeader
+{
+    EfiGuid name;
+    uint16_t integrityCheck;
+    uint8_t type;
+    uint8_t attributes;
+    uint8_t size[3];
+    uint8_t state;
+};
+
+struct EfiSectionHeader
+{
+    uint8_t size[3];
+    uint8_t type;
+};
+
+#pragma pack(pop)
+
+static constexpr uint32_t efiFvhSignature = 0x4856465F; // '_FVH'
+static constexpr uint8_t efiFvFileTypeFreeform = 0x02;
+static constexpr uint8_t efiFfsLargeFile = 0x01;
+static constexpr uint8_t efiSectionRaw = 0x19;
+static constexpr uint8_t efiSectionGuidDefined = 0x02;
+
+// EFI FFS2 file system GUID: {8C8CE578-8A3D-4F1C-9935-896185C32DD3}
+static constexpr EfiGuid ffs2Guid = {
+    0x8C8CE578, 0x8A3D, 0x4F1C,
+    {0x99, 0x35, 0x89, 0x61, 0x85, 0xC3, 0x2D, 0xD3}};
+
+static bool guidEqual(const EfiGuid& a, const EfiGuid& b)
+{
+    return std::memcmp(&a, &b, sizeof(EfiGuid)) == 0;
+}
+
+static bool guidIsAllFf(const EfiGuid& g)
+{
+    static constexpr EfiGuid allFf = {
+        0xFFFFFFFF, 0xFFFF, 0xFFFF,
+        {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+    return guidEqual(g, allFf);
+}
+
+static uint32_t ffsFileSize(const EfiFfsFileHeader& hdr)
+{
+    return static_cast<uint32_t>(hdr.size[0]) |
+           (static_cast<uint32_t>(hdr.size[1]) << 8) |
+           (static_cast<uint32_t>(hdr.size[2]) << 16);
+}
+
+std::vector<uint8_t> extractFfsFile(std::istream& rom, size_t romSize,
+                                     const EfiGuid& fvGuid,
+                                     const EfiGuid& fileGuid)
+{
+    size_t fvOffset = 0;
+    while (fvOffset + sizeof(EfiFvHeader) < romSize)
+    {
+        EfiFvHeader fvHdr{};
+        rom.seekg(static_cast<std::streamoff>(fvOffset));
+        rom.read(reinterpret_cast<char*>(&fvHdr), sizeof(fvHdr));
+        if (!rom.good())
+        {
+            break;
+        }
+
+        if (fvHdr.signature != efiFvhSignature)
+        {
+            fvOffset += 0x10000;
+            continue;
+        }
+
+        // Valid FV — compute step from fvLength, aligned up to 64k
+        auto fvLen = static_cast<size_t>(fvHdr.fvLength);
+        if (fvLen & 0xFFFF)
+        {
+            fvLen = (fvLen & ~size_t{0xFFFF}) + 0x10000;
+        }
+        if (fvLen == 0)
+        {
+            fvLen = 0x10000;
+        }
+
+        if (!guidEqual(fvHdr.fileSystemGuid, ffs2Guid))
+        {
+            fvOffset += fvLen;
+            continue;
+        }
+
+        if (fvHdr.extHeaderOffset == 0)
+        {
+            fvOffset += fvLen;
+            continue;
+        }
+
+        // Read extended header to check the volume name GUID
+        EfiFvExtHeader extHdr{};
+        rom.seekg(
+            static_cast<std::streamoff>(fvOffset + fvHdr.extHeaderOffset));
+        rom.read(reinterpret_cast<char*>(&extHdr), sizeof(extHdr));
+        if (!rom.good())
+        {
+            fvOffset += fvLen;
+            continue;
+        }
+
+        if (!guidEqual(extHdr.fvName, fvGuid))
+        {
+            fvOffset += fvLen;
+            continue;
+        }
+
+        lg2::info("UEFI FV: found matching volume at offset 0x{OFF}",
+                  "OFF", lg2::hex, fvOffset);
+
+        // Walk FFS file entries starting after the extended header
+        size_t fileOffset = fvOffset + fvHdr.extHeaderOffset +
+                            extHdr.extHeaderSize;
+        size_t fvEnd = fvOffset + static_cast<size_t>(fvHdr.fvLength);
+        if (fvEnd > romSize)
+        {
+            fvEnd = romSize;
+        }
+
+        while (fileOffset + sizeof(EfiFfsFileHeader) < fvEnd)
+        {
+            // 8-byte align
+            if (fileOffset & 0x07)
+            {
+                fileOffset = (fileOffset & ~0x07UL) + 0x08;
+            }
+
+            EfiFfsFileHeader fileHdr{};
+            rom.seekg(static_cast<std::streamoff>(fileOffset));
+            rom.read(reinterpret_cast<char*>(&fileHdr), sizeof(fileHdr));
+            if (!rom.good())
+            {
+                break;
+            }
+
+            // End of file list
+            if (guidIsAllFf(fileHdr.name))
+            {
+                break;
+            }
+
+            uint32_t fileSize = ffsFileSize(fileHdr);
+            if (fileSize < sizeof(EfiFfsFileHeader))
+            {
+                break;
+            }
+
+            uint32_t dataSize = fileSize - sizeof(EfiFfsFileHeader);
+            size_t dataOffset = fileOffset + sizeof(EfiFfsFileHeader);
+
+            if (guidEqual(fileHdr.name, fileGuid) &&
+                !(fileHdr.attributes & efiFfsLargeFile))
+            {
+                // Handle section header for FREEFORM files
+                if (fileHdr.type == efiFvFileTypeFreeform &&
+                    dataSize > sizeof(EfiSectionHeader))
+                {
+                    EfiSectionHeader secHdr{};
+                    rom.seekg(static_cast<std::streamoff>(dataOffset));
+                    rom.read(reinterpret_cast<char*>(&secHdr),
+                             sizeof(secHdr));
+                    if (!rom.good())
+                    {
+                        lg2::error("UEFI FV: section header read failed");
+                        return {};
+                    }
+
+                    if (secHdr.type == efiSectionRaw)
+                    {
+                        dataOffset += sizeof(EfiSectionHeader);
+                        dataSize -= sizeof(EfiSectionHeader);
+                    }
+                    else if (secHdr.type == efiSectionGuidDefined)
+                    {
+                        constexpr uint32_t guidSecHdrSize = 20;
+                        if (dataSize <= guidSecHdrSize)
+                        {
+                            break;
+                        }
+                        dataOffset += guidSecHdrSize;
+                        dataSize -= guidSecHdrSize;
+                    }
+                }
+
+                // Read the file payload
+                std::vector<uint8_t> data(dataSize);
+                rom.seekg(static_cast<std::streamoff>(dataOffset));
+                rom.read(reinterpret_cast<char*>(data.data()),
+                         static_cast<std::streamsize>(dataSize));
+
+                if (!rom.good())
+                {
+                    lg2::error("UEFI FV: read failed at offset 0x{OFF}",
+                               "OFF", lg2::hex, dataOffset);
+                    return {};
+                }
+
+                lg2::info("UEFI FV: extracted {SZ} bytes", "SZ",
+                          data.size());
+                return data;
+            }
+
+            fileOffset += fileSize;
+        }
+
+        fvOffset += fvLen;
+    }
+
+    return {};
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/uefi_fv.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/uefi_fv.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <cstdint>
+#include <istream>
+#include <vector>
+
+namespace chif
+{
+
+// Minimal EFI GUID representation for firmware volume identification.
+#pragma pack(push, 1)
+struct EfiGuid
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t data4[8];
+};
+#pragma pack(pop)
+
+// Extract the raw payload of an FFS file from a UEFI firmware image.
+// Scans every 64 KB for a firmware volume whose extended header name
+// matches fvGuid, then walks FFS entries for a file matching fileGuid.
+// Returns the file's section data, or an empty vector if not found.
+[[nodiscard]] std::vector<uint8_t> extractFfsFile(std::istream& rom,
+                                                   size_t romSize,
+                                                   const EfiGuid& fvGuid,
+                                                   const EfiGuid& fileGuid);
+
+} // namespace chif


### PR DESCRIPTION
Implement the CHIF I2C proxy pipeline: extract the Platform Definition blob from the host BIOS SPI flash, parse I2C segment mappings, map them with the kernel's i2cmux topology, and proxy I2C transactions from BIOS to the hardware during POST.

The individual commits are:
- bf5e469 - scan the host-prime MTD partition for the APML firmware volume, locate the PlatDef FFS file by GUID, and zlib-decompress the record bundle
- 7a418bc - walk PlatDef records (stride = hdr.size × 16), extract I2CEngine segments with CPLD mux register and channel values
- a3633d6 - combine PlatDef segment→CPLD mappings with sysfs i2cmux topology to produce segment→kernel bus number lookups
- 536dbd1 - handle CHIF command 0x0072 by resolving the BIOS segment to a kernel I2C bus and executing I2C_RDWR ioctl transactions
- 0cb3e9a - split the generic UEFI FV/FFS extraction logic into its own compilation unit for clarity and reuse
- 15868eb - Correctly respond to PlatDefv1 download requests with PLATDEF_SMIF_RC_NO_MORE_RECORDS

Tested on the DL365 and DL320.