### PR TITLE
CI: update-openbmc and build fixes

### DIFF
--- a/.github/workflows/build-canopy-qemu.yml
+++ b/.github/workflows/build-canopy-qemu.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'openbmc/**'
+      - 'openbmc'
       - 'meta-canopy/**'
       - '.github/**'
       - '.firmwareci/**'
@@ -14,7 +14,7 @@ on:
     branches:
       - main
     paths:
-      - 'openbmc/**'
+      - 'openbmc'
       - 'meta-canopy/**'
       - '.github/**'
       - '.firmwareci/**'

--- a/.github/workflows/build-hpe-proliant-g11.yml
+++ b/.github/workflows/build-hpe-proliant-g11.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'openbmc/**'
+      - 'openbmc'
       - 'meta-canopy/**'
       - '.github/**'
       - '.firmwareci/**'
@@ -14,7 +14,7 @@ on:
     branches:
       - main
     paths:
-      - 'openbmc/**'
+      - 'openbmc'
       - 'meta-canopy/**'
       - '.github/**'
       - '.firmwareci/**'

--- a/.github/workflows/update-openbmc.yml
+++ b/.github/workflows/update-openbmc.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   update-openbmc:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-openbmc.yml
+++ b/.github/workflows/update-openbmc.yml
@@ -24,10 +24,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git branch -D rebase/openbmc 2>/dev/null || true
           git fetch origin
-          git branch rebase/openbmc
-          git checkout rebase/openbmc
+          git branch -D rebase/openbmc 2>/dev/null || true
 
       - name: Run obmc-bump
         run: task -y obmc-bump
@@ -43,8 +41,8 @@ jobs:
           ```
           BODYEOF
 
-          git log -1 --pretty=%B >> "$BODY_FILE"
-          echo "```" >> "$BODY_FILE"
+          git log -1 --pretty=%B origin/rebase/openbmc >> "$BODY_FILE"
+          echo '```' >> "$BODY_FILE"
 
           gh pr create \
             --head rebase/openbmc \


### PR DESCRIPTION
This PR fixes three issues:
- update-openbmc: request the missing write permissions for branches and pull requests
- update-openbmc: fix the broken markdown block thingy (back-ticks are being interpreted as command execution, before `$()` was a thing. Single quotes prevent this ^^)
- build (canopy-qemu, hpe-proliant-g11): fix trigger for submodule-only commits