### PR TITLE
fix: IPMI KCS channel mismatch in channel_config.json

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
@@ -165,7 +165,7 @@
         }
     },
     "15": {
-        "name": "KCS",
+        "name": "ipmi_kcs1",
         "is_valid": true,
         "active_sessions": 0,
         "channel_info": {


### PR DESCRIPTION
Rename channel 15 from "KCS" to "ipmi_kcs1" to match the D-Bus name derived from KCS_DEVICE in the phosphor-ipmi-kcs bbappend.

Tested on the DL365. The Host can communicate with the BMC via IPMI KCS.

[oscar@hpe-dl365-g11-host ~]$ sudo ipmitool mc info
Device ID                 : 32
Device Revision           : 1
Firmware Revision         : 26.04
IPMI Version              : 2.0
Manufacturer ID           : 47196
Manufacturer Name         : Hewlett Packard Enterprise
Product ID                : 8192 (0x2000)
Product Name              : Unknown (0x2000)
Device Available          : yes
Provides Device SDRs      : no
Additional Device Support :
    Sensor Device
    SDR Repository Device
    SEL Device
    FRU Inventory Device
    IPMB Event Receiver
    IPMB Event Generator
    Chassis Device
Aux Firmware Rev Info     :
    0x00
    0x00
    0x00
    0x00