### PR TITLE
meta-hpe: dts: re-add gpio cells and line names

### DIFF
--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0235.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0235.dtso
@@ -40,6 +40,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -91,6 +94,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -142,6 +148,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -193,6 +202,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -244,6 +256,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -295,6 +310,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -346,6 +364,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -397,6 +418,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -448,6 +472,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "9_DRV17_PRESENCE", "9_DRV17_UUID", "9_DRV17_ACT",
+				"9_DRV18_PRESENCE", "9_DRV18_UUID", "9_DRV18_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -499,6 +526,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "10_DRV19_PRESENCE", "10_DRV19_UUID", "10_DRV19_ACT",
+				"10_DRV20_PRESENCE", "10_DRV20_UUID", "10_DRV20_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -550,6 +580,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "11_DRV21_PRESENCE", "11_DRV21_UUID", "11_DRV21_ACT",
+				"11_DRV22_PRESENCE", "11_DRV22_UUID", "11_DRV22_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -601,6 +634,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "12_DRV23_PRESENCE", "12_DRV23_UUID", "12_DRV23_ACT",
+				"12_DRV24_PRESENCE", "12_DRV24_UUID", "12_DRV24_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -652,6 +688,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "13_DRV25_PRESENCE", "13_DRV25_UUID", "13_DRV25_ACT",
+				"13_DRV26_PRESENCE", "13_DRV26_UUID", "13_DRV26_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -703,6 +742,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "14_DRV27_PRESENCE", "14_DRV27_UUID", "14_DRV27_ACT",
+				"14_DRV28_PRESENCE", "14_DRV28_UUID", "14_DRV28_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -754,6 +796,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "15_DRV29_PRESENCE", "15_DRV29_UUID", "15_DRV29_ACT",
+				"15_DRV30_PRESENCE", "15_DRV30_UUID", "15_DRV30_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -805,6 +850,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "16_DRV31_PRESENCE", "16_DRV31_UUID", "16_DRV31_ACT",
+				"16_DRV32_PRESENCE", "16_DRV32_UUID", "16_DRV32_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -863,6 +911,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "17_DRV33_PRESENCE", "17_DRV33_UUID", "17_DRV33_ACT",
+				"17_DRV34_PRESENCE", "17_DRV34_UUID", "17_DRV34_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -914,6 +965,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "18_DRV35_PRESENCE", "18_DRV35_UUID", "18_DRV35_ACT",
+				"18_DRV36_PRESENCE", "18_DRV36_UUID", "18_DRV36_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -972,6 +1026,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "19_DRV37_PRESENCE", "19_DRV37_UUID", "19_DRV37_ACT",
+				"19_DRV38_PRESENCE", "19_DRV38_UUID", "19_DRV38_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1023,6 +1080,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "20_DRV39_PRESENCE", "20_DRV39_UUID", "20_DRV39_ACT",
+				"20_DRV40_PRESENCE", "20_DRV40_UUID", "20_DRV40_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1074,6 +1134,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "21_DRV41_PRESENCE", "21_DRV41_UUID", "21_DRV41_ACT",
+				"21_DRV42_PRESENCE", "21_DRV42_UUID", "21_DRV42_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1125,6 +1188,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "22_DRV43_PRESENCE", "22_DRV43_UUID", "22_DRV43_ACT",
+				"22_DRV44_PRESENCE", "22_DRV44_UUID", "22_DRV44_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0236.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0236.dtso
@@ -40,6 +40,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -91,6 +94,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -142,6 +148,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -193,6 +202,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -244,6 +256,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -295,6 +310,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -346,6 +364,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -397,6 +418,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -448,6 +472,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "9_DRV17_PRESENCE", "9_DRV17_UUID", "9_DRV17_ACT",
+				"9_DRV18_PRESENCE", "9_DRV18_UUID", "9_DRV18_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -499,6 +526,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "10_DRV19_PRESENCE", "10_DRV19_UUID", "10_DRV19_ACT",
+				"10_DRV20_PRESENCE", "10_DRV20_UUID", "10_DRV20_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -550,6 +580,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "11_DRV21_PRESENCE", "11_DRV21_UUID", "11_DRV21_ACT",
+				"11_DRV22_PRESENCE", "11_DRV22_UUID", "11_DRV22_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -601,6 +634,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "12_DRV23_PRESENCE", "12_DRV23_UUID", "12_DRV23_ACT",
+				"12_DRV24_PRESENCE", "12_DRV24_UUID", "12_DRV24_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -652,6 +688,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "13_DRV25_PRESENCE", "13_DRV25_UUID", "13_DRV25_ACT",
+				"13_DRV26_PRESENCE", "13_DRV26_UUID", "13_DRV26_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -703,6 +742,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "14_DRV27_PRESENCE", "14_DRV27_UUID", "14_DRV27_ACT",
+				"14_DRV28_PRESENCE", "14_DRV28_UUID", "14_DRV28_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -754,6 +796,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "15_DRV29_PRESENCE", "15_DRV29_UUID", "15_DRV29_ACT",
+				"15_DRV30_PRESENCE", "15_DRV30_UUID", "15_DRV30_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -805,6 +850,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "16_DRV31_PRESENCE", "16_DRV31_UUID", "16_DRV31_ACT",
+				"16_DRV32_PRESENCE", "16_DRV32_UUID", "16_DRV32_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -863,6 +911,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "17_DRV33_PRESENCE", "17_DRV33_UUID", "17_DRV33_ACT",
+				"17_DRV34_PRESENCE", "17_DRV34_UUID", "17_DRV34_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -914,6 +965,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "18_DRV35_PRESENCE", "18_DRV35_UUID", "18_DRV35_ACT",
+				"18_DRV36_PRESENCE", "18_DRV36_UUID", "18_DRV36_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -972,6 +1026,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "19_DRV37_PRESENCE", "19_DRV37_UUID", "19_DRV37_ACT",
+				"19_DRV38_PRESENCE", "19_DRV38_UUID", "19_DRV38_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1023,6 +1080,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "20_DRV39_PRESENCE", "20_DRV39_UUID", "20_DRV39_ACT",
+				"20_DRV40_PRESENCE", "20_DRV40_UUID", "20_DRV40_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1074,6 +1134,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "21_DRV41_PRESENCE", "21_DRV41_UUID", "21_DRV41_ACT",
+				"21_DRV42_PRESENCE", "21_DRV42_UUID", "21_DRV42_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1125,6 +1188,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "22_DRV43_PRESENCE", "22_DRV43_UUID", "22_DRV43_ACT",
+				"22_DRV44_PRESENCE", "22_DRV44_UUID", "22_DRV44_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0241.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0241.dtso
@@ -68,6 +68,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "0_DRV1_PRESENCE", "0_DRV1_UUID", "0_DRV1_ACT",
+			"0_DRV2_PRESENCE", "0_DRV2_UUID", "0_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";
@@ -119,6 +122,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+			"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 		};
 	};
 	i2c3_9: i2c3@9 {
@@ -134,6 +140,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "2_DRV1_PRESENCE", "2_DRV1_UUID", "2_DRV1_ACT",
+			"2_DRV2_PRESENCE", "2_DRV2_UUID", "2_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";
@@ -185,6 +194,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "3_DRV1_PRESENCE", "3_DRV1_UUID", "3_DRV1_ACT",
+			"3_DRV2_PRESENCE", "3_DRV2_UUID", "3_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0243.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0243.dtso
@@ -213,6 +213,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -264,6 +267,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -315,6 +321,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -366,6 +375,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -417,6 +429,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -468,6 +483,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -519,6 +537,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -570,6 +591,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -621,6 +645,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "9_DRV17_PRESENCE", "9_DRV17_UUID", "9_DRV17_ACT",
+				"9_DRV18_PRESENCE", "9_DRV18_UUID", "9_DRV18_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -672,6 +699,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "10_DRV19_PRESENCE", "10_DRV19_UUID", "10_DRV19_ACT",
+				"10_DRV20_PRESENCE", "10_DRV20_UUID", "10_DRV20_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -723,6 +753,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "11_DRV21_PRESENCE", "11_DRV21_UUID", "11_DRV21_ACT",
+				"11_DRV22_PRESENCE", "11_DRV22_UUID", "11_DRV22_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -774,6 +807,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "12_DRV23_PRESENCE", "12_DRV23_UUID", "12_DRV23_ACT",
+				"12_DRV24_PRESENCE", "12_DRV24_UUID", "12_DRV24_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -825,6 +861,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "13_DRV25_PRESENCE", "13_DRV25_UUID", "13_DRV25_ACT",
+				"13_DRV26_PRESENCE", "13_DRV26_UUID", "13_DRV26_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -876,6 +915,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "14_DRV27_PRESENCE", "14_DRV27_UUID", "14_DRV27_ACT",
+				"14_DRV28_PRESENCE", "14_DRV28_UUID", "14_DRV28_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -927,6 +969,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "15_DRV29_PRESENCE", "15_DRV29_UUID", "15_DRV29_ACT",
+				"15_DRV30_PRESENCE", "15_DRV30_UUID", "15_DRV30_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -978,6 +1023,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "16_DRV31_PRESENCE", "16_DRV31_UUID", "16_DRV31_ACT",
+				"16_DRV32_PRESENCE", "16_DRV32_UUID", "16_DRV32_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1029,6 +1077,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "17_DRV33_PRESENCE", "17_DRV33_UUID", "17_DRV33_ACT",
+				"17_DRV34_PRESENCE", "17_DRV34_UUID", "17_DRV34_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1080,6 +1131,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "18_DRV35_PRESENCE", "18_DRV35_UUID", "18_DRV35_ACT",
+				"18_DRV36_PRESENCE", "18_DRV36_UUID", "18_DRV36_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1131,6 +1185,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "19_DRV37_PRESENCE", "19_DRV37_UUID", "19_DRV37_ACT",
+				"19_DRV38_PRESENCE", "19_DRV38_UUID", "19_DRV38_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1182,6 +1239,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "20_DRV39_PRESENCE", "20_DRV39_UUID", "20_DRV39_ACT",
+				"20_DRV40_PRESENCE", "20_DRV40_UUID", "20_DRV40_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1233,6 +1293,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "21_DRV41_PRESENCE", "21_DRV41_UUID", "21_DRV41_ACT",
+				"21_DRV42_PRESENCE", "21_DRV42_UUID", "21_DRV42_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1284,6 +1347,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "22_DRV43_PRESENCE", "22_DRV43_UUID", "22_DRV43_ACT",
+				"22_DRV44_PRESENCE", "22_DRV44_UUID", "22_DRV44_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1342,6 +1408,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "23_DRV45_PRESENCE", "23_DRV45_UUID", "23_DRV45_ACT",
+				"23_DRV46_PRESENCE", "23_DRV46_UUID", "23_DRV46_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1393,6 +1462,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "24_DRV47_PRESENCE", "24_DRV47_UUID", "24_DRV47_ACT",
+				"24_DRV48_PRESENCE", "24_DRV48_UUID", "24_DRV48_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1444,6 +1516,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "25_DRV49_PRESENCE", "25_DRV49_UUID", "25_DRV49_ACT",
+				"25_DRV50_PRESENCE", "25_DRV50_UUID", "25_DRV50_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1495,6 +1570,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "26_DRV51_PRESENCE", "26_DRV51_UUID", "26_DRV51_ACT",
+				"26_DRV52_PRESENCE", "26_DRV52_UUID", "26_DRV52_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1553,6 +1631,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "27_DRV53_PRESENCE", "27_DRV53_UUID", "27_DRV53_ACT",
+				"27_DRV54_PRESENCE", "27_DRV54_UUID", "27_DRV54_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1604,6 +1685,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "28_DRV55_PRESENCE", "28_DRV55_UUID", "28_DRV55_ACT",
+				"28_DRV56_PRESENCE", "28_DRV56_UUID", "28_DRV56_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1655,6 +1739,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "29_DRV57_PRESENCE", "29_DRV57_UUID", "29_DRV57_ACT",
+				"29_DRV58_PRESENCE", "29_DRV58_UUID", "29_DRV58_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1706,6 +1793,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "30_DRV59_PRESENCE", "30_DRV59_UUID", "30_DRV59_ACT",
+				"30_DRV60_PRESENCE", "30_DRV60_UUID", "30_DRV60_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0244.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0244.dtso
@@ -213,6 +213,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -264,6 +267,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -315,6 +321,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -366,6 +375,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -417,6 +429,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -468,6 +483,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -519,6 +537,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -570,6 +591,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -621,6 +645,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "9_DRV17_PRESENCE", "9_DRV17_UUID", "9_DRV17_ACT",
+				"9_DRV18_PRESENCE", "9_DRV18_UUID", "9_DRV18_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -672,6 +699,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "10_DRV19_PRESENCE", "10_DRV19_UUID", "10_DRV19_ACT",
+				"10_DRV20_PRESENCE", "10_DRV20_UUID", "10_DRV20_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -723,6 +753,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "11_DRV21_PRESENCE", "11_DRV21_UUID", "11_DRV21_ACT",
+				"11_DRV22_PRESENCE", "11_DRV22_UUID", "11_DRV22_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -774,6 +807,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "12_DRV23_PRESENCE", "12_DRV23_UUID", "12_DRV23_ACT",
+				"12_DRV24_PRESENCE", "12_DRV24_UUID", "12_DRV24_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -825,6 +861,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "13_DRV25_PRESENCE", "13_DRV25_UUID", "13_DRV25_ACT",
+				"13_DRV26_PRESENCE", "13_DRV26_UUID", "13_DRV26_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -876,6 +915,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "14_DRV27_PRESENCE", "14_DRV27_UUID", "14_DRV27_ACT",
+				"14_DRV28_PRESENCE", "14_DRV28_UUID", "14_DRV28_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -927,6 +969,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "15_DRV29_PRESENCE", "15_DRV29_UUID", "15_DRV29_ACT",
+				"15_DRV30_PRESENCE", "15_DRV30_UUID", "15_DRV30_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -978,6 +1023,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "16_DRV31_PRESENCE", "16_DRV31_UUID", "16_DRV31_ACT",
+				"16_DRV32_PRESENCE", "16_DRV32_UUID", "16_DRV32_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1036,6 +1084,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "17_DRV33_PRESENCE", "17_DRV33_UUID", "17_DRV33_ACT",
+				"17_DRV34_PRESENCE", "17_DRV34_UUID", "17_DRV34_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1087,6 +1138,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "18_DRV35_PRESENCE", "18_DRV35_UUID", "18_DRV35_ACT",
+				"18_DRV36_PRESENCE", "18_DRV36_UUID", "18_DRV36_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1138,6 +1192,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "19_DRV37_PRESENCE", "19_DRV37_UUID", "19_DRV37_ACT",
+				"19_DRV38_PRESENCE", "19_DRV38_UUID", "19_DRV38_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1189,6 +1246,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "20_DRV39_PRESENCE", "20_DRV39_UUID", "20_DRV39_ACT",
+				"20_DRV40_PRESENCE", "20_DRV40_UUID", "20_DRV40_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0245.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0245.dtso
@@ -213,6 +213,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -264,6 +267,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -315,6 +321,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -366,6 +375,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -417,6 +429,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -468,6 +483,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -519,6 +537,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -570,6 +591,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -621,6 +645,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "9_DRV17_PRESENCE", "9_DRV17_UUID", "9_DRV17_ACT",
+				"9_DRV18_PRESENCE", "9_DRV18_UUID", "9_DRV18_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -672,6 +699,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "10_DRV19_PRESENCE", "10_DRV19_UUID", "10_DRV19_ACT",
+				"10_DRV20_PRESENCE", "10_DRV20_UUID", "10_DRV20_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -723,6 +753,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "11_DRV21_PRESENCE", "11_DRV21_UUID", "11_DRV21_ACT",
+				"11_DRV22_PRESENCE", "11_DRV22_UUID", "11_DRV22_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -774,6 +807,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "12_DRV23_PRESENCE", "12_DRV23_UUID", "12_DRV23_ACT",
+				"12_DRV24_PRESENCE", "12_DRV24_UUID", "12_DRV24_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -825,6 +861,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "13_DRV25_PRESENCE", "13_DRV25_UUID", "13_DRV25_ACT",
+				"13_DRV26_PRESENCE", "13_DRV26_UUID", "13_DRV26_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -876,6 +915,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "14_DRV27_PRESENCE", "14_DRV27_UUID", "14_DRV27_ACT",
+				"14_DRV28_PRESENCE", "14_DRV28_UUID", "14_DRV28_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -927,6 +969,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "15_DRV29_PRESENCE", "15_DRV29_UUID", "15_DRV29_ACT",
+				"15_DRV30_PRESENCE", "15_DRV30_UUID", "15_DRV30_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -978,6 +1023,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "16_DRV31_PRESENCE", "16_DRV31_UUID", "16_DRV31_ACT",
+				"16_DRV32_PRESENCE", "16_DRV32_UUID", "16_DRV32_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1029,6 +1077,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "17_DRV33_PRESENCE", "17_DRV33_UUID", "17_DRV33_ACT",
+				"17_DRV34_PRESENCE", "17_DRV34_UUID", "17_DRV34_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1080,6 +1131,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "18_DRV35_PRESENCE", "18_DRV35_UUID", "18_DRV35_ACT",
+				"18_DRV36_PRESENCE", "18_DRV36_UUID", "18_DRV36_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1131,6 +1185,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "19_DRV37_PRESENCE", "19_DRV37_UUID", "19_DRV37_ACT",
+				"19_DRV38_PRESENCE", "19_DRV38_UUID", "19_DRV38_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1182,6 +1239,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "20_DRV39_PRESENCE", "20_DRV39_UUID", "20_DRV39_ACT",
+				"20_DRV40_PRESENCE", "20_DRV40_UUID", "20_DRV40_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1233,6 +1293,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "21_DRV41_PRESENCE", "21_DRV41_UUID", "21_DRV41_ACT",
+				"21_DRV42_PRESENCE", "21_DRV42_UUID", "21_DRV42_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1284,6 +1347,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "22_DRV43_PRESENCE", "22_DRV43_UUID", "22_DRV43_ACT",
+				"22_DRV44_PRESENCE", "22_DRV44_UUID", "22_DRV44_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1342,6 +1408,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "23_DRV45_PRESENCE", "23_DRV45_UUID", "23_DRV45_ACT",
+				"23_DRV46_PRESENCE", "23_DRV46_UUID", "23_DRV46_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1393,6 +1462,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "24_DRV47_PRESENCE", "24_DRV47_UUID", "24_DRV47_ACT",
+				"24_DRV48_PRESENCE", "24_DRV48_UUID", "24_DRV48_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1444,6 +1516,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "25_DRV49_PRESENCE", "25_DRV49_UUID", "25_DRV49_ACT",
+				"25_DRV50_PRESENCE", "25_DRV50_UUID", "25_DRV50_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1495,6 +1570,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "26_DRV51_PRESENCE", "26_DRV51_UUID", "26_DRV51_ACT",
+				"26_DRV52_PRESENCE", "26_DRV52_UUID", "26_DRV52_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1604,6 +1682,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "28_DRV55_PRESENCE", "28_DRV55_UUID", "28_DRV55_ACT",
+				"28_DRV56_PRESENCE", "28_DRV56_UUID", "28_DRV56_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1655,6 +1736,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "29_DRV57_PRESENCE", "29_DRV57_UUID", "29_DRV57_ACT",
+				"29_DRV58_PRESENCE", "29_DRV58_UUID", "29_DRV58_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1706,6 +1790,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "30_DRV59_PRESENCE", "30_DRV59_UUID", "30_DRV59_ACT",
+				"30_DRV60_PRESENCE", "30_DRV60_UUID", "30_DRV60_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0246.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0246.dtso
@@ -213,6 +213,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -264,6 +267,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -315,6 +321,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -366,6 +375,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -417,6 +429,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -468,6 +483,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -519,6 +537,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -570,6 +591,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -621,6 +645,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "9_DRV17_PRESENCE", "9_DRV17_UUID", "9_DRV17_ACT",
+				"9_DRV18_PRESENCE", "9_DRV18_UUID", "9_DRV18_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -672,6 +699,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "10_DRV19_PRESENCE", "10_DRV19_UUID", "10_DRV19_ACT",
+				"10_DRV20_PRESENCE", "10_DRV20_UUID", "10_DRV20_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -723,6 +753,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "11_DRV21_PRESENCE", "11_DRV21_UUID", "11_DRV21_ACT",
+				"11_DRV22_PRESENCE", "11_DRV22_UUID", "11_DRV22_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -774,6 +807,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "12_DRV23_PRESENCE", "12_DRV23_UUID", "12_DRV23_ACT",
+				"12_DRV24_PRESENCE", "12_DRV24_UUID", "12_DRV24_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -825,6 +861,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "13_DRV25_PRESENCE", "13_DRV25_UUID", "13_DRV25_ACT",
+				"13_DRV26_PRESENCE", "13_DRV26_UUID", "13_DRV26_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -876,6 +915,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "14_DRV27_PRESENCE", "14_DRV27_UUID", "14_DRV27_ACT",
+				"14_DRV28_PRESENCE", "14_DRV28_UUID", "14_DRV28_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -927,6 +969,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "15_DRV29_PRESENCE", "15_DRV29_UUID", "15_DRV29_ACT",
+				"15_DRV30_PRESENCE", "15_DRV30_UUID", "15_DRV30_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -978,6 +1023,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "16_DRV31_PRESENCE", "16_DRV31_UUID", "16_DRV31_ACT",
+				"16_DRV32_PRESENCE", "16_DRV32_UUID", "16_DRV32_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1036,6 +1084,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "17_DRV33_PRESENCE", "17_DRV33_UUID", "17_DRV33_ACT",
+				"17_DRV34_PRESENCE", "17_DRV34_UUID", "17_DRV34_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1087,6 +1138,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "18_DRV35_PRESENCE", "18_DRV35_UUID", "18_DRV35_ACT",
+				"18_DRV36_PRESENCE", "18_DRV36_UUID", "18_DRV36_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1138,6 +1192,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "19_DRV37_PRESENCE", "19_DRV37_UUID", "19_DRV37_ACT",
+				"19_DRV38_PRESENCE", "19_DRV38_UUID", "19_DRV38_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -1189,6 +1246,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "20_DRV39_PRESENCE", "20_DRV39_UUID", "20_DRV39_ACT",
+				"20_DRV40_PRESENCE", "20_DRV40_UUID", "20_DRV40_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0248.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0248.dtso
@@ -68,6 +68,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "0_DRV1_PRESENCE", "0_DRV1_UUID", "0_DRV1_ACT",
+			"0_DRV2_PRESENCE", "0_DRV2_UUID", "0_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";
@@ -119,6 +122,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+			"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 		};
 	};
 	i2c3_9: i2c3@9 {
@@ -134,6 +140,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "2_DRV1_PRESENCE", "2_DRV1_UUID", "2_DRV1_ACT",
+			"2_DRV2_PRESENCE", "2_DRV2_UUID", "2_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";
@@ -185,6 +194,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "3_DRV1_PRESENCE", "3_DRV1_UUID", "3_DRV1_ACT",
+			"3_DRV2_PRESENCE", "3_DRV2_UUID", "3_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0249.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0249.dtso
@@ -40,6 +40,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -91,6 +94,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -142,6 +148,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -193,6 +202,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -244,6 +256,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -295,6 +310,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -346,6 +364,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -397,6 +418,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x024a.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x024a.dtso
@@ -68,6 +68,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "0_DRV1_PRESENCE", "0_DRV1_UUID", "0_DRV1_ACT",
+			"0_DRV2_PRESENCE", "0_DRV2_UUID", "0_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";
@@ -119,6 +122,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+			"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 		};
 	};
 	i2c3_9: i2c3@9 {
@@ -134,6 +140,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "2_DRV1_PRESENCE", "2_DRV1_UUID", "2_DRV1_ACT",
+			"2_DRV2_PRESENCE", "2_DRV2_UUID", "2_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";
@@ -185,6 +194,9 @@ i2cmux3: i2cmux@3 {
 			compatible = "ubm4";
 			vcc-supply = <&host_power>;
 			reg = <0x40>;
+			#gpio-cells = <2>;
+			gpio-line-names = "3_DRV1_PRESENCE", "3_DRV1_UUID", "3_DRV1_ACT",
+			"3_DRV2_PRESENCE", "3_DRV2_UUID", "3_DRV2_ACT";
 		};
 		switch@72 {
 			compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0250.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0250.dtso
@@ -25,6 +25,9 @@
                 compatible = "ubm4";
                 vcc-supply = <&host_power>;
                 reg = <0x40>;
+                #gpio-cells = <2>;
+                gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+                "1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
             };
             switch@72 {
                 compatible = "nxp,pca9546";
@@ -76,6 +79,9 @@
                 compatible = "ubm4";
                 vcc-supply = <&host_power>;
                 reg = <0x40>;
+                #gpio-cells = <2>;
+                gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+                "2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
             };
             switch@72 {
                 compatible = "nxp,pca9546";
@@ -127,6 +133,9 @@
                 compatible = "ubm4";
                 vcc-supply = <&host_power>;
                 reg = <0x40>;
+                #gpio-cells = <2>;
+                gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+                "3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
             };
             switch@72 {
                 compatible = "nxp,pca9546";
@@ -178,6 +187,9 @@
                 compatible = "ubm4";
                 vcc-supply = <&host_power>;
                 reg = <0x40>;
+                #gpio-cells = <2>;
+                gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+                "4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
             };
             switch@72 {
                 compatible = "nxp,pca9546";
@@ -236,6 +248,9 @@
                 compatible = "ubm4";
                 vcc-supply = <&host_power>;
                 reg = <0x40>;
+                #gpio-cells = <2>;
+                gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+                "5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
             };
             switch@72 {
                 compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0261.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0261.dtso
@@ -41,6 +41,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "0_DRV1_PRESENCE", "0_DRV1_UUID", "0_DRV1_ACT",
+						  "0_DRV2_PRESENCE", "0_DRV2_UUID", "0_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -92,6 +95,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+						  "1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 		};
 		i2c3_9: i2c3@9 {
@@ -107,6 +113,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV1_PRESENCE", "2_DRV1_UUID", "2_DRV1_ACT",
+						  "2_DRV2_PRESENCE", "2_DRV2_UUID", "2_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -158,6 +167,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV1_PRESENCE", "3_DRV1_UUID", "3_DRV1_ACT",
+						  "3_DRV2_PRESENCE", "3_DRV2_UUID", "3_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0263.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0263.dtso
@@ -41,6 +41,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "0_DRV1_PRESENCE", "0_DRV1_UUID", "0_DRV1_ACT",
+						  "0_DRV2_PRESENCE", "0_DRV2_UUID", "0_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -92,6 +95,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+						  "1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 		};
 		i2c3_9: i2c3@9 {
@@ -107,6 +113,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV1_PRESENCE", "2_DRV1_UUID", "2_DRV1_ACT",
+						  "2_DRV2_PRESENCE", "2_DRV2_UUID", "2_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -158,6 +167,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV1_PRESENCE", "3_DRV1_UUID", "3_DRV1_ACT",
+						  "3_DRV2_PRESENCE", "3_DRV2_UUID", "3_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0264.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0264.dtso
@@ -26,6 +26,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "0_DRV1_PRESENCE", "0_DRV1_UUID", "0_DRV1_ACT",
+						  "0_DRV2_PRESENCE", "0_DRV2_UUID", "0_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -77,6 +80,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+						  "1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 		};
 		i2c3_9: i2c3@9 {
@@ -92,6 +98,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV1_PRESENCE", "2_DRV1_UUID", "2_DRV1_ACT",
+						  "2_DRV2_PRESENCE", "2_DRV2_UUID", "2_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -143,6 +152,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV1_PRESENCE", "3_DRV1_UUID", "3_DRV1_ACT",
+						  "3_DRV2_PRESENCE", "3_DRV2_UUID", "3_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0271.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0271.dtso
@@ -209,6 +209,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+				"1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -260,6 +263,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV3_PRESENCE", "2_DRV3_UUID", "2_DRV3_ACT",
+				"2_DRV4_PRESENCE", "2_DRV4_UUID", "2_DRV4_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -311,6 +317,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV5_PRESENCE", "3_DRV5_UUID", "3_DRV5_ACT",
+				"3_DRV6_PRESENCE", "3_DRV6_UUID", "3_DRV6_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -362,6 +371,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "4_DRV7_PRESENCE", "4_DRV7_UUID", "4_DRV7_ACT",
+				"4_DRV8_PRESENCE", "4_DRV8_UUID", "4_DRV8_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -413,6 +425,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "5_DRV9_PRESENCE", "5_DRV9_UUID", "5_DRV9_ACT",
+				"5_DRV10_PRESENCE", "5_DRV10_UUID", "5_DRV10_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -464,6 +479,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "6_DRV11_PRESENCE", "6_DRV11_UUID", "6_DRV11_ACT",
+				"6_DRV12_PRESENCE", "6_DRV12_UUID", "6_DRV12_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -515,6 +533,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "7_DRV13_PRESENCE", "7_DRV13_UUID", "7_DRV13_ACT",
+				"7_DRV14_PRESENCE", "7_DRV14_UUID", "7_DRV14_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -566,6 +587,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "8_DRV15_PRESENCE", "8_DRV15_UUID", "8_DRV15_ACT",
+				"8_DRV16_PRESENCE", "8_DRV16_UUID", "8_DRV16_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -617,6 +641,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "9_DRV17_PRESENCE", "9_DRV17_UUID", "9_DRV17_ACT",
+				"9_DRV18_PRESENCE", "9_DRV18_UUID", "9_DRV18_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -668,6 +695,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "10_DRV19_PRESENCE", "10_DRV19_UUID", "10_DRV19_ACT",
+				"10_DRV20_PRESENCE", "10_DRV20_UUID", "10_DRV20_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -719,6 +749,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "11_DRV21_PRESENCE", "11_DRV21_UUID", "11_DRV21_ACT",
+				"11_DRV22_PRESENCE", "11_DRV22_UUID", "11_DRV22_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -770,6 +803,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "12_DRV23_PRESENCE", "12_DRV23_UUID", "12_DRV23_ACT",
+				"12_DRV24_PRESENCE", "12_DRV24_UUID", "12_DRV24_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -828,6 +864,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "13_DRV25_PRESENCE", "13_DRV25_UUID", "13_DRV25_ACT",
+				"13_DRV26_PRESENCE", "13_DRV26_UUID", "13_DRV26_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -879,6 +918,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "14_DRV27_PRESENCE", "14_DRV27_UUID", "14_DRV27_ACT",
+				"14_DRV28_PRESENCE", "14_DRV28_UUID", "14_DRV28_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -930,6 +972,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "15_DRV29_PRESENCE", "15_DRV29_UUID", "15_DRV29_ACT",
+				"15_DRV30_PRESENCE", "15_DRV30_UUID", "15_DRV30_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -981,6 +1026,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "16_DRV31_PRESENCE", "16_DRV31_UUID", "16_DRV31_ACT",
+				"16_DRV32_PRESENCE", "16_DRV32_UUID", "16_DRV32_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0273.dtso
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable/gxp-0x0273.dtso
@@ -26,6 +26,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "0_DRV1_PRESENCE", "0_DRV1_UUID", "0_DRV1_ACT",
+						  "0_DRV2_PRESENCE", "0_DRV2_UUID", "0_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -77,6 +80,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "1_DRV1_PRESENCE", "1_DRV1_UUID", "1_DRV1_ACT",
+						  "1_DRV2_PRESENCE", "1_DRV2_UUID", "1_DRV2_ACT";
 			};
 		};
 		i2c3_9: i2c3@9 {
@@ -92,6 +98,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "2_DRV1_PRESENCE", "2_DRV1_UUID", "2_DRV1_ACT",
+						  "2_DRV2_PRESENCE", "2_DRV2_UUID", "2_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";
@@ -143,6 +152,9 @@
 				compatible = "ubm4";
 				vcc-supply = <&host_power>;
 				reg = <0x40>;
+				#gpio-cells = <2>;
+				gpio-line-names = "3_DRV1_PRESENCE", "3_DRV1_UUID", "3_DRV1_ACT",
+						  "3_DRV2_PRESENCE", "3_DRV2_UUID", "3_DRV2_ACT";
 			};
 			switch@72 {
 				compatible = "nxp,pca9546";


### PR DESCRIPTION
Commit 01047d4 removed the gpio cells and line names although they were still used by the LED drivers:

```
[    1.171634] OF: /ahb@80000000/leddrv60/uid: could not get #gpio-cells for /ahb@80000000/i2cmux@6/i2c6@4/ubm@40
[    1.181725] leds-gpio ahb@80000000:leddrv60: error -EINVAL: Failed to get GPIO '/ahb@80000000/leddrv60/uid'
[    1.191494] leds-gpio ahb@80000000:leddrv60: probe with driver leds-gpio failed with error -22
[    1.200156] OF: /ahb@80000000/leddrv59/uid: could not get #gpio-cells for /ahb@80000000/i2cmux@6/i2c6@4/ubm@40
[    1.210191] leds-gpio ahb@80000000:leddrv59: error -EINVAL: Failed to get GPIO '/ahb@80000000/leddrv59/uid'
[    1.219947] leds-gpio ahb@80000000:leddrv59: probe with driver leds-gpio failed with error -22
[    1.228657] OF: /ahb@80000000/leddrv58/uid: could not get #gpio-cells for /ahb@80000000/i2cmux@6/i2c6@3/ubm@40
[    1.238693] leds-gpio ahb@80000000:leddrv58: error -EINVAL: Failed to get GPIO '/ahb@80000000/leddrv58/uid'
[    1.248447] leds-gpio ahb@80000000:leddrv58: probe with driver leds-gpio failed with error -22
[    1.257107] OF: /ahb@80000000/leddrv57/uid: could not get #gpio-cells for /ahb@80000000/i2cmux@6/i2c6@3/ubm@40
```

Re-add those again, although they aren't used by the driver.

Fixes: 01047d4 ("meta-hpe: kernel: add UBM backplane init driver")

Closes #169 