### PR TITLE
docs: Remove Arch Linux from the list of supported systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ bitbake obmc-phosphor-image
 - Ubuntu 24.04
 - Fedora 42
 - Fedora 43
-- Arch Linux
 
 ### Known Issues
 


### PR DESCRIPTION
Arch Linux is a bleeding-edge, rolling-release distribution. Tan and I use it for development and always try to resolve any new issues that arise. However, I don't believe we should claim that it's officially supported.