### PR TITLE
HPE Proliant Gen11: add Field Access Command Handler to the CHIF service

### DIFF
--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
@@ -49,13 +49,13 @@ stages:
             - regex: "^(200|204)$"
 
       - cmd: cmd
-        name: Wait 120s for host to boot
+        name: Wait 260s for host to boot
         transport: *local
         options:
           timeout: 3m
         parameters:
           executable: sleep
-          args: ["120"]
+          args: ["260"]
 
   - name: Verify Host Is On
     steps:
@@ -191,13 +191,13 @@ stages:
             - regex: "^(200|204)$"
 
       - cmd: cmd
-        name: Wait 120s for host to boot
+        name: Wait 260s for host to boot
         transport: *local
         options:
           timeout: 3m
         parameters:
           executable: sleep
-          args: ["120"]
+          args: ["260"]
 
   - name: Verify Second Boot
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/inventory-dbus.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/inventory-dbus.yaml
@@ -40,13 +40,13 @@ stages:
             - "-c"
             - "HTTP=$(curl -sk -u root:[[attributes.BMCPassword]] -X POST -H 'Content-Type: application/json' -d '{\"ResetType\":\"On\"}' https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset -o /dev/null -w '%{http_code}'); echo \"Power On HTTP=$HTTP\"; test \"$HTTP\" = \"200\" || test \"$HTTP\" = \"204\""
       - cmd: cmd
-        name: Wait 220s for host POST and SMBIOS transfer
+        name: Wait 260s for host POST and SMBIOS transfer
         transport: *bmc_ssh
         options:
           timeout: 5m
         parameters:
           executable: sleep
-          args: ["220"]
+          args: ["260"]
 
   - name: SMBIOS D-Bus Objects
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
@@ -147,7 +147,7 @@ stages:
           executable: cat
           args: ["/sys/devices/platform/ahb@80000000/80fd0200.serial/lpc_address"]
           expect:
