### PR TITLE
ci: update-openbmc: fix command and repo-token

### DIFF
--- a/.github/workflows/update-openbmc.yml
+++ b/.github/workflows/update-openbmc.yml
@@ -17,6 +17,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up branch
         run: |
@@ -28,7 +29,7 @@ jobs:
           git checkout update_openbmc_action
 
       - name: Run obmc-bump
-        run: go-task -y obmc-bump
+        run: task -y obmc-bump
 
       - name: Push branch
         run: git push origin update_openbmc_action --force


### PR DESCRIPTION
The GitHub self-hosted runners sometimes run into API rate limits in unauthenticated mode.

Also, the binary is called task instead of go-task with the setup-task action.

Fixes: 0690bf23 ("ci: add weekly openbmc bump job")