### PR TITLE
meta-canopy: kernel: Move to 6.18.25 stable release

### DIFF
--- a/meta-canopy/recipes-kernel/linux/linux-stable_6.18.bb
+++ b/meta-canopy/recipes-kernel/linux/linux-stable_6.18.bb
@@ -1,5 +1,5 @@
 KBRANCH = "linux-6.18.y"
-LINUX_VERSION = "6.18.7"
-SRCREV = "740f166c484b5cd06f30eca8eb5bc6729a31cbb5"
+LINUX_VERSION = "6.18.25"
+SRCREV = "a256b1e6892e7fe840f0f9746316fa938e9a421f"
 
 require linux-stable.inc


### PR DESCRIPTION
Apply the upstream security and bug fixes.
Fixes CVE-2026-31431 too.