### PR TITLE
meta-canopy: install ipmitool only on dev channel

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
@@ -44,5 +44,4 @@ RDEPENDS:${PN}-system = " \
         gxp-chif-service \
         smbios-mdr \
         udev-gxp-i2c-passthrough \
-        ipmitool \
         "

--- a/meta-canopy/recipes-phosphor/images/obmc-phosphor-image.bbappend
+++ b/meta-canopy/recipes-phosphor/images/obmc-phosphor-image.bbappend
@@ -1,0 +1,3 @@
+OBMC_IMAGE_EXTRA_INSTALL:append:canopy:dev = " \
+    ipmitool \
+"


### PR DESCRIPTION
Debug tooling is usually not required on release systems which may also be locked down for security.

Install debug toolings such as ipmitool only when CANOPY_CONFIG is set to "dev".

Closes #102 