### PR TITLE
feat: upload SBOM as artifact into the CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -48,3 +48,9 @@ runs:
         name: obmc-phosphor-image-${{ inputs.board }}
         path: build/${{ inputs.board }}/tmp/deploy/images/${{ inputs.board }}/obmc-phosphor-image-${{ inputs.board }}.*static.mtd
 
+    - name: Upload SBOM
+      uses: actions/upload-artifact@v4
+      with:
+        name: sbom-${{ inputs.board }}
+        path: build/${{ inputs.board }}/tmp/deploy/images/${{ inputs.board }}/obmc-phosphor-image-${{ inputs.board }}.spdx.json
+


### PR DESCRIPTION
We should expose the SBOM files as artifacts per platform as well.