### PR TITLE
HPE Proliant Gen11: Fix EV Storage return codes and add host to dl320 dut config

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/dut.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/dut.yaml
@@ -5,4 +5,5 @@ attributes:
   BMCPassword: 0penBmc
   DutAgent: worker102.lab.9e.network:1024
   Device: dl320
-  Board: dl320
+  Host: dl320g11-1.lab.9e.network
+  HostUser: oscar

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
@@ -1,12 +1,11 @@
 name: "CHIF: Reboot Stability"
 description: >-
   Verify CHIF I2C proxy and PlatDef download handlers remain stable
-  across 3 consecutive host reboot cycles. Rebooting is triggered
-  from the host via SSH (`sudo reboot`) rather than via Redfish, as
-  Redfish GracefulRestart has been observed to power the host off
-  without bringing it back. After each reboot, checks the BMC journal
-  for consistent CHIF behavior and the host console log for absence
-  of response-format errors.
+  across 3 consecutive host reboot cycles. Reboots are triggered via
+  Redfish ForceRestart; host availability is detected by pinging the
+  host OS. After each reboot, checks the BMC journal for consistent
+  CHIF behavior and the host console log for absence of
+  response-format errors.
 
 defaults:
   transport: &bmc_ssh
@@ -42,15 +41,12 @@ stages:
           expect:
             - regex: "^(200|204)$"
 
-      - cmd: cmd
-        name: Wait for POST (5 min)
-        transport:
-          proto: local
+      - cmd: ping
+        name: Wait for host OS
         options:
-          timeout: 6m
+          timeout: 10m
         parameters:
-          executable: sleep
-          args: ["300"]
+          host: "[[attributes.Host]]"
 
       - cmd: shell
         name: Host state is Running
@@ -79,29 +75,27 @@ stages:
             - regex: "^0$"
 
       - cmd: shell
-        name: Reboot host via SSH
+        name: Reboot host via Redfish
         transport:
-          proto: ssh
-          options:
-            host: "[[attributes.Host]]"
-            user: "[[attributes.HostUser]]"
-            password: "[[attributes.HostPassword]]"
-        options:
-          on-error: continue
+          proto: local
         parameters:
-          command: "echo [[attributes.HostPassword]] | sudo -S reboot"
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"ForceRestart"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
 
   - name: Reboot Cycle 2
     steps:
-      - cmd: cmd
-        name: Wait for POST (5 min)
-        transport:
-          proto: local
+      - cmd: ping
+        name: Wait for host OS
         options:
-          timeout: 6m
+          timeout: 10m
         parameters:
-          executable: sleep
-          args: ["300"]
+          host: "[[attributes.Host]]"
 
       - cmd: shell
         name: Host state is Running
@@ -130,29 +124,27 @@ stages:
             - regex: "^0$"
 
       - cmd: shell
-        name: Reboot host via SSH
+        name: Reboot host via Redfish
         transport:
-          proto: ssh
-          options:
-            host: "[[attributes.Host]]"
-            user: "[[attributes.HostUser]]"
-            password: "[[attributes.HostPassword]]"
-        options:
-          on-error: continue
+          proto: local
         parameters:
-          command: "echo [[attributes.HostPassword]] | sudo -S reboot"
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"ForceRestart"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
 
   - name: Reboot Cycle 3
     steps:
-      - cmd: cmd
-        name: Wait for POST (5 min)
-        transport:
-          proto: local
+      - cmd: ping
+        name: Wait for host OS
         options:
-          timeout: 6m
+          timeout: 10m
         parameters:
