### PR TITLE
HPE Proliant Gen11: add Security State message handling to CHIF service

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -586,6 +586,50 @@ int SmifService::handlePlatDefDownload(const ChifPktHeader& hdr,
 }
 
 // ---------------------------------------------------------------------------
+// Security state handlers (0x0139 get, 0x0158 set)
+// ---------------------------------------------------------------------------
+
+int SmifService::handleSecurityStateGet(const ChifPktHeader& hdr,
+                                        std::span<uint8_t> response)
+{
+    // pkt_8139: rcode(4) + security_state(1) + reserved(3) = 8 bytes payload
+    constexpr size_t payloadSize = 8;
+    constexpr auto respSize =
+        static_cast<uint16_t>(sizeof(ChifPktHeader) + payloadSize);
+
+    if (response.size() < respSize)
+    {
+        return -1;
+    }
+
+    std::fill_n(response.data(), respSize, uint8_t{0});
+    initResponse(response, hdr, respSize);
+
+    auto resp = responsePayload(response);
+    // ErrorCode = 0 (already zeroed)
+    resp[sizeof(uint32_t)] =
+        static_cast<uint8_t>(SecurityState::production);
+
+    return respSize;
+}
+
+int SmifService::handleSecurityStateSet(const ChifPktHeader& hdr,
+                                        std::span<const uint8_t> reqPayload,
+                                        std::span<uint8_t> response)
+{
+    // BIOS sends its security state value -- accept and log it.
+    uint32_t secState = 0;
+    if (reqPayload.size() >= sizeof(secState))
+    {
+        std::memcpy(&secState, reqPayload.data(), sizeof(secState));
+    }
+    lg2::info("SMIF 0x0158: BIOS set security state = {STATE}", "STATE",
+              secState);
+
+    return buildSimpleResponse(hdr, response, 0);
+}
+
+// ---------------------------------------------------------------------------
 // Field access handler (0x0153)
 // ---------------------------------------------------------------------------
 
@@ -694,6 +738,12 @@ int SmifService::handle(std::span<const uint8_t> request,
         // ---- BIOS image auth status (Secure Start) ----
         case smifCmdGetEvAuthStatus:
             return handleGetEvAuthStatus(hdr, response);
+
+        // ---- Security state ----
+        case smifCmdSecurityStateGet:
+            return handleSecurityStateGet(hdr, response);
+        case smifCmdSecurityStateSet:
+            return handleSecurityStateSet(hdr, reqPayload, response);
 
         // ---- I2C proxy ----
         case smifCmdI2cTransaction:

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -83,6 +83,18 @@ enum class FieldOp : uint32_t
     writeCrProdId = 11,
 };
 
+// Security state values (from HPE pkt_8139 comment / event descriptors)
+enum class SecurityState : uint8_t
+{
+    error = 0,
+    factory = 1,
+    wipe = 2,
+    production = 3,
+    highSecurity = 4,
+    fips = 5,
+    suiteB = 6, // aka CNSA
+};
+
 // Event logging
 inline constexpr uint16_t smifCmdQuickEventLog = 0x0146;
 
@@ -130,6 +142,14 @@ class SmifService : public ServiceHandler
     int handleGetEvAuthStatus(const ChifPktHeader& hdr,
                               std::span<uint8_t> response);
 
+    // Security state handlers
+    int handleSecurityStateGet(const ChifPktHeader& hdr,
+                               std::span<uint8_t> response);
+    int handleSecurityStateSet(const ChifPktHeader& hdr,
+                               std::span<const uint8_t> reqPayload,
+                               std::span<uint8_t> response);
+
+    // I2C proxy handler
     int handleI2cProxy(const ChifPktHeader& hdr,
                        std::span<const uint8_t> reqPayload,
                        std::span<uint8_t> response);


### PR DESCRIPTION
This commit adds the Security State handling to the existing chif service. It _always_ replies to the security state with production, and logs the value when the BIOS tries to set it.