-            - regex: "0x3f8"
+            - regex: "0x3f8|0x2f8"
       - cmd: cmd
         name: SIRQ is 4 (COM1 IRQ)
         transport: *bmc_ssh

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -537,7 +537,7 @@ int SmifService::handleI2cProxy(const ChifPktHeader& hdr,
     if (rc < 0)
     {
         int savedErrno = errno;
-        lg2::warning("I2C proxy: ioctl failed seg=0x{SEG} addr=0x{ADDR} "
+        lg2::warning("I2C proxy: ioctl failed seg={SEG} addr={ADDR} "
                      "bus={BUS}: {ERR}",
                      "SEG", lg2::hex, segment, "ADDR", lg2::hex, i2cAddr,
                      "BUS", busNum, "ERR", strerror(savedErrno));

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -14,14 +14,76 @@
 #include <cstddef>
 #include <cstring>
 #include <format>
+#include <fstream>
+#include <string_view>
 
 namespace chif
 {
 
+// ---------------------------------------------------------------------------
+// Platform identity helpers
+// ---------------------------------------------------------------------------
+
+std::string SmifService::readDtString(const char* path)
+{
+    std::ifstream f(path, std::ios::binary);
+    if (!f)
+    {
+        return {};
+    }
+    std::string s;
+    std::getline(f, s, '\0');
+    while (!s.empty() && (s.back() == '\0' || s.back() == ' ' ||
+                          s.back() == '\n'))
+    {
+        s.pop_back();
+    }
+    return s;
+}
+
+std::string SmifService::deriveShortProductId(const std::string& model)
+{
+    std::string s = model;
+
+    constexpr std::string_view prefix = "HPE ProLiant ";
+    if (s.starts_with(prefix))
+    {
+        s.erase(0, prefix.size());
+    }
+
+    // " Gen11" -> "G11", " Gen12" -> "G12"
+    auto genPos = s.find(" Gen");
+    if (genPos != std::string::npos)
+    {
+        s.replace(genPos, 4, "G");
+    }
+
+    std::erase(s, ' ');
+    return s;
+}
+
 SmifService::SmifService(EvStorage* evStorage,
                          std::unordered_map<uint8_t, int> segmentBusMap) :
     evStorage_(evStorage), segmentToBus_(std::move(segmentBusMap))
-{}
+{
+    boardSerial_ = readDtString("/proc/device-tree/serial-number");
+    if (boardSerial_.empty())
+    {
+        boardSerial_ = "UNKNOWN";
+        lg2::warning("No serial number in device-tree, using fallback");
+    }
+
+    productId_ = deriveShortProductId(
+        readDtString("/proc/device-tree/model"));
+    if (productId_.empty())
+    {
+        productId_ = "UNKNOWN";
+        lg2::warning("No model in device-tree, using fallback");
+    }
+
+    lg2::info("Platform serial: {SN}, product ID: {PID}", "SN",
+              boardSerial_, "PID", productId_);
+}
 
 // ---------------------------------------------------------------------------
 // Response helpers
@@ -524,6 +586,76 @@ int SmifService::handlePlatDefDownload(const ChifPktHeader& hdr,
 }
 
 // ---------------------------------------------------------------------------
+// Field access handler (0x0153)
+// ---------------------------------------------------------------------------
+
+// Payload layout (shared by request and response):
+//   [rcode u32][op u32][sz u32][reserved u32][buf 256] = 272 bytes
+static constexpr size_t fieldBufSize = 256;
+static constexpr size_t fieldPayloadSize =
+    4 * sizeof(uint32_t) + fieldBufSize;
+static constexpr auto fieldRespSize =
+    static_cast<uint16_t>(sizeof(ChifPktHeader) + fieldPayloadSize);
+
+constexpr uint32_t fop(FieldOp o)
+{
+    return static_cast<uint32_t>(o);
+}
+
+int SmifService::handleFieldAccess(const ChifPktHeader& hdr,
+                                   std::span<const uint8_t> reqPayload,
+                                   std::span<uint8_t> response)
+{
+    if (response.size() < fieldRespSize)
+    {
+        return -1;
+    }
+
+    std::fill_n(response.data(), fieldRespSize, uint8_t{0});
+    initResponse(response, hdr, fieldRespSize);
+    auto resp = responsePayload(response);
+
+    // op is at offset 4 (offset 0 is rcode, always 0 on send)
+    uint32_t op = 0;
+    if (reqPayload.size() >= 2 * sizeof(uint32_t))
+    {
+        std::memcpy(&op, reqPayload.data() + 4, sizeof(op));
+    }
+
+    uint32_t rcode = 0;
+    uint32_t sz = 0;
+
+    switch (op)
+    {
+        case fop(FieldOp::readSN):
+        {
+            sz = static_cast<uint32_t>(
+                std::min(boardSerial_.size(), fieldBufSize));
+            std::memcpy(resp.data() + 16, boardSerial_.data(), sz);
+            lg2::info("SMIF 0x0153: read S/N = '{SN}'", "SN", boardSerial_);
+            break;
+        }
+        case fop(FieldOp::readProdId):
+        {
+            sz = static_cast<uint32_t>(
+                std::min(productId_.size(), fieldBufSize));
+            std::memcpy(resp.data() + 16, productId_.data(), sz);
+            lg2::info("SMIF 0x0153: read ProdID = '{PID}'", "PID",
+                      productId_);
+            break;
+        }
+        default:
+            break;
+    }
+
+    std::memcpy(resp.data(), &rcode, sizeof(rcode));
+    std::memcpy(resp.data() + 4, &op, sizeof(op));
+    std::memcpy(resp.data() + 8, &sz, sizeof(sz));
+
+    return fieldRespSize;
+}
+
+// ---------------------------------------------------------------------------
 // SmifService::handle — main dispatch
 // ---------------------------------------------------------------------------
 int SmifService::handle(std::span<const uint8_t> request,
@@ -571,7 +703,10 @@ int SmifService::handle(std::span<const uint8_t> request,
         case smifCmdPlatDefUpload:
             return handlePlatDefDownload(hdr, reqPayload, response);
 
-        // ---- All other commands: stub with ErrorCode=0 ----
+        // ---- Field access (serial number, product ID) ----
+        case smifCmdFieldAccess:
+            return handleFieldAccess(hdr, reqPayload, response);
+
         default:
             return buildSimpleResponse(hdr, response, 0);
     }

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <span>
+#include <string>
 #include <unordered_map>
 
 namespace chif
@@ -66,6 +67,22 @@ enum class EvError : uint32_t
     unsupported = 5,
 };
 
+// Field access operation codes (0x0153)
+enum class FieldOp : uint32_t
+{
+    readSN = 1,
+    writeSN = 2,
+    readProdId = 3,
+    writeProdId = 4,
+    readPcaNum = 5,
+    writePcaNum = 6,
+    readPcaPart = 7,
+    writePcaPart = 8,
+    readCrBrand = 9,
+    readCrProdId = 10,
+    writeCrProdId = 11,
+};
+
 // Event logging
 inline constexpr uint16_t smifCmdQuickEventLog = 0x0146;
 
@@ -113,15 +130,19 @@ class SmifService : public ServiceHandler
     int handleGetEvAuthStatus(const ChifPktHeader& hdr,
                               std::span<uint8_t> response);
 
-    // I2C proxy handler
     int handleI2cProxy(const ChifPktHeader& hdr,
                        std::span<const uint8_t> reqPayload,
                        std::span<uint8_t> response);
-
-    // PlatDef v1 download handler
     int handlePlatDefDownload(const ChifPktHeader& hdr,
                               std::span<const uint8_t> reqPayload,
                               std::span<uint8_t> response);
+    int handleFieldAccess(const ChifPktHeader& hdr,
+                          std::span<const uint8_t> reqPayload,
+                          std::span<uint8_t> response);
+
+    static std::string readDtString(const char* path);
+    // "HPE ProLiant DL365 Gen11" -> "DL365G11"
+    static std::string deriveShortProductId(const std::string& model);
 
     // Response helpers
     static int buildSimpleResponse(const ChifPktHeader& hdr,
@@ -133,6 +154,8 @@ class SmifService : public ServiceHandler
 
     EvStorage* evStorage_;
     std::unordered_map<uint8_t, int> segmentToBus_;
+    std::string boardSerial_;
+    std::string productId_;
 };
 
 } // namespace chif


### PR DESCRIPTION
The BIOS reads Serial Number and Product ID via the CHIF Field Access Command (0x0153) and display them in the BIOS.

This PR also fixes two small nits:
- FirmwareCI tests: We now accept 0x2f8 and 0x3f8 as valid LPC addresses for the serial; and we wait a bit longer until the SMBIOS data has been parsed
- Fix a logging error in the CHIF service so that we can properly see the segments and addresses.