### PR TITLE
Prevent own user and root user deletion

### DIFF
--- a/meta-canopy/recipes-phosphor/interfaces/bmcweb/0001-account-service-prevent-deletion-of-own-account.patch
+++ b/meta-canopy/recipes-phosphor/interfaces/bmcweb/0001-account-service-prevent-deletion-of-own-account.patch
@@ -1,0 +1,44 @@
+From 43374d7bfa8c79536b83ff24f5f1b94b3e3369ac Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Wed, 22 Apr 2026 18:20:04 +0200
+Subject: [PATCH 1/2] account-service: prevent deletion of own account
+
+Deleting the own account via the Redfish AccountService could leave the
+system in an inconsistent or unmanageable state.
+
+Reject such requests with an InsufficientPrivilege response before any
+D-Bus interaction takes place.
+
+Tested: Deleting own user fails with InsufficientPrivileges
+        successfully.
+
+Upstream-Status: Pending
+Change-Id: I9a519593a43ce14b7c136d16c264dc753a7204eb
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+[Tan: modified patch because the "shorter type aliases" commit is missing]
+---
+ redfish-core/lib/account_service.hpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/redfish-core/lib/account_service.hpp b/redfish-core/lib/account_service.hpp
+index a91d707f..f8226fb5 100644
+--- a/redfish-core/lib/account_service.hpp
++++ b/redfish-core/lib/account_service.hpp
+@@ -2172,6 +2172,14 @@ inline void handleAccountDelete(
+         messages::resourceNotFound(asyncResp->res, "ManagerAccount", username);
+         return;
+     }
++
++    // Do not allow the removal of the own user
++    if (username == req.session->username)
++    {
++        messages::insufficientPrivilege(asyncResp->res);
++        return;
++    }
++
+     sdbusplus::message::object_path tempObjPath(rootUserDbusPath);
+     tempObjPath /= username;
+     const std::string userPath(tempObjPath);
+-- 
+2.53.0
+

