### PR TITLE
meta-hpe: bmcweb: increase http body limit

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -1,1 +1,5 @@
 PACKAGECONFIG:append = " redfish-allow-deprecated-power-thermal"
+
+EXTRA_OEMESON:append = " \
+    -Dhttp-body-limit=64 \
+"


### PR DESCRIPTION
The BIOS flash chip is 64M (512Mb). An uncompressed tar file would exceed the default 30M body limit.

Set it to the max possible value, allowing an upload of a full BMC and BIOS update.

**Note:** This PR is a prerequisite for an upcoming PR to fix the U-Boot environment leakage.