### PR TITLE
ci: use GXP2loader image directly and capture all build variants

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -45,6 +45,6 @@ runs:
     - name: Upload firmware image
       uses: actions/upload-artifact@v4
       with:
-        name: obmc-phosphor-image-${{ inputs.board }}.static.mtd
-        path: build/${{ inputs.board }}/tmp/deploy/images/${{ inputs.board }}/obmc-phosphor-image-${{ inputs.board }}.static.mtd
+        name: obmc-phosphor-image-${{ inputs.board }}
+        path: build/${{ inputs.board }}/tmp/deploy/images/${{ inputs.board }}/obmc-phosphor-image-${{ inputs.board }}.*static.mtd
 

--- a/.github/workflows/build-canopy-qemu.yml
+++ b/.github/workflows/build-canopy-qemu.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Download firmware image
         uses: actions/download-artifact@v8
         with:
-          name: obmc-phosphor-image-canopy-qemu.static.mtd
+          name: obmc-phosphor-image-canopy-qemu
 
       - name: Upload to FirmwareCI
         uses: docker://firmwareci/action:v5.2

--- a/.github/workflows/build-hpe-proliant-g11.yml
+++ b/.github/workflows/build-hpe-proliant-g11.yml
@@ -43,42 +43,7 @@ jobs:
       - name: Download firmware image
         uses: actions/download-artifact@v8
         with:
-          name: obmc-phosphor-image-hpe-proliant-g11.static.mtd
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.FETCHER_APP_ID }}
-          private-key: ${{ secrets.FETCHER_PRIVATE_KEY }}
-          owner: canopybmc
-          repositories: hpe-gxp-bootblock
-
-      - name: Debug token access
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          curl -H "Authorization: token ${GH_TOKEN}" https://api.github.com/repos/canopybmc/hpe-gxp-bootblock
-
-      - name: Fetch GXP bootblock
-        uses: actions/checkout@v6
-        with:
-          repository: canopybmc/hpe-gxp-bootblock
-          token: ${{ steps.app-token.outputs.token }}
-          path: hpe-gxp-bootblock
-
-      - name: Copy GXP bootblock
-        run: | 
-          cp hpe-gxp-bootblock/9elements/test-keys/9e-gxp-dl360.rom .
-
-      - name: Prepare flash image
-        run: |
-          cat obmc-phosphor-image-hpe-proliant-g11.static.mtd 9e-gxp-dl360.rom > flash-image-hpe-proliant-g11.rom
-          size=$(stat --printf='%s' flash-image-hpe-proliant-g11.rom)
-          if [ "$size" -ne 33554432 ]; then
-            echo "::error::Flash image size is ${size} bytes, expected 33554432 (32MB)"
-            exit 1
-          fi
+          name: obmc-phosphor-image-hpe-proliant-g11
 
       - name: Upload to FirmwareCI
         uses: docker://firmwareci/action:v5.2
@@ -86,7 +51,7 @@ jobs:
           TOKEN: ${{ secrets.FWCI_TOKEN }}
           WORKFLOW_NAME: ${{ secrets.FWCI_WORKFLOW_NAME }}
           COMMIT_HASH: ${{ github.sha }}
-          BINARIES: Binary=flash-image-hpe-proliant-g11.rom
+          BINARIES: Binary=obmc-phosphor-image-hpe-proliant-g11.GXP2loader-t282-t288-sgn00.static.mtd
           GITHUB_INSTALLATION_ID: ${{ secrets.FWCI_GITHUB_INSTALLATION_ID }}
 
   firmwareci-main:
@@ -97,36 +62,7 @@ jobs:
       - name: Download firmware image
         uses: actions/download-artifact@v8
         with:
-          name: obmc-phosphor-image-hpe-proliant-g11.static.mtd
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.FETCHER_APP_ID }}
-          private-key: ${{ secrets.FETCHER_PRIVATE_KEY }}
-          owner: canopybmc
-          repositories: hpe-gxp-bootblock
-
-      - name: Fetch GXP bootblock
-        uses: actions/checkout@v6
-        with:
-          repository: canopybmc/hpe-gxp-bootblock
-          token: ${{ steps.app-token.outputs.token }}
-          path: hpe-gxp-bootblock
-
-      - name: Copy GXP bootblock
-        run: |
-          cp hpe-gxp-bootblock/9elements/test-keys/9e-gxp-dl360.rom .
-
-      - name: Prepare flash image
-        run: |
-          cat obmc-phosphor-image-hpe-proliant-g11.static.mtd 9e-gxp-dl360.rom > flash-image-hpe-proliant-g11.rom
-          size=$(stat --printf='%s' flash-image-hpe-proliant-g11.rom)
-          if [ "$size" -ne 33554432 ]; then
-            echo "::error::Flash image size is ${size} bytes, expected 33554432 (32MB)"
-            exit 1
-          fi
+          name: obmc-phosphor-image-hpe-proliant-g11
 
       - name: Upload to FirmwareCI
         uses: docker://firmwareci/action:v5.2
@@ -134,5 +70,5 @@ jobs:
           TOKEN: ${{ secrets.FWCI_TOKEN }}
           WORKFLOW_NAME: ${{ secrets.FWCI_MAIN_WORKFLOW_NAME }}
           COMMIT_HASH: ${{ github.sha }}
-          BINARIES: Binary=flash-image-hpe-proliant-g11.rom
+          BINARIES: Binary=obmc-phosphor-image-hpe-proliant-g11.GXP2loader-t282-t288-sgn00.static.mtd
           GITHUB_INSTALLATION_ID: ${{ secrets.FWCI_GITHUB_INSTALLATION_ID }}


### PR DESCRIPTION
The generic build action now uploads all obmc-phosphor-image-<board>.*static.mtd artifacts, capturing variant images (e.g. GXP2loader) without leaking platform-specific details. The HPE workflow uses the GXP2loader image directly for FirmwareCI, removing the bootblock concatenation step.

- Generic build action captures all obmc-phosphor-image-<board>.*static.mtd variants in a single artifact, excluding date-stamped images                                                                                                   
- HPE workflow uploads GXP2loader image directly to FirmwareCI, removing the bootblock fetch/concatenation steps and the hpe-gxp-bootblock repo dependency                                                                                 
- QEMU workflow updated to match new artifact naming