--- a/meta-canopy/recipes-phosphor/interfaces/bmcweb/0002-account-service-return-proper-error-on-deletion.patch
+++ b/meta-canopy/recipes-phosphor/interfaces/bmcweb/0002-account-service-return-proper-error-on-deletion.patch
@@ -1,0 +1,74 @@
+From f1ee4e2668ac59564c1d92dbd2898c35057d9f8e Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Wed, 22 Apr 2026 22:12:29 +0200
+Subject: [PATCH 2/2] account-service: return proper error on deletion
+
+phosphor-user-manager may return an error on deletion if userdel fails
+for arbitrary reasons (e.g. the user is still logged in and running
+processes). Previously, any D-Bus error was unconditionally mapped to
+404 Not Found, which was misleading for users that existed but could
+not be removed.
+
+Inspect the D-Bus error name and return the most appropriate Redfish
+response: ResourceNotFound for unknown objects, InsufficientPrivilege
+for NotAllowed (e.g. removing the root user), and InternalError for
+anything else.
+
+Tested: Verified correct error responses when deleting a non-existent
+        user, when attempting to delete root (prohibited by
+        phosphor-user-manager), and on unknown errors. Ran
+        openbmc-test-automation against AccountService with no
+        unexpected regressions.
+
+Upstream-Status: Pending
+Change-Id: I559a4081d992b424319ae243c176baae91b1c322
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ redfish-core/lib/account_service.hpp | 29 +++++++++++++++++++++++++---
+ 1 file changed, 26 insertions(+), 3 deletions(-)
+
+diff --git a/redfish-core/lib/account_service.hpp b/redfish-core/lib/account_service.hpp
+index f8226fb5..0ca2ee7e 100644
+--- a/redfish-core/lib/account_service.hpp
++++ b/redfish-core/lib/account_service.hpp
+@@ -2186,11 +2186,34 @@ inline void handleAccountDelete(
+ 
+     dbus::utility::async_method_call(
+         asyncResp,
+-        [asyncResp, username](const boost::system::error_code& ec) {
++        [asyncResp, username](const boost::system::error_code& ec,
++                              sdbusplus::message_t& m) {
+             if (ec)
+             {
+-                messages::resourceNotFound(asyncResp->res, "ManagerAccount",
+-                                           username);
++                const sd_bus_error* e = m.get_error();
++
++                if (e == nullptr)
++                {
++                    messages::internalError(asyncResp->res);
++                    return;
++                }
++
++                const std::string_view em = e->name;
++                if (em == "org.freedesktop.DBus.Error.UnknownObject")
++                {
++                    messages::resourceNotFound(asyncResp->res, "ManagerAccount",
++                                               username);
++                }
++                else if (em == "xyz.openbmc_project.Common.Error.NotAllowed")
++                {
++                    messages::insufficientPrivilege(asyncResp->res);
++                }
++                else
++                {
++                    BMCWEB_LOG_ERROR("DBUS response error {}", em);
++                    messages::internalError(asyncResp->res);
++                }
++
+                 return;
+             }
+ 
+-- 
+2.53.0
+

--- a/meta-canopy/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-canopy/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -1,3 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+        file://0001-account-service-prevent-deletion-of-own-account.patch \
+"
+
 PACKAGECONFIG:append = " \
         redfish-dbus-log \
         redfish-dump-log \

--- a/meta-canopy/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-canopy/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = " \
         file://0001-account-service-prevent-deletion-of-own-account.patch \
+        file://0002-account-service-return-proper-error-on-deletion.patch \
 "
 
 PACKAGECONFIG:append = " \

--- a/meta-canopy/recipes-phosphor/users/phosphor-user-manager/0001-user-mgr-prevent-deletion-of-user-with-uid-0.patch
+++ b/meta-canopy/recipes-phosphor/users/phosphor-user-manager/0001-user-mgr-prevent-deletion-of-user-with-uid-0.patch
@@ -1,0 +1,80 @@
+From 023fbbbca0fbc4e253c002cfbd5feb52eb3e26c0 Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Wed, 22 Apr 2026 20:42:53 +0200
+Subject: [PATCH] user-mgr: prevent deletion of user with uid 0
+
+Deleting the user with uid 0 (often known as "root") would render the
+system unmanageable, regardless of their username.
+
+Add throwForUidZero() which looks up the user's passwd entry and
+throws NotAllowed if the UID is 0. This will be called before actually
+deleting the user.
+
+Upstream-Status: Pending
+Change-Id: I62d61c05cfad1b703ef7b4b56badc80f8d396da4
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ user_mgr.cpp | 13 +++++++++++++
+ user_mgr.hpp |  8 ++++++++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/user_mgr.cpp b/user_mgr.cpp
+index 80ddc26..7acaf2a 100644
+--- a/user_mgr.cpp
++++ b/user_mgr.cpp
+@@ -101,6 +101,8 @@ using UserNameGroupFail =
+     sdbusplus::xyz::openbmc_project::User::Common::Error::UserNameGroupFail;
+ using NoResource =
+     sdbusplus::xyz::openbmc_project::User::Common::Error::NoResource;
++using NotAllowed = sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
++using NotAllowedArgument = xyz::openbmc_project::Common::NotAllowed;
+ using Argument = xyz::openbmc_project::Common::InvalidArgument;
+ using GroupNameExists =
+     sdbusplus::xyz::openbmc_project::User::Common::Error::GroupNameExists;
+@@ -347,6 +349,16 @@ void UserMgr::throwForUserNameConstraints(
+     }
+ }
+ 
++void UserMgr::throwForUidZero(const std::string& userName)
++{
++    auto systemUser = getSystemUser(userName);
++    if (systemUser && systemUser->pwd.pw_uid == 0)
++    {
++        lg2::error("User '{USERNAME}' is UID 0", "USERNAME", userName);
++        elog<NotAllowed>(NotAllowedArgument::REASON("User is UID 0"));
++    }
++}
++
+ void UserMgr::throwForMaxGrpUserCount(
+     const std::vector<std::string>& groupNames)
+ {
+@@ -540,6 +552,7 @@ void UserMgr::deleteUserImpl(const std::string& userName)
+ void UserMgr::deleteUser(std::string userName)
+ {
+     throwForUserDoesNotExist(userName);
++    throwForUidZero(userName);
+     deleteUserImpl(userName);
+     lg2::info("User '{USERNAME}' deleted successfully", "USERNAME", userName);
+ }
+diff --git a/user_mgr.hpp b/user_mgr.hpp
+index 8c1ece5..db93a29 100644
+--- a/user_mgr.hpp
++++ b/user_mgr.hpp
+@@ -481,6 +481,14 @@ class UserMgr : public Ifaces
+ 
+     size_t getNonIpmiUsersCount();
+ 
++    /** @brief check user has UID 0
++     *  method to check whether user is not UID 0 (i.e. root),
++     *  and throw if it is.
++     *
++     *  @param[in] userName - name of the user
++     */
++    void throwForUidZero(const std::string& userName);
++
+     /** @brief check user exists
+      *  method to check whether user exist, and throw if not.
+      *
+-- 
+2.53.0
+

--- a/meta-canopy/recipes-phosphor/users/phosphor-user-manager_%.bbappend
+++ b/meta-canopy/recipes-phosphor/users/phosphor-user-manager_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+        file://0001-user-mgr-prevent-deletion-of-user-with-uid-0.patch \
+        "


### PR DESCRIPTION
This PR adds three patches. Two for bmcweb, one for user-manager.

user-manager:
  - Prevent uid 0 deletion

bmcweb:
  - Prevent deletion of own user account
  - Return an actual error instead of using 404 not found for every error message

Closes #157 