-          executable: sleep
-          args: ["300"]
+          host: "[[attributes.Host]]"
 
       - cmd: shell
         name: Host state is Running

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -90,24 +90,29 @@ int SmifService::buildEvDataResponse(const ChifPktHeader& hdr,
 // EV command handlers
 // ---------------------------------------------------------------------------
 
+constexpr uint32_t ev(EvError e)
+{
+    return static_cast<uint32_t>(e);
+}
+
 int SmifService::handleGetEvByIndex(const ChifPktHeader& hdr,
                                     std::span<const uint8_t> reqPayload,
                                     std::span<uint8_t> response)
 {
     if (!evStorage_ || reqPayload.size() < sizeof(uint32_t))
     {
-        return buildSimpleResponse(hdr, response, 1);
+        return buildSimpleResponse(hdr, response, ev(EvError::deviceError));
     }
 
     uint32_t index = 0;
     std::memcpy(&index, reqPayload.data(), sizeof(index));
 
-    auto ev = evStorage_->getByIndex(index);
-    if (!ev)
+    auto entry = evStorage_->getByIndex(index);
+    if (!entry)
     {
-        return buildSimpleResponse(hdr, response, 1);
+        return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
     }
-    return buildEvDataResponse(hdr, response, *ev);
+    return buildEvDataResponse(hdr, response, *entry);
 }
 
 int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
@@ -116,23 +121,23 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
 {
     if (!evStorage_ || reqPayload.size() < sizeof(uint32_t))
     {
-        return buildSimpleResponse(hdr, response, 2);
+        return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
     }
 
     uint8_t flags = reqPayload[0];
 
-    // Priority: deleteAll > delete > set
     if (flags & evFlagDeleteAll)
     {
         bool ok = evStorage_->deleteAll();
-        return buildSimpleResponse(hdr, response, ok ? 0 : 3);
+        return buildSimpleResponse(
+            hdr, response, ok ? ev(EvError::success) : ev(EvError::nameTooLong));
     }
 
     if (flags & evFlagDelete)
     {
         if (reqPayload.size() < sizeof(uint32_t) + maxEvNameLen)
         {
-            return buildSimpleResponse(hdr, response, 2);
+            return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
         }
         std::string_view nameRegion(
             reinterpret_cast<const char*>(reqPayload.data()) +
@@ -140,10 +145,11 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
             maxEvNameLen);
         if (nameRegion.back() != '\0')
         {
-            return buildSimpleResponse(hdr, response, 3);
+            return buildSimpleResponse(hdr, response, ev(EvError::nameTooLong));
         }
         bool ok = evStorage_->del(std::string(nameRegion.data()));
-        return buildSimpleResponse(hdr, response, ok ? 0 : 1);
+        return buildSimpleResponse(
+            hdr, response, ok ? ev(EvError::success) : ev(EvError::deviceError));
     }
 
     if (flags & evFlagSet)
@@ -152,7 +158,7 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
             sizeof(uint32_t) + maxEvNameLen + sizeof(uint16_t);
         if (reqPayload.size() < minSetPayload)
         {
-            return buildSimpleResponse(hdr, response, 2);
+            return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
         }
 
         char nameBuf[maxEvNameLen] = {};
@@ -166,27 +172,28 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
 
         if (dataLen > maxEvDataSize)
         {
-            return buildSimpleResponse(hdr, response, 3);
+            return buildSimpleResponse(hdr, response, ev(EvError::dataTooLarge));
         }
 
-        // HPE behavior: set with sz_ev=0 is treated as delete
+        // Set with sz_ev=0 is treated as delete
         if (dataLen == 0)
         {
             evStorage_->del(nameBuf);
-            return buildSimpleResponse(hdr, response, 0);
+            return buildSimpleResponse(hdr, response, ev(EvError::success));
         }
 
         if (reqPayload.size() < minSetPayload + dataLen)
         {
-            return buildSimpleResponse(hdr, response, 2);
+            return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
         }
 
         auto data = reqPayload.subspan(minSetPayload, dataLen);
         bool ok = evStorage_->set(nameBuf, data);
-        return buildSimpleResponse(hdr, response, ok ? 0 : 3);
+        return buildSimpleResponse(
+            hdr, response, ok ? ev(EvError::success) : ev(EvError::nameTooLong));
     }
 
-    return buildSimpleResponse(hdr, response, 2);
+    return buildSimpleResponse(hdr, response, ev(EvError::unsupported));
 }
 
 int SmifService::handleGetEvByName(const ChifPktHeader& hdr,
@@ -195,26 +202,26 @@ int SmifService::handleGetEvByName(const ChifPktHeader& hdr,
 {
     if (reqPayload.size() < maxEvNameLen)
     {
-        return buildSimpleResponse(hdr, response, 2);
+        return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
     }
     if (!evStorage_)
     {
-        return buildSimpleResponse(hdr, response, 1);
+        return buildSimpleResponse(hdr, response, ev(EvError::deviceError));
     }
     if (reqPayload[maxEvNameLen - 1] != 0x00)
     {
-        return buildSimpleResponse(hdr, response, 3);
+        return buildSimpleResponse(hdr, response, ev(EvError::nameTooLong));
     }
 
     char nameBuf[maxEvNameLen] = {};
     std::memcpy(nameBuf, reqPayload.data(), maxEvNameLen - 1);
 
-    auto ev = evStorage_->getByName(nameBuf);
-    if (!ev)
+    auto entry = evStorage_->getByName(nameBuf);
+    if (!entry)
     {
-        return buildSimpleResponse(hdr, response, 1);
+        return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
     }
-    return buildEvDataResponse(hdr, response, *ev);
+    return buildEvDataResponse(hdr, response, *entry);
 }
 
 int SmifService::handleEvStats(const ChifPktHeader& hdr,

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -55,6 +55,17 @@ inline constexpr uint8_t evFlagSet = 0x01;
 inline constexpr uint8_t evFlagDelete = 0x02;
 inline constexpr uint8_t evFlagDeleteAll = 0x04;
 
+// EV response error codes
+enum class EvError : uint32_t
+{
+    success = 0,
+    deviceError = 1,
+    noSuchEv = 2,
+    nameTooLong = 3,
+    dataTooLarge = 4,
+    unsupported = 5,
+};
+
 // Event logging
 inline constexpr uint16_t smifCmdQuickEventLog = 0x0146;
 


### PR DESCRIPTION
We need to return proper EV Storage return codes in order to prevent a reboot loop on the DL320. Weirdly enough this does not happen on the DL365.

So this PR changes the error return codes to be similar with the original HPE definition.

I also fixed the FirmwareCI DL320 dut configuration with this PR.