### PR TITLE
meta-hpe: leds: add missing bmc_booted group

### DIFF
--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/service-failures.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/service-failures.yaml
@@ -38,7 +38,7 @@ stages:
           executable: sh
           args:
             - "-c"
-            - "FAILED=$(systemctl list-units --state=failed --no-pager --no-legend | grep -v 'clear-once\\|bmc_booted\\|trace-enable'); if [ -n \"$FAILED\" ]; then echo \"$FAILED\"; exit 1; fi; echo '0 unexpected failures'"
+            - "FAILED=$(systemctl list-units --state=failed --no-pager --no-legend | grep -v 'clear-once\\|trace-enable'); if [ -n \"$FAILED\" ]; then echo \"$FAILED\"; exit 1; fi; echo '0 unexpected failures'"
 
   - name: No Crash Loops
     steps:

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/leds/phosphor-led-manager/led-group-config.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/leds/phosphor-led-manager/led-group-config.json
@@ -1,6 +1,18 @@
 {
     "leds": [
         {
+            "group": "bmc_booted",
+            "members": [
+                {
+                    "Name": "heartbeat_platform",
+                    "Action" : "Blink",
+                    "Priority" : "Blink",
+                    "DutyOn" : 50,
+                    "Period" : 1000
+                }
+            ]
+        },
+        {
             "group": "enclosure_identify",
             "members": [
                 {


### PR DESCRIPTION
The bmc_booted LED group is always being started and throws an error if
it is not defined in the LED group config:

```
root@hpe-proliant-g11:~# journalctl -b 0 -u obmc-led-group-start@bmc_booted.service
Mar 13 15:35:50 hpe-proliant-g11 systemd[1]: Starting Assert bmc_booted LED...
Mar 13 15:35:51 hpe-proliant-g11 busctl[359]: Failed to set property Asserted on interface xyz.openbmc_project.Led.Group: Unknown object '/xyz/openbmc_project/led/groups/bmc_booted'.
Mar 13 15:35:51 hpe-proliant-g11 systemd[1]: obmc-led-group-start@bmc_booted.service: Main process exited, code=exited, status=1/FAILURE
Mar 13 15:35:51 hpe-proliant-g11 systemd[1]: obmc-led-group-start@bmc_booted.service: Failed with result 'exit-code'.
Mar 13 15:35:51 hpe-proliant-g11 systemd[1]: Failed to start Assert bmc_booted LED.
```

Add the group with the `heartbeat_platform` LED as member.

Also remove the the failed unit from the expected error list in the CI.

Closes #167 