### PR TITLE
Security: meta-canopy: bmcweb: backport security fix (body limit enforcement)

### DIFF
--- a/meta-canopy/recipes-phosphor/interfaces/bmcweb/0003-Move-body-limit-enforcement.patch
+++ b/meta-canopy/recipes-phosphor/interfaces/bmcweb/0003-Move-body-limit-enforcement.patch
@@ -1,0 +1,55 @@
+From 0b2049b0ae1a717c3e73b70d6a064854b3208199 Mon Sep 17 00:00:00 2001
+From: Gunnar Mills <gmills@us.ibm.com>
+Date: Mon, 23 Feb 2026 21:08:49 -0600
+Subject: [PATCH] Move body limit enforcement
+
+Make sure the body limit enforcement happens before the Expect:
+100-continue check.
+
+Tested: Verified the body limit check happens first, even when Expect:
+        100-continue is used. Now rejects with 413 Payload Too Large.
+        Normal operations such as the Redfish Validator still work.
+
+Upstream-Status: Backport [from commit 0b2049b0]
+Change-Id: I185dab82c75b3c44d89102750fd03666659a57a6
+Signed-off-by: Gunnar Mills <gmills@us.ibm.com>
+---
+ http/http_connection.hpp | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/http/http_connection.hpp b/http/http_connection.hpp
+index 70f7b82c..eb7a6e6c 100644
+--- a/http/http_connection.hpp
++++ b/http/http_connection.hpp
+@@ -646,21 +646,21 @@ class Connection :
+                 ip, res, method, value.base(), mtlsSession);
+         }
+ 
+-        std::string_view expect = value[boost::beast::http::field::expect];
+-        if (bmcweb::asciiIEquals(expect, "100-continue"))
++        if (!handleContentLengthError())
+         {
+-            res.result(boost::beast::http::status::continue_);
+-            doWrite();
+             return;
+         }
+ 
+-        if (!handleContentLengthError())
++        parse.body_limit(getContentLengthLimit());
++
++        std::string_view expect = value[boost::beast::http::field::expect];
++        if (bmcweb::asciiIEquals(expect, "100-continue"))
+         {
++            res.result(boost::beast::http::status::continue_);
++            doWrite();
+             return;
+         }
+ 
+-        parse.body_limit(getContentLengthLimit());
+-
+         if (parse.is_done())
+         {
+             handle();
+-- 
+2.53.0
+

--- a/meta-canopy/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-canopy/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " \
         file://0001-account-service-prevent-deletion-of-own-account.patch \
         file://0002-account-service-return-proper-error-on-deletion.patch \
+        file://0003-Move-body-limit-enforcement.patch \
 "
 
 PACKAGECONFIG:append = " \


### PR DESCRIPTION
A security advisory was published on April 21th, 2026 (informed via email on April 27th, 2026) for bmcweb as it did not correctly enforce the maximum payload size when `Expect: 100-continue` is set.

Backport the commit that fixes the issue.

Link: https://github.com/openbmc/bmcweb/security/advisories/GHSA-p3gc-68x5-g9w3

