### PR TITLE
Add IPMI test cases for HPE ProLiant Gen11 and implements OpenBMC ipmi fixes

### DIFF
--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/01-service-health.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/01-service-health.yaml
@@ -1,0 +1,40 @@
+name: "Smoke: Service Health"
+description: >-
+  Verify all critical IPMI services are running.
+  Each step checks one systemd unit via systemctl is-active.
+
+defaults:
+  transport: &bmc_ssh
+    proto: ssh
+    options:
+      host: "[[attributes.BMC]]"
+      user: "root"
+      password: "[[attributes.BMCPassword]]"
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for SSH
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Critical Services Running
+    steps:
+      - cmd: shell
+        name: Ipmi Host service
+        transport: *bmc_ssh
+        parameters:
+          command: systemctl is-active phosphor-ipmi-host.service
+      - cmd: shell
+        name: Ipmi KCS service
+        transport: *bmc_ssh
+        parameters:
+          command: systemctl is-active phosphor-ipmi-kcs@ipmi_kcs1.service
+      - cmd: shell
+        name: Ipmi Log (SEL)
+        transport: *bmc_ssh
+        parameters:
+          command: systemctl is-active xyz.openbmc_project.Logging.IPMI

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/02-app-global.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/02-app-global.yaml
@@ -1,0 +1,168 @@
+name: "IPMI: App - IPM Device Global Commands (NetFn 0x06)"
+description: >-
+  Verify IPM Device Global commands (Table G-1, §20): Get Device ID (01h),
+  Get Self Test Results (04h), Get/Set ACPI Power State (07h/06h), and
+  Get Device GUID (08h, the BMC device GUID).
+
+  Get/Set ACPI Power State (07h/06h) are currently unsupported on HPE ProLiant
+  Gen11.
+
+  Note: ipmitool 'mc guid' alias issues Get System GUID (37h), not Get Device
+  GUID (08h).
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Get Device ID
+    steps:
+      - cmd: shell
+        name: Get Device ID (0x06 0x01)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x01
+
+  - name: Get Self Test Results
+    steps:
+      - cmd: shell
+        name: Get Self Test Results (0x06 0x04)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x04
+
+  - name: ACPI Power State (unsupported on this platform)
+    steps:
+      - cmd: shell
+        name: Get ACPI Power State (0x06 0x07) rejected with 0xFF
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x07 2>&1 || true
+          expect:
+            - regex: 'rsp=0xff|Unspecified error'
+      - cmd: shell
+        name: Set ACPI Power State (0x06 0x06) - S0/G0 working, D0
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x06 0x00 0x00
+
+  - name: Get Device GUID
+    steps:
+      - cmd: shell
+        name: Get Device GUID (0x06 0x08)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x08
+
+  - name: Wait for SMBIOS System GUID source
+    steps:
+      - cmd: shell
+        name: Power host on so BIOS pushes SMBIOS (no-op if already on)
+        transport: *local
+        options:
+          timeout: "1m"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            chassis power on
+      - cmd: shell
+        name: Wait until smbios-mdr publishes a non-zero System UUID
+        transport: &bmc_ssh
+          proto: ssh
+          options:
+            host: "[[attributes.BMC]]"
+            user: "root"
+            password: "[[attributes.BMCPassword]]"
+        options:
+          timeout: "8m"
+        parameters:
+          command: >-
+            until busctl get-property xyz.openbmc_project.Smbios.MDR_V2
+            /xyz/openbmc_project/inventory/system/chassis/motherboard/bios
+            xyz.openbmc_project.Common.UUID UUID 2>/dev/null
+            | grep -qiE '[1-9a-f]'; do sleep 10; done;
+            echo "System GUID source ready:";
+            busctl get-property xyz.openbmc_project.Smbios.MDR_V2
+            /xyz/openbmc_project/inventory/system/chassis/motherboard/bios
+            xyz.openbmc_project.Common.UUID UUID
+          expect:
+            - regex: 'System GUID source ready'
+            - regex: 's "[0-9a-fA-F]'
+
+  - name: IPM Global via ipmitool Aliases
+    steps:
+      - cmd: shell
+        name: mc info (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            mc info
+          expect:
+            - regex: 'Device ID\s*:'
+            - regex: 'IPMI Version\s*:'
+      - cmd: shell
+        name: mc guid (alias, Get System GUID 0x37 from SMBIOS)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            mc guid
+          expect:
+            - regex: 'System GUID'
+      - cmd: shell
+        name: mc selftest is not implemented
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            mc selftest || exit 0
+          expect:
+            - regex: '^Selftest: not implemented$'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/03-app-watchdog.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/03-app-watchdog.yaml
@@ -1,0 +1,174 @@
+name: "IPMI: App - BMC Watchdog Timer Commands (NetFn 0x06)"
+description: >-
+  Validate BMC Watchdog Timer commands (Table G-1, §27): Get Watchdog Timer
+  (25h), Set Watchdog Timer (24h), and Reset Watchdog Timer (22h). The test
+  sets a 120-second countdown, resets it, verifies the value, then restores
+  the original 300-second default.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Get Watchdog Timer
+    steps:
+      - cmd: shell
+        name: Get Watchdog Timer (0x06 0x25)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x25
+
+  - name: Check for default Watchdog Timer value
+    steps:
+      - cmd: shell
+        name: Get Watchdog Timer (0x06 0x25)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x25
+          expect:
+            - regex: '[0-9a-f]{2} [0-9a-f]{2} [0-9a-f]{2} [0-9a-f]{2} b8 0b [0-9a-f]{2} [0-9a-f]{2}'
+
+  - name: Set Watchdog Timer
+    steps:
+      - cmd: shell
+        name: Set Watchdog Timer (0x06 0x24) - 120 seconds, no action
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x24
+            0x04 0x00 0x00 0x00 0xB0 0x04
+
+  - name: Reset Watchdog Timer
+    steps:
+      - cmd: shell
+        name: Reset Watchdog Timer (0x06 0x22)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x22
+
+  - name: Verify Watchdog Timer Configuration
+    steps:
+      - cmd: shell
+        name: Get Watchdog Timer to verify settings (0x06 0x25)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x25
+          expect:
+            - regex: '[0-9a-f]{2} [0-9a-f]{2} [0-9a-f]{2} [0-9a-f]{2} b0 04 [0-9a-f]{2} [0-9a-f]{2}'
+
+  - name: Verify Watchdog reached phosphor-watchdog on BMC
+    steps:
+      - cmd: shell
+        name: phosphor-watchdog D-Bus props reflect the IPMI Set (BMC-side)
+        transport: &bmc_ssh
+          proto: ssh
+          options:
+            host: "[[attributes.BMC]]"
+            user: "root"
+            password: "[[attributes.BMCPassword]]"
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            busctl get-property xyz.openbmc_project.Watchdog
+            /xyz/openbmc_project/watchdog/host0
+            xyz.openbmc_project.State.Watchdog
+            Interval Enabled ExpireAction CurrentTimerUse
+          expect:
+            - regex: 't 120000'
+            - regex: 'b true'
+            - regex: 'Action\.None'
+            - regex: 'TimerUse\.SMSOS'
+      - cmd: shell
+        name: phosphor-watchdog daemon is active (BMC-side)
+        transport: *bmc_ssh
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: systemctl is-active phosphor-watchdog.service
+          expect:
+            - regex: '^active$'
+      - cmd: shell
+        name: Expire-action to systemd-service map is configured (BMC-side)
+        transport: *bmc_ssh
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: systemctl cat phosphor-watchdog.service
+          expect:
+            - regex: 'Action\.HardReset=phosphor-watchdog-host-reset\.service'
+            - regex: 'Action\.PowerOff=phosphor-watchdog-host-poweroff\.service'
+            - regex: 'Action\.PowerCycle=phosphor-watchdog-host-powercycle\.service'
+
+  - name: Watchdog via ipmitool Alias
+    steps:
+      - cmd: shell
+        name: mc watchdog get (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            mc watchdog get
+          expect:
+            - regex: 'Watchdog Timer'
+            - regex: 'Initial Countdown:\s*120.0 sec'
+
+  - name: Restore Default Watchdog Timer
+    steps:
+      - cmd: shell
+        name: Set Watchdog Timer (0x06 0x24) - 300 seconds, no action
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x24
+            0x04 0x00 0x00 0x00 0xb8 0x0b

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
@@ -1,0 +1,264 @@
+name: "IPMI: App - BMC Device and Messaging Commands (NetFn 0x06)"
+description: >-
+  Verify BMC Device and Messaging commands (Table G-1, §22): Get BMC Global
+  Enables (2Fh), BT Interface Capabilities (36h), Get System GUID (37h),
+  Get Channel Auth Capabilities (38h), Get Session Info (3Dh), Get Channel
+  Access (41h), Get Channel Info (42h), Get User Access (44h), Get User Name
+  (46h), Get Channel Cipher Suites (54h), Get System Interface Capabilities
+  (57h), and Get System Info Parameters (59h). Commands that may not be
+  supported on all builds carry on-error: continue.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: BMC Global Enables
+    steps:
+      - cmd: shell
+        name: Get BMC Global Enables (0x06 0x2f)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x2f
+
+  - name: Interface Capabilities
+    steps:
+      - cmd: shell
+        name: Get BT Interface Capabilities (0x06 0x36)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x36
+      - cmd: shell
+        name: Get System Interface Capabilities (0x06 0x57)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x57 0x00
+
+  - name: System Identity and Authentication
+    steps:
+      - cmd: shell
+        name: Get System GUID (0x06 0x37)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x37
+          expect:
+            - regex: '^[0-9a-f]{2}( [0-9a-f]{2}){15}$'
+      - cmd: shell
+        name: Get Channel Auth Capabilities (0x06 0x38) - ch14 admin
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x38 0x0e 0x04
+
+  - name: Session Info
+    steps:
+      - cmd: shell
+        name: Get Session Info (0x06 0x3d) - current session
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x3d 0x00
+
+  - name: Channel and User Information
+    steps:
+      - cmd: shell
+        name: Get Channel Access (0x06 0x41) - ch1
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x41 0x01 0x00
+      - cmd: shell
+        name: Get Channel Info (0x06 0x42) - ch1
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x42 0x01
+      - cmd: shell
+        name: Get User Access (0x06 0x44) - ch1 user1
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x44 0x01 0x01
+      - cmd: shell
+        name: Get User Name (0x06 0x46) - user1
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x46 0x01
+      - cmd: shell
+        name: Get Channel Cipher Suites (0x06 0x54) - ch14 list index 0
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x54 0x0e 0x00 0x00
+
+  - name: System Info Parameters
+    steps:
+      - cmd: shell
+        name: Get System Info Parameters (0x06 0x59) - param0 set in progress
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x59 0x00 0x00 0x00
+
+  - name: Messaging via ipmitool Aliases
+    steps:
+      - cmd: shell
+        name: mc getenables (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            mc getenables
+          expect:
+            - regex: 'System Event Logging'
+      - cmd: shell
+        name: user list 1 (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            user list 1
+          expect:
+            - regex: 'Name'
+      - cmd: shell
+        name: user summary 1 (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            user summary 1
+          expect:
+            - regex: 'Maximum IDs'
+      - cmd: shell
+        name: channel info 1 (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            channel info 1
+          expect:
+            - regex: 'Channel 0x1 info'
+      - cmd: shell
+        name: channel info 15 (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            channel info 15
+          expect:
+            - regex: 'Channel 0xf info'
+            - regex: 'Channel Protocol Type\s*:\s*KCS'
+      - cmd: shell
+        name: channel authcap 1 4 (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            channel authcap 1 4
+          expect:
+            - regex: 'User level authentication'
+      - cmd: shell
+        name: channel getciphers ipmi 1 (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            channel getciphers ipmi 1
+          expect:
+            - regex: 'Integrity Alg'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
@@ -1,0 +1,221 @@
+name: "IPMI: Chassis Commands (NetFn 0x00)"
+description: >-
+  Validate non-destructive Chassis commands (Table G-1, §28): Get Chassis
+  Capabilities (00h), Get Chassis Status (01h), Chassis Identify (04h),
+  Set Chassis Capabilities (05h), Set Power Restore Policy (06h), Get System
+  Restart Cause (07h), Get/Set System Boot Options (09h/08h), Set Front Panel
+  Button Enables (0Ah), and Get POH Counter (0Fh). Power cycle is in
+  12-chassis-power-cycle.yaml.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Get Chassis Capabilities
+    steps:
+      - cmd: shell
+        name: Get Chassis Capabilities (0x00 0x00)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x00
+
+  - name: Get Chassis Status
+    steps:
+      - cmd: shell
+        name: Get Chassis Status (0x00 0x01)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x01
+
+  - name: Chassis Identify
+    steps:
+      - cmd: shell
+        name: Chassis Identify - Turn on for 15 seconds (0x00 0x04)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x04 0x0f 0x00
+      - cmd: shell
+        name: Chassis Identify - Turn off immediately (0x00 0x04)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x04 0x00 0x00
+
+  - name: Get System Restart Cause
+    steps:
+      - cmd: shell
+        name: Get System Restart Cause (0x00 0x07)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x07
+
+  - name: Get POH Counter
+    steps:
+      - cmd: shell
+        name: Get POH Counter (0x00 0x0f)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x0f
+          expect:
+            - regex: '^[0-9a-f]{2} '
+
+  - name: Get System Boot Options
+    steps:
+      - cmd: shell
+        name: Get Boot Options - Boot Flags (0x00 0x09)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x09 0x05 0x00 0x00
+
+  - name: Set System Boot Options
+    steps:
+      - cmd: shell
+        name: Set Boot Options - Boot from default device (0x00 0x08)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x08 0x05 0x80 0x00 0x00 0x00 0x00
+
+  - name: Set Power Restore Policy
+    steps:
+      - cmd: shell
+        name: Set Power Restore Policy - Restore previous (0x00 0x06)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x06 0x01
+
+  - name: Set Chassis Capabilities
+    steps:
+      - cmd: shell
+        name: Set Chassis Capabilities (0x00 0x05)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x05 0x03 0x20 0x20 0x20 0x20 0x20
+
+  - name: Set Front Panel Button Enables
+    steps:
+      - cmd: shell
+        name: Set Front Panel Enables - All enabled (0x00 0x0a)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x0a 0x00
+
+  - name: Chassis via ipmitool Aliases
+    steps:
+      - cmd: shell
+        name: chassis status (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            chassis status
+          expect:
+            - regex: 'System Power\s*:'
+      - cmd: shell
+        name: chassis restart_cause (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            chassis restart_cause
+          expect:
+            - regex: 'Restart Cause'
+      - cmd: shell
+        name: chassis poh (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            chassis poh
+          expect:
+            - regex: 'POH Counter'
+      - cmd: shell
+        name: chassis bootparam get 5 (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            chassis bootparam get 5
+          expect:
+            - regex: 'Boot parameter'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
@@ -1,12 +1,9 @@
-name: "IPMI: Sensor and Event Commands (NetFn 0x04)"
+name: "IPMI: Sensor Commands (NetFn 0x04)"
 description: >-
-  Verify Sensor/Event NetFn commands (Table G-1, §29/§35). Event commands:
-  Get Event Receiver (01h), Set Event Receiver (00h), and Platform Event
-  (02h). Sensor commands target sensor number 0x01 (SDR-assigned): Get Sensor
-  Reading (2Dh), Get Sensor Threshold (27h), and Get Sensor Type (2Fh). Set
-  Event Receiver and Platform Event require Operator/Administrator privilege
-  and carry on-error: continue; sensor commands carry on-error: continue as
-  sensor numbers are dynamically assigned.
+  Verify Sensor NetFn commands (Table G-1, §35). Sensor commands target sensor
+  number 0x01 (SDR-assigned): Get Sensor Reading (2Dh), Get Sensor Threshold
+  (27h), and Get Sensor Type (2Fh). All carry on-error: continue as sensor
+  numbers are dynamically assigned.
 
 defaults:
   transport: &local
@@ -21,47 +18,6 @@ stages:
           timeout: 5m
         parameters:
           host: "[[attributes.BMC]]"
-
-  - name: Event Receiver
-    steps:
-      - cmd: shell
-        name: Get Event Receiver (0x04 0x01)
-        transport: *local
-        options:
-          timeout: "30s"
-          on-error: continue
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x04 0x01
-          expect:
-            - regex: '^[0-9a-f]{2} [0-9a-f]{2}$'
-      - cmd: shell
-        name: Set Event Receiver (0x04 0x00) - BMC 0x20 LUN 0x00
-        transport: *local
-        options:
-          timeout: "30s"
-          on-error: continue
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x04 0x00 0x20 0x00
-
-  - name: Platform Event
-    steps:
-      - cmd: shell
-        name: Platform Event (0x04 0x02) - temperature sensor-specific event
-        transport: *local
-        options:
-          timeout: "30s"
-          on-error: continue
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x04 0x02 0x04 0x01 0x00 0x6f 0x00 0x00 0x00
 
   - name: Sensor Commands
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
@@ -1,0 +1,102 @@
+name: "IPMI: Sensor and Event Commands (NetFn 0x04)"
+description: >-
+  Verify Sensor/Event NetFn commands (Table G-1, §29/§35). Event commands:
+  Get Event Receiver (01h), Set Event Receiver (00h), and Platform Event
+  (02h). Sensor commands target sensor number 0x01 (SDR-assigned): Get Sensor
+  Reading (2Dh), Get Sensor Threshold (27h), and Get Sensor Type (2Fh). Set
+  Event Receiver and Platform Event require Operator/Administrator privilege
+  and carry on-error: continue; sensor commands carry on-error: continue as
+  sensor numbers are dynamically assigned.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Event Receiver
+    steps:
+      - cmd: shell
+        name: Get Event Receiver (0x04 0x01)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x04 0x01
+          expect:
+            - regex: '^[0-9a-f]{2} [0-9a-f]{2}$'
+      - cmd: shell
+        name: Set Event Receiver (0x04 0x00) - BMC 0x20 LUN 0x00
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x04 0x00 0x20 0x00
+
+  - name: Platform Event
+    steps:
+      - cmd: shell
+        name: Platform Event (0x04 0x02) - temperature sensor-specific event
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x04 0x02 0x04 0x01 0x00 0x6f 0x00 0x00 0x00
+
+  - name: Sensor Commands
+    steps:
+      - cmd: shell
+        name: Get Sensor Reading (0x04 0x2d) - sensor number 1
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x04 0x2d 0x01
+      - cmd: shell
+        name: Get Sensor Threshold (0x04 0x27) - sensor number 1
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x04 0x27 0x01
+      - cmd: shell
+        name: Get Sensor Type (0x04 0x2f) - sensor number 1
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x04 0x2f 0x01
+          expect:
+            - regex: '^[0-9a-f]{2}'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/07-fru.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/07-fru.yaml
@@ -1,0 +1,160 @@
+name: "IPMI: FRU Inventory"
+description: >-
+  Verify FRU inventory commands (Table G-1, §34): Get FRU Inventory Area Info
+  (10h) and Read FRU Data (11h). HPE ProLiant Gen11 has no physical FRU EEPROMs;
+  fru-synthesizer builds FRU images from device-tree VPD (baseboard) and host
+  SMBIOS (CPU/DIMM), fru-device publishes them via xyz.openbmc_project.FruDevice,
+  and phosphor-ipmi-host's dbus-sdr handlers serve them over IPMI.
+  FRU device 0 is the baseboard (Rack Mount chassis); it is available without the
+  host. CPU/DIMM FRUs come from SMBIOS, so this test powers the host on and waits
+  for the synthetic FRU files to appear before asserting on them.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: FRU Inventory Area Info
+    steps:
+      - cmd: shell
+        name: Get FRU Inventory Area Info (0x0a 0x10) - FRU device 0
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x10 0x00
+
+  - name: Read FRU Data
+    steps:
+      - cmd: shell
+        name: Read FRU Data (0x0a 0x11) - FRU 0 offset 0 8 bytes
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x11 0x00 0x00 0x00 0x08
+
+  - name: Baseboard FRU Values (device 0)
+    steps:
+      - cmd: shell
+        name: fru print 0 - baseboard from device-tree VPD
+        transport: *local
+        options:
+          timeout: "1m"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            fru print 0
+          expect:
+            # Rack Mount chassis area is what makes the baseboard FRU device 0.
+            - regex: 'Chassis Type\s*:\s*Rack Mount Chassis'
+            - regex: 'Board Mfg\s*:\s*\S'
+            - regex: 'Board Product\s*:\s*\S'
+            - regex: 'Board Serial\s*:\s*\S'
+
+  - name: Power on host for SMBIOS-sourced FRU
+    steps:
+      - cmd: shell
+        name: Chassis power on (no-op if already on)
+        transport: *local
+        options:
+          timeout: "1m"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            chassis power on
+
+  - name: Wait for CPU and DIMM synthetic FRUs
+    steps:
+      - cmd: shell
+        name: Wait until fru-synthesizer has written a CPU and a DIMM FRU
+        transport: &bmc_ssh
+          proto: ssh
+          options:
+            host: "[[attributes.BMC]]"
+            user: "root"
+            password: "[[attributes.BMCPassword]]"
+        options:
+          timeout: "8m"
+        parameters:
+          command: >-
+            until ls /etc/fru/254-*.fru.bin >/dev/null 2>&1 &&
+            ls /etc/fru/255-*.fru.bin >/dev/null 2>&1; do sleep 5; done
+
+  - name: fru-synthesizer Service
+    steps:
+      - cmd: shell
+        name: fru-synthesizer is active
+        transport: *bmc_ssh
+        options:
+          timeout: "30s"
+        parameters:
+          command: systemctl is-active fru-synthesizer.service
+
+  - name: CPU FRU present
+    steps:
+      - cmd: shell
+        name: At least one CPU FRU (bus 254) generated from SMBIOS
+        transport: *bmc_ssh
+        options:
+          timeout: "30s"
+        parameters:
+          command: ls -1 /etc/fru/254-*.fru.bin
+          expect:
+            - regex: '254-[0-9]+\.fru\.bin'
+
+  - name: DIMM FRU present
+    steps:
+      - cmd: shell
+        name: At least one DIMM FRU (bus 255) generated from SMBIOS
+        transport: *bmc_ssh
+        options:
+          timeout: "30s"
+        parameters:
+          command: ls -1 /etc/fru/255-*.fru.bin
+          expect:
+            - regex: '255-[0-9]+\.fru\.bin'
+
+  - name: IPMI serves baseboard, CPU and DIMM
+    steps:
+      - cmd: shell
+        name: At least 3 FRU devices enumerated (baseboard + CPU + DIMM)
+        transport: *local
+        options:
+          timeout: "1m"
+        parameters:
+          command: >-
+            test "$(ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            fru print | grep -c 'FRU Device Description')" -ge 3
+      - cmd: shell
+        name: Product-area FRU fields present over IPMI
+        transport: *local
+        options:
+          timeout: "1m"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            fru print
+          expect:
+            - regex: 'Product Manufacturer\s*:\s*\S'
+            - regex: 'Product Name\s*:\s*\S'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/08-sdr.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/08-sdr.yaml
@@ -1,0 +1,115 @@
+name: "IPMI: SDR Repository Commands (NetFn 0x0a)"
+description: >-
+  Verify SDR Repository commands (Table G-1, §33): Get SDR Repository Info
+  (20h), Get SDR Repository Allocation Info (21h), Reserve SDR Repository
+  (22h), Get SDR (23h, first record header), and Get SDR Repository Time
+  (28h). Allocation Info and Repository Time carry on-error: continue as they
+  are not universally implemented.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Get SDR Repository Info
+    steps:
+      - cmd: shell
+        name: Get SDR Repository Info (0x0a 0x20)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x20
+
+  - name: Get SDR Repository Allocation Info
+    steps:
+      - cmd: shell
+        name: Get SDR Repository Allocation Info (0x0a 0x21)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x21
+
+  - name: Reserve SDR Repository
+    steps:
+      - cmd: shell
+        name: Reserve SDR Repository (0x0a 0x22)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x22
+
+  - name: Get SDR
+    steps:
+      - cmd: shell
+        name: Get SDR (0x0a 0x23) - first record header (5 bytes)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x23 0x00 0x00 0x00 0x00 0x00 0x05
+
+  - name: SDR Repository Time
+    steps:
+      - cmd: shell
+        name: Get SDR Repository Time (0x0a 0x28)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x28
+
+  - name: SDR Repository via ipmitool Aliases
+    steps:
+      - cmd: shell
+        name: sdr info (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            sdr info
+          expect:
+            - regex: 'Record Count\s*:'
+      - cmd: shell
+        name: sdr list (alias - enumerates all sensor records)
+        transport: *local
+        options:
+          timeout: "3m"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            sdr list
+          expect:
+            - regex: '\|'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/09-sel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/09-sel.yaml
@@ -1,0 +1,200 @@
+name: "IPMI: SEL Commands (NetFn 0x0a)"
+description: >-
+  Verify System Event Log commands (Table G-1, §31): Get SEL Info (40h), Get
+  SEL Allocation Info (41h), Reserve SEL (42h), Get SEL Entry (43h), Add SEL
+  Entry (44h), Partial Add SEL Entry (45h), Delete SEL Entry (46h), Clear SEL
+  (47h), Get/Set SEL Time (48h/49h), and Get SEL Time UTC Offset (5Ch). Set
+  SEL Time, Delete, Partial Add, Allocation Info, and UTC Offset carry
+  on-error: continue. Clear SEL runs last using a fresh reservation.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Get SEL Info
+    steps:
+      - cmd: shell
+        name: Get SEL Info (0x0a 0x40)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x40
+
+  - name: Reserve SEL
+    steps:
+      - cmd: shell
+        name: Reserve SEL (0x0a 0x42)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x42
+
+  - name: Add SEL Entry
+    steps:
+      - cmd: shell
+        name: Add SEL Entry (0x0a 0x44) - test system event record
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x44
+            0xff 0xff 0x02 0x00 0x00 0x00 0x00
+            0x20 0x00 0x04 0x01 0x01 0x00 0x00 0x00 0x00
+
+  - name: Get SEL Entry
+    steps:
+      - cmd: shell
+        name: Get SEL Entry (0x0a 0x43) - last record
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x43 0x00 0x00 0xff 0xff 0x00 0xff
+      - cmd: shell
+        name: Partial Add SEL Entry (0x0a 0x45)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x45 0x00 0x00 0xff 0xff 0x00 0xff
+
+  - name: SEL Time
+    steps:
+      - cmd: shell
+        name: Get SEL Time (0x0a 0x48)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x48
+      - cmd: shell
+        name: Set SEL Time (0x0a 0x49)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x49 0x00 0x00 0x00 0x00
+      - cmd: shell
+        name: Get SEL Time UTC Offset (0x0a 0x5c)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x5c
+
+  - name: SEL Management
+    steps:
+      - cmd: shell
+        name: Get SEL Allocation Info (0x0a 0x41)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x41
+      - cmd: shell
+        name: Delete SEL Entry (0x0a 0x46)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0a 0x46 0x00 0x00 0x01 0x00
+
+  - name: Clear SEL
+    steps:
+      - cmd: shell
+        name: Clear SEL (0x0a 0x47) - reserve then clear in one step
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            RES=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x0a 0x42);
+            ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x0a 0x47
+            $(echo "$RES" | awk '{print "0x"$1, "0x"$2}') 0x43 0x4c 0x52 0xaa
+
+  - name: SEL via ipmitool Aliases
+    steps:
+      - cmd: shell
+        name: sel info (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            sel info
+          expect:
+            - regex: 'Entries\s*:'
+      - cmd: shell
+        name: sel time get (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            sel time get
+          expect:
+            - regex: '[0-9]{4}'
+      - cmd: shell
+        name: sel list after clear (alias - expects empty)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            sel list
+          expect:
+            - regex: '(SEL has no entries|\|)'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/10-lan.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/10-lan.yaml
@@ -1,0 +1,94 @@
+name: "IPMI: LAN Configuration Commands (NetFn 0x0c)"
+description: >-
+  Verify Get LAN Configuration Parameter (0x0c 0x02) for key network
+  parameters on channel 1: IP address (param3), subnet mask (param6), MAC
+  address (param5), VLAN ID (param20), and cipher suite list (param17).
+  Cipher suite list carries on-error: continue as it may not be implemented
+  on all firmware builds.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: LAN Configuration - IP and Network
+    steps:
+      - cmd: shell
+        name: Get LAN Config IP Address (0x0c 0x02) - ch1 param3
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0c 0x02 0x01 0x03 0x00 0x00
+      - cmd: shell
+        name: Get LAN Config Subnet Mask (0x0c 0x02) - ch1 param6
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0c 0x02 0x01 0x06 0x00 0x00
+      - cmd: shell
+        name: Get LAN Config MAC Address (0x0c 0x02) - ch1 param5
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0c 0x02 0x01 0x05 0x00 0x00
+
+  - name: LAN Configuration - VLAN and Cipher
+    steps:
+      - cmd: shell
+        name: Get LAN Config VLAN ID (0x0c 0x02) - ch1 param20
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0c 0x02 0x01 0x14 0x00 0x00
+      - cmd: shell
+        name: Get LAN Config Cipher Suite List (0x0c 0x02) - ch1 param17
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x0c 0x02 0x01 0x11 0x00 0x00
+
+  - name: LAN Configuration via ipmitool Alias
+    steps:
+      - cmd: shell
+        name: lan print 1 (alias - full channel 1 LAN config)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            lan print 1
+          expect:
+            - regex: 'IP Address Source\s*:'
+            - regex: 'MAC Address\s*:'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/11-dcmi.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/11-dcmi.yaml
@@ -1,0 +1,178 @@
+name: "IPMI: DCMI Group Extension Commands (NetFn 0x2c, Group 0xDC)"
+description: >-
+  Verify DCMI 1.5 commands (group extension 0xDC). Get DCMI Capability Info,
+  Get Management Controller ID String, Get Temperature Reading, and Get Power
+  Reading are expected to work. Get DCMI Sensor Info (0x07), Get Asset Tag
+  (0x06), and Get Power Limit (0x03) carry on-error: continue as support
+  varies across firmware builds.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: DCMI Capability Info
+    steps:
+      - cmd: shell
+        name: Get DCMI Capability Info (0x2c 0x01) - platform capabilities
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x01 0xdc 0x01
+
+  - name: DCMI Sensor and Temperature
+    steps:
+      - cmd: shell
+        name: Get DCMI Sensor Info (0x2c 0x07) - temperature sensors
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x07 0xdc 0x01 0x40 0x01 0x01
+          expect:
+            - regex: '^[0-9a-f]'
+      - cmd: shell
+        name: Get Temperature Reading (0x2c 0x10) - inlet air entity
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x10 0xdc 0x01 0x40 0x01 0x00
+
+  - name: DCMI Management Info
+    steps:
+      - cmd: shell
+        name: Get Asset Tag (0x2c 0x06)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x06 0xdc 0x00 0x10
+      - cmd: shell
+        name: Get Management Controller ID String (0x2c 0x09)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x09 0xdc 0x00 0x10
+
+  - name: DCMI Power
+    steps:
+      - cmd: shell
+        name: Get DCMI Power Reading (0x2c 0x02) - current system power
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x02 0xdc 0x01 0x00 0x00
+      - cmd: shell
+        name: Get DCMI Power Limit (0x2c 0x03)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x03 0xdc 0x00 0x00
+          expect:
+            - regex: '^[0-9a-f]{2}'
+
+  - name: DCMI Configuration
+    steps:
+      - cmd: shell
+        name: Get DCMI Configuration Parameters (0x2c 0x13) - power reading
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x2c 0x13 0xdc 0x01 0x00
+
+  - name: DCMI via ipmitool Aliases
+    steps:
+      - cmd: shell
+        name: dcmi discover (alias - DCMI capabilities summary)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            dcmi discover
+          expect:
+            - regex: 'DCMI'
+      - cmd: shell
+        name: dcmi power reading (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            dcmi power reading
+          expect:
+            - regex: 'Watts'
+      - cmd: shell
+        name: dcmi get_mc_id_string (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            dcmi get_mc_id_string
+          expect:
+            - regex: 'Management Controller ID'
+      - cmd: shell
+        name: dcmi asset_tag (alias)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            dcmi asset_tag
+          expect:
+            - regex: 'Asset tag'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
@@ -1,0 +1,499 @@
+name: "IPMI: User Management Lifecycle (NetFn 0x06)"
+description: >-
+  Create an IPMI user (NetFn 0x06), confirm it works over IPMI LAN and is
+  visible/manageable in Redfish as an Administrator, then delete it and confirm
+  it is gone from both. Also regression-tests a non-contiguous slot (user in
+  slot 3 while slot 2 is empty), which previously left the user unusable and
+  unmanageable in Redfish. Note: IPMI-created users are listed and manageable
+  in Redfish but cannot log in over Redfish, so usability is checked over IPMI.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Create User
+    steps:
+      - cmd: shell
+        name: Set User Name, slot 2 "fwcitest"
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x45 0x02
+            0x66 0x77 0x63 0x69 0x74 0x65 0x73 0x74 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+
+      - cmd: shell
+        name: Set User Password, slot 2, Testpass123
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x47 0x82 0x02
+            0x54 0x65 0x73 0x74 0x70 0x61 0x73 0x73
+            0x31 0x32 0x33
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+
+      - cmd: shell
+        name: Enable User - slot 2
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x47 0x82 0x01
+
+      - cmd: shell
+        name: Set User Access, slot 2, ch1, Administrator, IPMI msg
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x43 0xe1 0x02 0x04 0x00
+
+      - cmd: shell
+        name: Set User Privilege
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            user priv 2 0x03
+
+      - cmd: shell
+        name: Enable IPMI messaging for slot 2, ch1, administrator
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            channel setaccess 1 2 link=off callin=off ipmi=on privilege=0x4
+
+  - name: Verify User Exists
+    steps:
+      - cmd: shell
+        name: Get User Name slot 2, expect "fwcitest" bytes
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x46 0x02
+          expect:
+            - regex: '66 77 63 69 74 65 73 74'
+
+      - cmd: shell
+        name: Get User Access  - slot 2, ch1
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x44 0x01 0x02
+
+      - cmd: shell
+        name: user list 1 (alias) - slot 2 shows fwcitest as ADMINISTRATOR
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            user list 1
+          expect:
+            - regex: 'fwcitest'
+            - regex: 'ADMINISTRATOR'
+
+  - name: Verify Authentication
+    steps:
+      - cmd: shell
+        name: Login as fwcitest and run mc info
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U fwcitest -P Testpass123 -C 17 -L Administrator
+            mc info
+          expect:
+            - regex: 'Device ID\s*: [0-9]{2}'
+
+      - cmd: shell
+        name: Login as fwcitest at User privilege and run Get Device ID
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U fwcitest -P Testpass123 -C 17 -L Administrator
+            raw 0x06 0x01
+          expect:
+            - regex: '[0-9a-f]{2}'
+
+  - name: Verify User in Redfish
+    steps:
+      - cmd: shell
+        name: Account fwcitest visible in Redfish AccountService
+        transport: *local
+        options:
+          timeout: "60s"
+        parameters:
+          command: >-
+            i=0;
+            while [ $i -lt 20 ]; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}'
+            -u root:[[attributes.BMCPassword]]
+            https://[[attributes.BMC]]/redfish/v1/AccountService/Accounts/fwcitest);
+            [ "$CODE" = 200 ] && break;
+            i=$((i+1));
+            sleep 1;
+            done;
+            echo "Redfish GET fwcitest HTTP=$CODE";
+            test "$CODE" = 200
+
+      - cmd: shell
+        name: Account fwcitest has Administrator role and is enabled
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            https://[[attributes.BMC]]/redfish/v1/AccountService/Accounts/fwcitest
+          expect:
+            - regex: '"UserName": *"fwcitest"'
+            - regex: '"RoleId": *"Administrator"'
+            - regex: '"Enabled": *true'
+
+      - cmd: shell
+        name: Account fwcitest is manageable via Redfish (PATCH HTTP 200/204)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            curl -sk -o /dev/null -w '%{http_code}'
+            -u root:[[attributes.BMCPassword]]
+            -X PATCH -H 'Content-Type: application/json'
+            -d '{"Enabled":true}'
+            https://[[attributes.BMC]]/redfish/v1/AccountService/Accounts/fwcitest
+          expect:
+            - regex: '^(200|204)$'
+
+  - name: Delete User
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: Disable User  - slot 2
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x47 0x82 0x00
+      - cmd: shell
+        name: Downgrade User Access slot 2, ch1, User privilege
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x43 0x81 0x02 0x02 0x00
+      - cmd: shell
+        name: Clear User Name  - slot 2, 16 null bytes
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x45 0x02
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+
+  - name: Verify Deletion
+    steps:
+      - cmd: shell
+        name: Get User Name  - slot 2 should be all null bytes
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x46 0x02
+          expect:
+            - regex: '^(00 ?){8}'
+
+      - cmd: shell
+        name: Get User Access slot 2, ch1 should have no access
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x44 0x01 0x02
+
+  - name: Verify Deletion in Redfish
+    steps:
+      - cmd: shell
+        name: Account fwcitest removed from Redfish AccountService (HTTP 404)
+        transport: *local
+        options:
+          timeout: "60s"
+          on-error: continue
+        parameters:
+          command: >-
+            i=0;
+            while [ $i -lt 20 ]; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}'
+            -u root:[[attributes.BMCPassword]]
+            https://[[attributes.BMC]]/redfish/v1/AccountService/Accounts/fwcitest);
+            [ "$CODE" = 404 ] && break;
+            i=$((i+1));
+            sleep 1;
+            done;
+            echo "Redfish GET deleted fwcitest HTTP=$CODE";
+            test "$CODE" = 404
+
+  # ---------------------------------------------------------------------------
+  # Non-contiguous slot regression (issue: user created in a non-contiguous
+  # IPMI slot became unusable and invisible/unmanageable in Redfish).
+  # Slot 2 is empty at this point (deleted above), so creating in slot 3
+  # reproduces the "gap" condition. The user must remain usable over IPMI LAN
+  # and visible + manageable in Redfish with the Administrator role.
+  # ---------------------------------------------------------------------------
+  - name: Non-Contiguous Slot - Create in Slot 3 (slot 2 empty)
+    steps:
+      - cmd: shell
+        name: Set User Name, slot 3 "fwcigap"
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x45 0x03
+            0x66 0x77 0x63 0x69 0x67 0x61 0x70 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+
+      - cmd: shell
+        name: Set User Password, slot 3, GapUser789!
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x47 0x83 0x02
+            0x47 0x61 0x70 0x55 0x73 0x65 0x72 0x37
+            0x38 0x39 0x21
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+
+      - cmd: shell
+        name: Enable User - slot 3
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x47 0x83 0x01
+
+      - cmd: shell
+        name: Set User Access, slot 3, ch1, Administrator, IPMI msg
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x43 0xe1 0x03 0x04 0x00
+
+      - cmd: shell
+        name: Enable IPMI messaging for slot 3, ch1, administrator
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            channel setaccess 1 3 link=off callin=off ipmi=on privilege=0x4
+
+  - name: Non-Contiguous Slot - Verify on BMC (IPMI)
+    steps:
+      - cmd: shell
+        name: Get User Name slot 3, expect "fwcigap" bytes
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x46 0x03
+          expect:
+            - regex: '66 77 63 69 67 61 70'
+
+      - cmd: shell
+        name: Slot 2 still empty (confirms non-contiguous allocation)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x46 0x02
+          expect:
+            - regex: '^(00 ?){8}'
+
+      - cmd: shell
+        name: Login as fwcigap over LAN (slot 3 user is usable)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U fwcigap -P GapUser789! -C 17 -L Administrator
+            mc info
+          expect:
+            - regex: 'Device ID\s*: [0-9]{2}'
+
+  - name: Non-Contiguous Slot - Verify in Redfish
+    steps:
+      - cmd: shell
+        name: Account fwcigap visible in Redfish AccountService (HTTP 200)
+        transport: *local
+        options:
+          timeout: "60s"
+        parameters:
+          command: >-
+            i=0;
+            while [ $i -lt 20 ]; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}'
+            -u root:[[attributes.BMCPassword]]
+            https://[[attributes.BMC]]/redfish/v1/AccountService/Accounts/fwcigap);
+            [ "$CODE" = 200 ] && break;
+            i=$((i+1));
+            sleep 1;
+            done;
+            echo "Redfish GET fwcigap HTTP=$CODE";
+            test "$CODE" = 200
+
+      - cmd: shell
+        name: Account fwcigap has Administrator role and is enabled
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            https://[[attributes.BMC]]/redfish/v1/AccountService/Accounts/fwcigap
+          expect:
+            - regex: '"UserName": *"fwcigap"'
+            - regex: '"RoleId": *"Administrator"'
+            - regex: '"Enabled": *true'
+
+      - cmd: shell
+        name: Account fwcigap is manageable via Redfish (PATCH HTTP 200/204)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            curl -sk -o /dev/null -w '%{http_code}'
+            -u root:[[attributes.BMCPassword]]
+            -X PATCH -H 'Content-Type: application/json'
+            -d '{"Enabled":true}'
+            https://[[attributes.BMC]]/redfish/v1/AccountService/Accounts/fwcigap
+          expect:
+            - regex: '^(200|204)$'
+
+  - name: Non-Contiguous Slot - Cleanup
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: Disable User - slot 3
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x47 0x83 0x00
+      - cmd: shell
+        name: Downgrade User Access slot 3, ch1, User privilege
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x43 0x81 0x03 0x02 0x00
+      - cmd: shell
+        name: Clear User Name - slot 3, 16 null bytes
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x45 0x03
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/13-chassis-power-cycle.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/13-chassis-power-cycle.yaml
@@ -1,0 +1,124 @@
+name: "IPMI: Chassis Power Cycle"
+description: >-
+  Validate chassis power cycle via IPMI. Verifies the host is initially on,
+  sets the restore policy to always-on (0x02), powers the host off, confirms
+  it is off, powers it back on, then polls chassis status until bit 0 is set
+  again. Run this test last as it disrupts the host.
+
+defaults:
+  transport: &local
+    proto: local
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for IPMI LAN
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+
+  - name: Pre-condition Checks
+    steps:
+      - cmd: shell
+        name: Verify host is currently powered on (bit 0 of byte 0)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x01 | awk '{print $1}');
+            echo "power byte: 0x$S";
+            test $(( 0x$S & 1 )) -eq 1
+
+  - name: Set Restore Policy
+    steps:
+      - cmd: shell
+        name: Set power restore policy to always-on (0x00 0x06 0x02)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x06 0x02
+
+  - name: Power Down
+    steps:
+      - cmd: shell
+        name: Chassis Control - Power down (0x00 0x02 0x00)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x02 0x00
+      - cmd: shell
+        name: Wait for host to power down
+        transport: *local
+        options:
+          timeout: "35s"
+        parameters:
+          command: sleep 30
+      - cmd: shell
+        name: Verify host is powered off (bit 0 of byte 0 clear)
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x01 | awk '{print $1}');
+            echo "power byte: 0x$S";
+            test $(( 0x$S & 1 )) -eq 0
+
+  - name: Power On
+    steps:
+      - cmd: shell
+        name: Chassis Control - Power on (0x00 0x02 0x01)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x02 0x01
+
+  - name: Wait for Host to Come On
+    steps:
+      - cmd: shell
+        name: Poll chassis status until power-on bit is set (3 min timeout)
+        transport: *local
+        options:
+          timeout: "4m"
+        parameters:
+          command: >-
+            for i in $(seq 36); do
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x00 0x01 2>/dev/null | awk '{print $1}');
+            [ -n "$S" ] && [ $(( 0x$S & 1 )) -eq 1 ] && echo "host on (0x$S)" && exit 0;
+            sleep 5;
+            done; echo "timeout: host not on after 3 minutes"; exit 1
+
+  - name: Verify Host Is On
+    steps:
+      - cmd: shell
+        name: Chassis Status confirms power on (bit 0 of byte 0 set)
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x00 0x01 | awk '{print $1}');
+            echo "power byte: 0x$S";
+            test $(( 0x$S & 1 )) -eq 1

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/workflow.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/workflow.yaml
@@ -1,0 +1,3 @@
+name: hpe-dl320-g11-ipmi
+description: OpenBMC IPMI CI tests for HPE ProLiant DL320 Gen11 BMC
+runs-on: hpe-dl320

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/fru-synthesizer.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/fru-synthesizer.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Synthesize IPMI FRU data from D-Bus inventory
+Wants=xyz.openbmc_project.FruDevice.service
+After=xyz.openbmc_project.FruDevice.service
+After=xyz.openbmc_project.EntityManager.service
+
+[Service]
+ExecStart=/usr/bin/fru-synthesizer
+Restart=on-failure
+RestartSec=5
+SyslogIdentifier=fru-synthesizer
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/fru_encoder.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/fru_encoder.cpp
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "fru_encoder.hpp"
+
+namespace fru
+{
+
+namespace
+{
+
+constexpr uint8_t fruVersion = 0x01;
+constexpr uint8_t endOfFields = 0xC1;
+// Type/length code: type = 0b11 (ASCII + Latin 1), length in the low 6 bits.
+constexpr uint8_t typeAscii = 0xC0;
+constexpr size_t maxFieldLen = 63;
+constexpr size_t areaAlign = 8;
+
+void appendField(std::vector<uint8_t>& out, const std::optional<std::string>& v)
+{
+    if (!v || v->empty())
+    {
+        // Zero-length ASCII field.
+        out.push_back(typeAscii);
+        return;
+    }
+    std::string s = *v;
+    if (s.size() > maxFieldLen)
+    {
+        s.resize(maxFieldLen);
+    }
+    out.push_back(static_cast<uint8_t>(typeAscii | s.size()));
+    out.insert(out.end(), s.begin(), s.end());
+}
+
+// Two's-complement "zero" checksum over [begin, end): the byte that makes the
+// running sum of all bytes (including the checksum) equal zero mod 256.
+uint8_t zeroChecksum(const std::vector<uint8_t>& data, size_t begin, size_t end)
+{
+    uint8_t sum = 0;
+    for (size_t i = begin; i < end; i++)
+    {
+        sum = static_cast<uint8_t>(sum + data[i]);
+    }
+    return static_cast<uint8_t>(0U - sum);
+}
+
+// Append the end-of-fields marker, pad to a multiple of 8 (leaving room for the
+// checksum), write the area length, and append the checksum.
+void finalizeArea(std::vector<uint8_t>& area)
+{
+    area.push_back(endOfFields);
+    while (((area.size() + 1) % areaAlign) != 0)
+    {
+        area.push_back(0x00);
+    }
+    // Length field counts 8-byte blocks of the whole area, including checksum.
+    area[1] = static_cast<uint8_t>((area.size() + 1) / areaAlign);
+    area.push_back(zeroChecksum(area, 0, area.size()));
+}
+
+std::vector<uint8_t> buildChassisArea(const ChassisInfo& c)
+{
+    std::vector<uint8_t> a;
+    a.push_back(fruVersion);
+    a.push_back(0x00);    // length placeholder
+    a.push_back(c.type);  // chassis type (SMBIOS enclosure type)
+    appendField(a, c.partNumber);
+    appendField(a, c.serialNumber);
+    for (const auto& f : c.custom)
+    {
+        appendField(a, f);
+    }
+    finalizeArea(a);
+    return a;
+}
+
+std::vector<uint8_t> buildBoardArea(const BoardInfo& b)
+{
+    std::vector<uint8_t> a;
+    a.push_back(fruVersion);
+    a.push_back(0x00); // length placeholder
+    a.push_back(0x00); // language code: English
+    // Mfg date/time, 3 bytes, minutes since 1996-01-01; 0 = unspecified.
+    a.push_back(0x00);
+    a.push_back(0x00);
+    a.push_back(0x00);
+    appendField(a, b.manufacturer);
+    appendField(a, b.productName);
+    appendField(a, b.serialNumber);
+    appendField(a, b.partNumber);
+    appendField(a, b.fruFileId);
+    for (const auto& c : b.custom)
+    {
+        appendField(a, c);
+    }
+    finalizeArea(a);
+    return a;
+}
+
+std::vector<uint8_t> buildProductArea(const ProductInfo& p)
+{
+    std::vector<uint8_t> a;
+    a.push_back(fruVersion);
+    a.push_back(0x00); // length placeholder
+    a.push_back(0x00); // language code: English
+    appendField(a, p.manufacturer);
+    appendField(a, p.productName);
+    appendField(a, p.partNumber);
+    appendField(a, p.version);
+    appendField(a, p.serialNumber);
+    appendField(a, p.assetTag);
+    appendField(a, p.fruFileId);
+    for (const auto& c : p.custom)
+    {
+        appendField(a, c);
+    }
+    finalizeArea(a);
+    return a;
+}
+
+} // namespace
+
+std::vector<uint8_t> build(const std::optional<ChassisInfo>& chassis,
+                           const std::optional<BoardInfo>& board,
+                           const std::optional<ProductInfo>& product)
+{
+    std::vector<uint8_t> chassisArea;
+    std::vector<uint8_t> boardArea;
+    std::vector<uint8_t> productArea;
+    if (chassis)
+    {
+        chassisArea = buildChassisArea(*chassis);
+    }
+    if (board)
+    {
+        boardArea = buildBoardArea(*board);
+    }
+    if (product)
+    {
+        productArea = buildProductArea(*product);
+    }
+
+    std::vector<uint8_t> out(areaAlign, 0x00); // common header (8 bytes)
+    out[0] = fruVersion;
+
+    size_t blockOffset = 1; // header occupies the first 8-byte block
+    if (!chassisArea.empty())
+    {
+        out[2] = static_cast<uint8_t>(blockOffset);
+        blockOffset += chassisArea.size() / areaAlign;
+    }
+    if (!boardArea.empty())
+    {
+        out[3] = static_cast<uint8_t>(blockOffset);
+        blockOffset += boardArea.size() / areaAlign;
+    }
+    if (!productArea.empty())
+    {
+        out[4] = static_cast<uint8_t>(blockOffset);
+        blockOffset += productArea.size() / areaAlign;
+    }
+    out[7] = zeroChecksum(out, 0, 7);
+
+    out.insert(out.end(), chassisArea.begin(), chassisArea.end());
+    out.insert(out.end(), boardArea.begin(), boardArea.end());
+    out.insert(out.end(), productArea.begin(), productArea.end());
+    return out;
+}
+
+} // namespace fru

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/fru_encoder.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/fru_encoder.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Encoder for the IPMI Platform Management FRU Information Storage Definition
+// v1.0. Produces a binary FRU image (Common Header + optional Board area +
+// optional Product area) suitable for serving via xyz.openbmc_project.FruDevice
+// and the stock IPMI storage handlers.
+namespace fru
+{
+
+// Chassis Info Area. The numeric `type` is the SMBIOS System Enclosure type
+// (e.g. 23 = Rack Mount Chassis, 17 = Main Server Chassis). dbus-sdr assigns
+// IPMI FRU device id 0 to a FRU whose chassis type is rack-mount or main-server,
+// so the baseboard FRU should carry one of those.
+struct ChassisInfo
+{
+    uint8_t type = 0;
+    std::optional<std::string> partNumber;
+    std::optional<std::string> serialNumber;
+    std::vector<std::string> custom;
+};
+
+// String fields for the Board Info Area, in spec order. Unset/empty values are
+// encoded as zero-length ASCII fields.
+struct BoardInfo
+{
+    std::optional<std::string> manufacturer;
+    std::optional<std::string> productName;
+    std::optional<std::string> serialNumber;
+    std::optional<std::string> partNumber;
+    std::optional<std::string> fruFileId;
+    std::vector<std::string> custom;
+};
+
+// String fields for the Product Info Area, in spec order.
+struct ProductInfo
+{
+    std::optional<std::string> manufacturer;
+    std::optional<std::string> productName;
+    std::optional<std::string> partNumber; // a.k.a. model/part number
+    std::optional<std::string> version;
+    std::optional<std::string> serialNumber;
+    std::optional<std::string> assetTag;
+    std::optional<std::string> fruFileId;
+    std::vector<std::string> custom;
+};
+
+// Build a complete FRU image. Each present area is padded to a multiple of 8
+// bytes and terminated with a valid checksum; the common header offsets and
+// checksum are filled accordingly. Returns the binary blob.
+std::vector<uint8_t> build(const std::optional<ChassisInfo>& chassis,
+                           const std::optional<BoardInfo>& board,
+                           const std::optional<ProductInfo>& product);
+
+} // namespace fru

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/main.cpp
@@ -75,6 +75,10 @@ constexpr const char* fruDeviceMgrIntf =
 constexpr unsigned cpuBus = 254;
 constexpr unsigned dimmBus = 255;
 
+// Bound every blocking D-Bus call so a hung peer can't stall the
+// single-threaded regeneration loop indefinitely.
+constexpr auto dbusTimeout = std::chrono::seconds(30);
+
 using DbusValue =
     std::variant<bool, std::string, uint8_t, int16_t, uint16_t, int32_t,
                  uint32_t, int64_t, uint64_t, double, std::vector<std::string>>;
@@ -108,7 +112,7 @@ PropertyMap getAllProps(sdbusplus::bus_t& bus, const std::string& service,
         auto m = bus.new_method_call(service.c_str(), path.c_str(), propIntf,
                                      "GetAll");
         m.append(intf);
-        bus.call(m).read(props);
+        bus.call(m, dbusTimeout).read(props);
     }
     catch (const std::exception& e)
     {
@@ -127,7 +131,7 @@ SubTree getSubTree(sdbusplus::bus_t& bus, const std::string& intf)
                                      "GetSubTree");
         m.append(std::string(inventoryRoot), 0,
                  std::vector<std::string>{intf});
-        bus.call(m).read(tree);
+        bus.call(m, dbusTimeout).read(tree);
     }
     catch (const std::exception& e)
     {
@@ -431,7 +435,7 @@ void regenerate(sdbusplus::bus_t& bus)
     {
         auto m = bus.new_method_call(fruDeviceService, fruDevicePath,
                                      fruDeviceMgrIntf, "ReScan");
-        bus.call_noreply(m);
+        bus.call_noreply(m, dbusTimeout);
         lg2::info("Requested FruDevice ReScan");
     }
     catch (const std::exception& e)

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/main.cpp
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// fru-synthesizer: build IPMI FRU images from D-Bus inventory and publish them
+// through xyz.openbmc_project.FruDevice on platforms with no physical FRU
+// EEPROMs (e.g. HPE ProLiant Gen11).
+//
+//   * baseboard  <- xyz.openbmc_project.MachineContext (device-tree VPD)
+//   * cpuN/dimmN <- smbios-mdr inventory (host SMBIOS)
+//
+// FRU images are written to /etc/fru where the (patched) fru-device picks them
+// up: baseboard.fru.bin at bus 0/addr 0 (native), and "<bus>-<addr>.fru.bin"
+// for the rest. After writing, fru-device's ReScan is invoked so the stock IPMI
+// storage handlers serve the data.
+
+#include "fru_encoder.hpp"
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+#include <sdbusplus/message.hpp>
+
+#include <cctype>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+constexpr const char* fruDir = "/etc/fru";
+
+constexpr const char* mapperService = "xyz.openbmc_project.ObjectMapper";
+constexpr const char* mapperPath = "/xyz/openbmc_project/object_mapper";
+constexpr const char* mapperIntf = "xyz.openbmc_project.ObjectMapper";
+constexpr const char* propIntf = "org.freedesktop.DBus.Properties";
+
+constexpr const char* inventoryRoot = "/xyz/openbmc_project/inventory";
+
+constexpr const char* assetIntf = "xyz.openbmc_project.Inventory.Decorator.Asset";
+constexpr const char* assetTagIntf =
+    "xyz.openbmc_project.Inventory.Decorator.AssetTag";
+constexpr const char* itemIntf = "xyz.openbmc_project.Inventory.Item";
+constexpr const char* revisionIntf =
+    "xyz.openbmc_project.Inventory.Decorator.Revision";
+constexpr const char* cpuIntf = "xyz.openbmc_project.Inventory.Item.Cpu";
+constexpr const char* dimmIntf = "xyz.openbmc_project.Inventory.Item.Dimm";
+constexpr const char* chassisIntf =
+    "xyz.openbmc_project.Inventory.Item.Chassis";
+
+constexpr const char* entityManagerService =
+    "xyz.openbmc_project.EntityManager";
+constexpr const char* machineCtxService = "xyz.openbmc_project.MachineContext";
+constexpr const char* machineCtxPath = "/xyz/openbmc_project/MachineContext";
+constexpr const char* baseboardCtxPath =
+    "/xyz/openbmc_project/MachineContext/Baseboard";
+
+constexpr const char* fruDeviceService = "xyz.openbmc_project.FruDevice";
+constexpr const char* fruDevicePath = "/xyz/openbmc_project/FruDevice";
+constexpr const char* fruDeviceMgrIntf =
+    "xyz.openbmc_project.FruDeviceManager";
+
+// Virtual i2c bus numbers for synthetic FRU files (avoid bus 0 which is the
+// native baseboard slot). The per-device address is the inventory index.
+constexpr unsigned cpuBus = 254;
+constexpr unsigned dimmBus = 255;
+
+using DbusValue =
+    std::variant<bool, std::string, uint8_t, int16_t, uint16_t, int32_t,
+                 uint32_t, int64_t, uint64_t, double, std::vector<std::string>>;
+using PropertyMap = std::map<std::string, DbusValue>;
+using SubTree =
+    std::map<std::string, std::map<std::string, std::vector<std::string>>>;
+
+std::optional<std::string> getString(const PropertyMap& props,
+                                     const std::string& key)
+{
+    auto it = props.find(key);
+    if (it == props.end())
+    {
+        return std::nullopt;
+    }
+    const auto* s = std::get_if<std::string>(&it->second);
+    if (s == nullptr || s->empty())
+    {
+        return std::nullopt;
+    }
+    return *s;
+}
+
+// Read all properties of an interface from a specific owning service.
+PropertyMap getAllProps(sdbusplus::bus_t& bus, const std::string& service,
+                        const std::string& path, const std::string& intf)
+{
+    PropertyMap props;
+    try
+    {
+        auto m = bus.new_method_call(service.c_str(), path.c_str(), propIntf,
+                                     "GetAll");
+        m.append(intf);
+        bus.call(m).read(props);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::debug("GetAll failed for {PATH} {INTF}: {ERR}", "PATH", path,
+                   "INTF", intf, "ERR", e.what());
+    }
+    return props;
+}
+
+SubTree getSubTree(sdbusplus::bus_t& bus, const std::string& intf)
+{
+    SubTree tree;
+    try
+    {
+        auto m = bus.new_method_call(mapperService, mapperPath, mapperIntf,
+                                     "GetSubTree");
+        m.append(std::string(inventoryRoot), 0,
+                 std::vector<std::string>{intf});
+        bus.call(m).read(tree);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::debug("GetSubTree failed for {INTF}: {ERR}", "INTF", intf, "ERR",
+                   e.what());
+    }
+    return tree;
+}
+
+// Trailing decimal index of an inventory path (e.g. ".../dimm12" -> 12).
+std::optional<unsigned> trailingIndex(const std::string& path)
+{
+    size_t i = path.size();
+    while (i > 0 && (std::isdigit(static_cast<unsigned char>(path[i - 1])) != 0))
+    {
+        i--;
+    }
+    if (i == path.size())
+    {
+        return std::nullopt;
+    }
+    return static_cast<unsigned>(std::stoul(path.substr(i)));
+}
+
+std::vector<uint8_t> readFileBytes(const fs::path& path)
+{
+    std::ifstream f(path, std::ios::binary);
+    if (!f.good())
+    {
+        return {};
+    }
+    return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+}
+
+// ---- inventory -> FRU mappers -------------------------------------------
+
+std::optional<std::vector<uint8_t>> buildBaseboard(sdbusplus::bus_t& bus)
+{
+    std::optional<std::string> manufacturer;
+    std::optional<std::string> model;
+    std::optional<std::string> prettyName;
+    std::optional<std::string> part;
+    std::optional<std::string> serial;
+    std::optional<std::string> assetTag;
+
+    // Preferred source: the EntityManager chassis/baseboard object, which holds
+    // the curated asset data (manufacturer, model, part, serial, asset tag).
+    std::string emPath;
+    for (const auto& [path, owners] : getSubTree(bus, chassisIntf))
+    {
+        if (owners.contains(entityManagerService))
+        {
+            emPath = path;
+            break;
+        }
+    }
+
+    if (!emPath.empty())
+    {
+        PropertyMap asset =
+            getAllProps(bus, entityManagerService, emPath, assetIntf);
+        PropertyMap tag =
+            getAllProps(bus, entityManagerService, emPath, assetTagIntf);
+        PropertyMap item =
+            getAllProps(bus, entityManagerService, emPath, itemIntf);
+        manufacturer = getString(asset, "Manufacturer");
+        model = getString(asset, "Model");
+        part = getString(asset, "PartNumber");
+        serial = getString(asset, "SerialNumber");
+        assetTag = getString(tag, "AssetTag");
+        prettyName = getString(item, "PrettyName");
+    }
+    else
+    {
+        // Fallback: device-tree VPD via MachineContext (available before EM,
+        // e.g. early boot). PCA (baseboard) VPD wins for serial/part.
+        PropertyMap sys =
+            getAllProps(bus, machineCtxService, machineCtxPath, assetIntf);
+        PropertyMap bb =
+            getAllProps(bus, machineCtxService, baseboardCtxPath, assetIntf);
+        manufacturer = getString(sys, "Manufacturer");
+        model = getString(sys, "Model");
+        serial = getString(bb, "SerialNumber");
+        if (!serial)
+        {
+            serial = getString(sys, "SerialNumber");
+        }
+        part = getString(bb, "PartNumber");
+        if (!part)
+        {
+            part = getString(sys, "PartNumber");
+        }
+    }
+
+    if (!manufacturer && !model && !prettyName && !serial && !part)
+    {
+        return std::nullopt;
+    }
+
+    fru::BoardInfo board;
+    board.manufacturer = manufacturer;
+    board.productName = model ? model : prettyName;
+    board.serialNumber = serial;
+    board.partNumber = part;
+    board.fruFileId = "baseboard";
+
+    // A rack-mount chassis area makes dbus-sdr assign this FRU device id 0.
+    fru::ChassisInfo chassis;
+    chassis.type = 23; // Rack Mount Chassis (SMBIOS enclosure type)
+    chassis.partNumber = part;
+    chassis.serialNumber = serial;
+
+    // Emit a Product area only when there is curated data beyond the board
+    // fields to carry (asset tag); this keeps the device-tree fallback minimal.
+    std::optional<fru::ProductInfo> product;
+    if (assetTag)
+    {
+        fru::ProductInfo p;
+        p.manufacturer = manufacturer;
+        p.productName = model ? model : prettyName;
+        p.partNumber = part;
+        p.serialNumber = serial;
+        p.assetTag = assetTag;
+        product = std::move(p);
+    }
+
+    return fru::build(chassis, board, product);
+}
+
+std::optional<std::vector<uint8_t>> buildCpu(sdbusplus::bus_t& bus,
+                                             const std::string& service,
+                                             const std::string& path)
+{
+    PropertyMap asset = getAllProps(bus, service, path, assetIntf);
+    PropertyMap item = getAllProps(bus, service, path, itemIntf);
+    PropertyMap rev = getAllProps(bus, service, path, revisionIntf);
+
+    fru::BoardInfo board;
+    board.manufacturer = getString(asset, "Manufacturer");
+    board.productName = getString(item, "PrettyName");
+    if (!board.productName)
+    {
+        board.productName = getString(asset, "Model");
+    }
+    board.serialNumber = getString(asset, "SerialNumber");
+    board.partNumber = getString(asset, "PartNumber");
+    if (auto version = getString(rev, "Version"))
+    {
+        board.custom.push_back(*version);
+    }
+
+    if (!board.manufacturer && !board.productName && !board.serialNumber &&
+        !board.partNumber)
+    {
+        return std::nullopt;
+    }
+    return fru::build(std::nullopt, board, std::nullopt);
+}
+
+std::optional<std::vector<uint8_t>> buildDimm(sdbusplus::bus_t& bus,
+                                              const std::string& service,
+                                              const std::string& path)
+{
+    PropertyMap asset = getAllProps(bus, service, path, assetIntf);
+    PropertyMap item = getAllProps(bus, service, path, itemIntf);
+    PropertyMap rev = getAllProps(bus, service, path, revisionIntf);
+
+    fru::ProductInfo product;
+    product.manufacturer = getString(asset, "Manufacturer");
+    product.productName = getString(item, "PrettyName");
+    product.partNumber = getString(asset, "PartNumber");
+    if (!product.partNumber)
+    {
+        product.partNumber = getString(asset, "Model");
+    }
+    product.version = getString(rev, "Version");
+    product.serialNumber = getString(asset, "SerialNumber");
+
+    if (!product.manufacturer && !product.productName &&
+        !product.serialNumber && !product.partNumber)
+    {
+        return std::nullopt;
+    }
+    return fru::build(std::nullopt, std::nullopt, product);
+}
+
+// ---- regeneration --------------------------------------------------------
+
+bool isSyntheticFile(const std::string& name)
+{
+    if (name == "baseboard.fru.bin")
+    {
+        return true;
+    }
+    // "<bus>-<addr>.fru.bin"
+    size_t dash = name.find('-');
+    if (dash == std::string::npos || dash == 0)
+    {
+        return false;
+    }
+    if (!name.ends_with(".fru.bin"))
+    {
+        return false;
+    }
+    return true;
+}
+
+void regenerate(sdbusplus::bus_t& bus)
+{
+    std::error_code ec;
+    fs::create_directories(fruDir, ec);
+
+    std::map<std::string, std::vector<uint8_t>> desired;
+
+    if (auto bb = buildBaseboard(bus))
+    {
+        desired[std::string(fruDir) + "/baseboard.fru.bin"] = std::move(*bb);
+    }
+
+    for (const auto& [path, owners] : getSubTree(bus, cpuIntf))
+    {
+        if (owners.empty())
+        {
+            continue;
+        }
+        auto idx = trailingIndex(path);
+        if (!idx)
+        {
+            continue;
+        }
+        if (auto blob = buildCpu(bus, owners.begin()->first, path))
+        {
+            desired[std::string(fruDir) + "/" + std::to_string(cpuBus) + "-" +
+                    std::to_string(*idx) + ".fru.bin"] = std::move(*blob);
+        }
+    }
+
+    for (const auto& [path, owners] : getSubTree(bus, dimmIntf))
+    {
+        if (owners.empty())
+        {
+            continue;
+        }
+        auto idx = trailingIndex(path);
+        if (!idx)
+        {
+            continue;
+        }
+        if (auto blob = buildDimm(bus, owners.begin()->first, path))
+        {
+            desired[std::string(fruDir) + "/" + std::to_string(dimmBus) + "-" +
+                    std::to_string(*idx) + ".fru.bin"] = std::move(*blob);
+        }
+    }
+
+    bool changed = false;
+
+    // Write new/changed files.
+    for (const auto& [path, data] : desired)
+    {
+        if (readFileBytes(path) == data)
+        {
+            continue;
+        }
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        if (!out.good())
+        {
+            lg2::error("Unable to write {PATH}", "PATH", path);
+            continue;
+        }
+        out.write(reinterpret_cast<const char*>(data.data()),
+                  static_cast<std::streamsize>(data.size()));
+        changed = true;
+        lg2::info("Wrote FRU {PATH} ({SIZE} bytes)", "PATH", path, "SIZE",
+                  data.size());
+    }
+
+    // Remove synthetic files that are no longer present in inventory.
+    for (const auto& entry : fs::directory_iterator(fruDir, ec))
+    {
+        const std::string name = entry.path().filename().string();
+        if (!isSyntheticFile(name))
+        {
+            continue;
+        }
+        if (!desired.contains(entry.path().string()))
+        {
+            fs::remove(entry.path(), ec);
+            changed = true;
+            lg2::info("Removed stale FRU {PATH}", "PATH",
+                      entry.path().string());
+        }
+    }
+
+    if (!changed)
+    {
+        return;
+    }
+
+    try
+    {
+        auto m = bus.new_method_call(fruDeviceService, fruDevicePath,
+                                     fruDeviceMgrIntf, "ReScan");
+        bus.call_noreply(m);
+        lg2::info("Requested FruDevice ReScan");
+    }
+    catch (const std::exception& e)
+    {
+        lg2::warning("FruDevice ReScan failed (will retry on next event): {ERR}",
+                     "ERR", e.what());
+    }
+}
+
+} // namespace
+
+int main()
+{
+    boost::asio::io_context io;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+    conn->request_name("xyz.openbmc_project.FruSynthesizer");
+    auto& bus = static_cast<sdbusplus::bus_t&>(*conn);
+
+    // Debounce: collapse bursts of inventory signals into one regeneration.
+    boost::asio::steady_timer debounce(io);
+    auto schedule = [&]() {
+        debounce.expires_after(std::chrono::seconds(2));
+        debounce.async_wait([&](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                return; // cancelled by a newer event
+            }
+            regenerate(bus);
+        });
+    };
+
+    sdbusplus::bus::match_t inventoryAdded(
+        bus, sdbusplus::bus::match::rules::interfacesAdded(),
+        [&](sdbusplus::message_t&) { schedule(); });
+
+    sdbusplus::bus::match_t assetChanged(
+        bus,
+        "type='signal',member='PropertiesChanged',interface='org.freedesktop."
+        "DBus.Properties',arg0='xyz.openbmc_project.Inventory.Decorator."
+        "Asset'",
+        [&](sdbusplus::message_t&) { schedule(); });
+
+    // Re-publish (ReScan) whenever fru-device (re)appears on the bus.
+    sdbusplus::bus::match_t fruDeviceOwner(
+        bus,
+        "type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop."
+        "DBus',member='NameOwnerChanged',arg0='xyz.openbmc_project.FruDevice'",
+        [&](sdbusplus::message_t&) { schedule(); });
+
+    // Initial pass once services have had a moment to settle.
+    schedule();
+
+    io.run();
+    return 0;
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/main.cpp
@@ -95,7 +95,8 @@ std::optional<std::string> getString(const PropertyMap& props,
         return std::nullopt;
     }
     const auto* s = std::get_if<std::string>(&it->second);
-    if (s == nullptr || s->empty())
+    if (s == nullptr || s->empty() || *s == "UNKNOWN" ||
+        *s == "NOT AVAILABLE")
     {
         return std::nullopt;
     }

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/meson.build
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/files/meson.build
@@ -1,0 +1,33 @@
+project(
+    'fru-synthesizer',
+    'cpp',
+    version: '1.0',
+    default_options: [
+        'cpp_std=c++23',
+        'warning_level=3',
+        'werror=false',
+    ],
+)
+
+deps = [
+    dependency('sdbusplus'),
+    dependency('phosphor-logging'),
+    dependency('boost'),
+]
+
+executable(
+    'fru-synthesizer',
+    ['main.cpp', 'fru_encoder.cpp'],
+    dependencies: deps,
+    install: true,
+    install_dir: get_option('bindir'),
+)
+
+systemd = dependency('systemd')
+systemd_system_unit_dir = systemd.get_variable(
+    pkgconfig: 'systemdsystemunitdir',
+)
+install_data(
+    'fru-synthesizer.service',
+    install_dir: systemd_system_unit_dir,
+)

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/fru-synthesizer_1.0.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/fru-synthesizer/fru-synthesizer_1.0.bb
@@ -1,0 +1,33 @@
+SUMMARY = "Synthesize IPMI FRU images from D-Bus inventory"
+DESCRIPTION = "Builds IPMI FRU blobs from MachineContext (device-tree VPD) and \
+smbios-mdr (host SMBIOS) inventory and writes them to /etc/fru, where fru-device \
+publishes them via xyz.openbmc_project.FruDevice for the stock IPMI storage \
+handlers. Used on platforms (e.g. HPE ProLiant Gen11) that have no physical \
+baseboard/CPU/DIMM FRU EEPROMs."
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit meson pkgconfig systemd
+
+DEPENDS = " \
+    sdbusplus \
+    phosphor-logging \
+    boost \
+    systemd \
+    "
+
+# fru-device must be present to consume the generated /etc/fru files.
+RDEPENDS:${PN} += "fru-device"
+
+SRC_URI = " \
+    file://meson.build;subdir=${BP} \
+    file://fru_encoder.hpp;subdir=${BP} \
+    file://fru_encoder.cpp;subdir=${BP} \
+    file://main.cpp;subdir=${BP} \
+    file://fru-synthesizer.service;subdir=${BP} \
+    "
+
+S = "${UNPACKDIR}/${BP}"
+
+SYSTEMD_SERVICE:${PN} = "fru-synthesizer.service"

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
@@ -41,6 +41,7 @@ SUMMARY:${PN}-system = "HPE System"
 RDEPENDS:${PN}-system = " \
         entity-manager \
         dbus-sensors \
+        fru-synthesizer \
         gxp-chif-service \
         smbios-mdr \
         udev-gxp-i2c-passthrough \

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0005-fru-device-load-synthetic-FRUs-from-etc-fru.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0005-fru-device-load-synthetic-FRUs-from-etc-fru.patch
@@ -1,0 +1,101 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pedro Maione <pedro.maione@9elements.com>
+Date: Wed, 18 Jun 2026 00:00:00 +0000
+Subject: [PATCH] fru-device: load synthetic FRUs from /etc/fru
+
+fru-device already loads a single file-based "baseboard" FRU from
+/etc/fru/baseboard.fru.bin and inserts it at bus 0 / address 0. On
+platforms with no physical FRU EEPROMs (e.g. HPE ProLiant Gen11, where
+baseboard/CPU/DIMM inventory comes from device-tree VPD and host SMBIOS),
+we need to publish more than one synthetic FRU through the standard
+xyz.openbmc_project.FruDevice service so the stock IPMI storage handlers
+can serve them.
+
+Generalize the mechanism: in addition to baseboard.fru.bin, scan /etc/fru
+for files named "<bus>-<address>.fru.bin" (decimal) and insert each into
+the bus map at the encoded (bus, address). Encoding the identifiers in the
+filename keeps the resulting FruDevice bus/address stable across reboots,
+which is required for deterministic IPMI FRU device IDs and for correlating
+EntityManager FRU-locator decorators.
+
+A companion service (fru-synthesizer) writes these files from D-Bus
+inventory and calls ReScan.
+
+Upstream-Status: Inappropriate [HPE platform integration]
+
+Signed-off-by: Pedro Maione <pedro.maione@9elements.com>
+---
+diff --git a/src/fru_device/fru_device.cpp b/src/fru_device/fru_device.cpp
+index 2b73b7694..3e47c6a8c 100644
+--- a/src/fru_device/fru_device.cpp
++++ b/src/fru_device/fru_device.cpp
+@@ -1003,6 +1003,59 @@ static bool readBaseboardFRU(std::vector<uint8_t>& baseboardFRU)
+     return true;
+ }
+ 
++// Load additional synthetic (non-EEPROM) FRUs from /etc/fru. Files must be
++// named "<bus>-<address>.fru.bin" (decimal) so each resulting FruDevice object
++// gets a stable bus/address identifier. This lets platforms without physical
++// FRU EEPROMs publish baseboard/CPU/DIMM FRU data (sourced from device-tree VPD
++// or host SMBIOS by a companion service) through the standard FruDevice service.
++static void loadSyntheticFRUs(BusMap& busmap)
++{
++    const static std::string fruDir = "/etc/fru";
++    std::error_code ec;
++    if (!fs::is_directory(fruDir, ec))
++    {
++        return;
++    }
++
++    static const std::regex fileRegex(R"(^([0-9]+)-([0-9]+)\.fru\.bin$)");
++    for (const auto& entry : fs::directory_iterator(fruDir, ec))
++    {
++        if (ec)
++        {
++            break;
++        }
++
++        const std::string name = entry.path().filename().string();
++        std::smatch match;
++        if (!std::regex_match(name, match, fileRegex))
++        {
++            continue;
++        }
++
++        size_t bus = std::stoul(match[1].str());
++        size_t address = std::stoul(match[2].str());
++
++        std::ifstream fruFile(entry.path(), std::ios::binary);
++        if (!fruFile.good())
++        {
++            continue;
++        }
++        fruFile.seekg(0, std::ios_base::end);
++        size_t fileSize = static_cast<size_t>(fruFile.tellg());
++        if (fileSize == 0 || fileSize > maxFruSize)
++        {
++            continue;
++        }
++        std::vector<uint8_t> fru(fileSize);
++        fruFile.seekg(0, std::ios_base::beg);
++        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
++        fruFile.read(reinterpret_cast<char*>(fru.data()), fileSize);
++
++        auto busEntry = busmap.try_emplace(bus, std::make_shared<DeviceMap>());
++        busEntry.first->second->emplace(address, std::move(fru));
++    }
++}
++
+ bool writeFruByteData(bool is16Bit, int file, uint8_t address, uint16_t index,
+                       uint8_t byteData)
+ {
+@@ -1320,6 +1373,7 @@ void rescanBusses(
+                         busmap.try_emplace(0, std::make_shared<DeviceMap>());
+                     bus0.first->second->emplace(0, baseboardFRU);
+                 }
++                loadSyntheticFRUs(busmap);
+                 for (auto devicemap : busmap)
+                 {
+                     for (auto device : *devicemap.second)
+--
+2.43.0

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
@@ -12,6 +12,11 @@ PACKAGECONFIG:append = " dts-vpd"
 # Baseboard (PCA) VPD support for devicetree-vpd-parser
 SRC_URI += "file://0001-devicetree-vpd-parser-add-baseboard-PCA-VPD-support.patch"
 
+# Let fru-device publish multiple synthetic (non-EEPROM) FRUs from /etc/fru,
+# so baseboard/CPU/DIMM FRU (sourced from device-tree VPD + host SMBIOS by the
+# fru-synthesizer service) are served over IPMI via xyz.openbmc_project.FruDevice.
+SRC_URI += "file://0005-fru-device-load-synthetic-FRUs-from-etc-fru.patch"
+
 # HPE ProLiant Gen11 baseboard configurations
 SRC_URI += " \
     file://blocklist.json \

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/hpe-yaml-config.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/hpe-yaml-config.bb
@@ -1,0 +1,27 @@
+SUMMARY = "YAML configuration for HPE ProLiant Gen11"
+PR = "r1"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit allarch
+
+SRC_URI = " \
+    file://hpe-ipmi-fru.yaml \
+    file://hpe-ipmi-fru-properties.yaml \
+    "
+
+S = "${UNPACKDIR}/sources"
+
+do_install() {
+    install -m 0644 -D ${UNPACKDIR}/hpe-ipmi-fru-properties.yaml \
+        ${D}${datadir}/${BPN}/ipmi-extra-properties.yaml
+    install -m 0644 -D ${UNPACKDIR}/hpe-ipmi-fru.yaml \
+        ${D}${datadir}/${BPN}/ipmi-fru-read.yaml
+}
+
+FILES:${PN}-dev = " \
+    ${datadir}/${BPN}/ipmi-extra-properties.yaml \
+    ${datadir}/${BPN}/ipmi-fru-read.yaml \
+    "
+
+ALLOW_EMPTY:${PN} = "1"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/hpe-yaml-config/hpe-ipmi-fru-properties.yaml
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/hpe-yaml-config/hpe-ipmi-fru-properties.yaml
@@ -1,0 +1,17 @@
+/system: &DEFAULTS
+    xyz.openbmc_project.Inventory.Decorator.Cacheable:
+        Cached: 'true'
+    xyz.openbmc_project.Inventory.Decorator.Replaceable:
+        FieldReplaceable: 'true'
+    xyz.openbmc_project.Inventory.Item:
+        Present: 'true'
+/system/chassis/chassis:
+    <<: *DEFAULTS
+/system/chassis/motherboard/cpu0:
+    <<: *DEFAULTS
+/system/chassis/motherboard/cpu1:
+    <<: *DEFAULTS
+/system/chassis/motherboard/cpu2:
+    <<: *DEFAULTS
+/system/chassis/motherboard/cpu3:
+    <<: *DEFAULTS

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/hpe-yaml-config/hpe-ipmi-fru.yaml
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/hpe-yaml-config/hpe-ipmi-fru.yaml
@@ -1,0 +1,1575 @@
+0:
+    /system/chassis/chassis:
+        entityID: 7
+        entityInstance: 1
+        interfaces:
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Board
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Board
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Board
+
+1:
+    /system/chassis/motherboard/cpu0: &CPU_DEFAULTS
+        entityID: 3
+        entityInstance: 1
+        interfaces:
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Board
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Board
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Board
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Custom Field 2
+                    IPMIFruSection: Board
+                    IPMIFruValueDelimiter: 58
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Name
+                    IPMIFruSection: Board
+2:
+    /system/chassis/motherboard/cpu1:
+        <<: *CPU_DEFAULTS
+        entityInstance: 2
+
+3:
+    /system/chassis/motherboard/cpu2:
+        <<: *CPU_DEFAULTS
+        entityInstance: 3
+
+4:
+    /system/chassis/motherboard/cpu3:
+        <<: *CPU_DEFAULTS
+        entityInstance: 4
+
+5:
+    /system/chassis/motherboard/dimm0: &DIMM_DEFAULTS
+        entityID: 32
+        entityInstance: 1
+        interfaces:
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                BuildDate:
+                    IPMIFruProperty: Mfg Date
+                    IPMIFruSection: Product
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                Model:
+                    IPMIFruProperty: Model Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Name
+                    IPMIFruSection: Product
+6:
+    /system/chassis/motherboard/dimm1:
+        <<: *DIMM_DEFAULTS
+        entityInstance: 2
+7:
+    /system/chassis/motherboard/dimm2:
+        entityID: 32
+        entityInstance: 3
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+8:
+    /system/chassis/motherboard/dimm3:
+        entityID: 32
+        entityInstance: 4
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+9:
+    /system/chassis/motherboard/dimm4:
+        entityID: 32
+        entityInstance: 5
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+10:
+    /system/chassis/motherboard/dimm5:
+        entityID: 32
+        entityInstance: 6
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+11:
+    /system/chassis/motherboard/dimm6:
+        entityID: 32
+        entityInstance: 7
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+12:
+    /system/chassis/motherboard/dimm7:
+        entityID: 32
+        entityInstance: 8
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+13:
+    /system/chassis/motherboard/dimm8:
+        entityID: 32
+        entityInstance: 9
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+14:
+    /system/chassis/motherboard/dimm9:
+        entityID: 32
+        entityInstance: 10
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+15:
+    /system/chassis/motherboard/dimm10:
+        entityID: 32
+        entityInstance: 11
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+16:
+    /system/chassis/motherboard/dimm11:
+        entityID: 32
+        entityInstance: 12
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+17:
+    /system/chassis/motherboard/dimm12:
+        entityID: 32
+        entityInstance: 13
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+18:
+    /system/chassis/motherboard/dimm13:
+        entityID: 32
+        entityInstance: 14
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+19:
+    /system/chassis/motherboard/dimm14:
+        entityID: 32
+        entityInstance: 15
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+20:
+    /system/chassis/motherboard/dimm15:
+        entityID: 32
+        entityInstance: 16
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+21:
+    /system/chassis/motherboard/dimm16:
+        entityID: 32
+        entityInstance: 17
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+22:
+    /system/chassis/motherboard/dimm17:
+        entityID: 32
+        entityInstance: 18
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+23:
+    /system/chassis/motherboard/dimm18:
+        entityID: 32
+        entityInstance: 19
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+24:
+    /system/chassis/motherboard/dimm19:
+        entityID: 32
+        entityInstance: 20
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+25:
+    /system/chassis/motherboard/dimm20:
+        entityID: 32
+        entityInstance: 21
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+26:
+    /system/chassis/motherboard/dimm21:
+        entityID: 32
+        entityInstance: 22
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+27:
+    /system/chassis/motherboard/dimm22:
+        entityID: 32
+        entityInstance: 23
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+28:
+    /system/chassis/motherboard/dimm23:
+        entityID: 32
+        entityInstance: 24
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+29:
+    /system/chassis/motherboard/dimm24:
+        entityID: 32
+        entityInstance: 25
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+30:
+    /system/chassis/motherboard/dimm25:
+        entityID: 32
+        entityInstance: 26
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+31:
+    /system/chassis/motherboard/dimm26:
+        entityID: 32
+        entityInstance: 27
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+32:
+    /system/chassis/motherboard/dimm27:
+        entityID: 32
+        entityInstance: 28
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+33:
+    /system/chassis/motherboard/dimm28:
+        entityID: 32
+        entityInstance: 29
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+34:
+    /system/chassis/motherboard/dimm29:
+        entityID: 32
+        entityInstance: 30
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+35:
+    /system/chassis/motherboard/dimm30:
+        entityID: 32
+        entityInstance: 31
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+36:
+    /system/chassis/motherboard/dimm31:
+        entityID: 32
+        entityInstance: 32
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+37:
+    /system/chassis/motherboard/dimm32:
+        entityID: 32
+        entityInstance: 33
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+38:
+    /system/chassis/motherboard/dimm33:
+        entityID: 32
+        entityInstance: 34
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+39:
+    /system/chassis/motherboard/dimm34:
+        entityID: 32
+        entityInstance: 35
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+40:
+    /system/chassis/motherboard/dimm35:
+        entityID: 32
+        entityInstance: 36
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+41:
+    /system/chassis/motherboard/dimm36:
+        entityID: 32
+        entityInstance: 37
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+42:
+    /system/chassis/motherboard/dimm37:
+        entityID: 32
+        entityInstance: 38
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+43:
+    /system/chassis/motherboard/dimm38:
+        entityID: 32
+        entityInstance: 39
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+44:
+    /system/chassis/motherboard/dimm39:
+        entityID: 32
+        entityInstance: 40
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+45:
+    /system/chassis/motherboard/dimm40:
+        entityID: 32
+        entityInstance: 41
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+46:
+    /system/chassis/motherboard/dimm41:
+        entityID: 32
+        entityInstance: 42
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+47:
+    /system/chassis/motherboard/dimm42:
+        entityID: 32
+        entityInstance: 43
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+48:
+    /system/chassis/motherboard/dimm43:
+        entityID: 32
+        entityInstance: 44
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+49:
+    /system/chassis/motherboard/dimm44:
+        entityID: 32
+        entityInstance: 45
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+50:
+    /system/chassis/motherboard/dimm45:
+        entityID: 32
+        entityInstance: 46
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+51:
+    /system/chassis/motherboard/dimm46:
+        entityID: 32
+        entityInstance: 47
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+52:
+    /system/chassis/motherboard/dimm47:
+        entityID: 32
+        entityInstance: 48
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+53:
+    /system/chassis/motherboard/dimm48:
+        entityID: 32
+        entityInstance: 49
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+54:
+    /system/chassis/motherboard/dimm49:
+        entityID: 32
+        entityInstance: 50
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+55:
+    /system/chassis/motherboard/dimm50:
+        entityID: 32
+        entityInstance: 51
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+56:
+    /system/chassis/motherboard/dimm51:
+        entityID: 32
+        entityInstance: 52
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+57:
+    /system/chassis/motherboard/dimm52:
+        entityID: 32
+        entityInstance: 53
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+58:
+    /system/chassis/motherboard/dimm53:
+        entityID: 32
+        entityInstance: 54
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+59:
+    /system/chassis/motherboard/dimm54:
+        entityID: 32
+        entityInstance: 55
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+60:
+    /system/chassis/motherboard/dimm55:
+        entityID: 32
+        entityInstance: 56
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+61:
+    /system/chassis/motherboard/dimm56:
+        entityID: 32
+        entityInstance: 57
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+62:
+    /system/chassis/motherboard/dimm57:
+        entityID: 32
+        entityInstance: 58
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+63:
+    /system/chassis/motherboard/dimm58:
+        entityID: 32
+        entityInstance: 59
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+64:
+    /system/chassis/motherboard/dimm59:
+        entityID: 32
+        entityInstance: 60
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+65:
+    /system/chassis/motherboard/dimm60:
+        entityID: 32
+        entityInstance: 61
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+66:
+    /system/chassis/motherboard/dimm61:
+        entityID: 32
+        entityInstance: 62
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+67:
+    /system/chassis/motherboard/dimm62:
+        entityID: 32
+        entityInstance: 63
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:
+68:
+    /system/chassis/motherboard/dimm63:
+        entityID: 32
+        entityInstance: 64
+        interfaces:
+            xyz.openbmc_project.Inventory.Item:
+                PrettyName:
+                    IPMIFruProperty: Product Name
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Asset:
+                Manufacturer:
+                    IPMIFruProperty: Manufacturer
+                    IPMIFruSection: Product
+                SerialNumber:
+                    IPMIFruProperty: Serial Number
+                    IPMIFruSection: Product
+                PartNumber:
+                    IPMIFruProperty: Part Number
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Decorator.Revision:
+                Version:
+                    IPMIFruProperty: Version
+                    IPMIFruSection: Product
+            xyz.openbmc_project.Inventory.Item.Dimm:

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-apphandler-fall-back-to-ObjectMapper-when-settings-U.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-apphandler-fall-back-to-ObjectMapper-when-settings-U.patch
@@ -1,0 +1,79 @@
+From 8d45c6eb95c9226368690780f8f5a544544db573 Mon Sep 17 00:00:00 2001
+From: Pedro Maione <pedro.maione@9elements.com>
+Date: Thu, 9 Jul 2026 20:14:28 +0200
+Subject: [PATCH] apphandler: fall back to ObjectMapper when settings UUID is
+ absent
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+phosphor-ipmi-host's ipmiAppGetSystemGuid hard-codes
+xyz.openbmc_project.Settings / /xyz/openbmc_project/Common/UUID as the
+only source for the system UUID.  On platforms where the UUID is not
+vended by phosphor-settings — for example when it is exposed by a
+different service at a different object path — the command returns an
+Unspecified Error.
+
+Make the lookup more resilient by keeping the existing settings read
+as the primary path and, only when it fails, falling back to
+ObjectMapper: call getDbusObject() to discover whichever service
+currently advertises xyz.openbmc_project.Common.UUID, then read the
+UUID property from that object. This preserves backward compatibility
+while allowing platforms with alternative UUID providers to work
+correctly.
+
+Upstream-Status: Pending
+
+Signed-off-by: Pedro Maione <pedro.maione@9elements.com>
+---
+ apphandler.cpp | 31 ++++++++++++++++++++++++++++---
+ 1 file changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/apphandler.cpp b/apphandler.cpp
+index ddc15612..f5e15af2 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -866,12 +866,37 @@ auto ipmiAppGetSystemGuid(ipmi::Context::ptr& ctx)
+         ctx, uuidService, uuidObject, uuidInterface, uuidProperty, rfc4122Uuid);
+     if (ec.value())
+     {
+-        lg2::error("Failed to read System UUID property, "
+-                   "interface: {INTERFACE}, property: {PROPERTY}, "
++        lg2::error("Failed to read System UUID from settings, falling back to "
++                   "ObjectMapper, interface: {INTERFACE}, property: {PROPERTY}, "
+                    "error: {ERROR}",
+                    "INTERFACE", uuidInterface, "PROPERTY", uuidProperty,
+                    "ERROR", ec.message());
+-        return ipmi::responseUnspecifiedError();
++
++        // Fallback to ObjectMapper in case phosphor-settings does not provide it
++        ipmi::DbusObjectInfo uuidObjectInfo{};
++        ec = ipmi::getDbusObject(ctx, uuidInterface, "/", {}, uuidObjectInfo);
++        if (ec.value())
++        {
++            lg2::error("Failed to find System UUID object, "
++                       "interface: {INTERFACE}, error: {ERROR}",
++                       "INTERFACE", uuidInterface, "ERROR", ec.message());
++            return ipmi::responseUnspecifiedError();
++        }
++
++        ec = ipmi::getDbusProperty(ctx, uuidObjectInfo.second,
++                                   uuidObjectInfo.first, uuidInterface,
++                                   uuidProperty, rfc4122Uuid);
++        if (ec.value())
++        {
++            lg2::error("Failed to read System UUID property, "
++                       "service: {SERVICE}, object: {OBJECT}, "
++                       "interface: {INTERFACE}, property: {PROPERTY}, "
++                       "error: {ERROR}",
++                       "SERVICE", uuidObjectInfo.second, "OBJECT",
++                       uuidObjectInfo.first, "INTERFACE", uuidInterface,
++                       "PROPERTY", uuidProperty, "ERROR", ec.message());
++            return ipmi::responseUnspecifiedError();
++        }
+     }
+     std::array<uint8_t, 16> uuid;
+     try
+-- 
+2.39.5
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " dynamic-sensors"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-# dynamic-sensors routes both sensor (SDR) and storage (FRU) IPMI commands
-# through the dbus-sdr handlers. FRU is served from xyz.openbmc_project.FruDevice
-# (populated by fru-device + fru-synthesizer), so the legacy compiled-YAML FRU
-# path (-Dfru-yaml-gen / hpe-yaml-config) is not used on this platform.
 PACKAGECONFIG:append = " dynamic-sensors"
+
+SRC_URI:append = " file://0001-apphandler-fall-back-to-ObjectMapper-when-settings-U.patch"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -1,1 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+# dynamic-sensors routes both sensor (SDR) and storage (FRU) IPMI commands
+# through the dbus-sdr handlers. FRU is served from xyz.openbmc_project.FruDevice
+# (populated by fru-device + fru-synthesizer), so the legacy compiled-YAML FRU
+# path (-Dfru-yaml-gen / hpe-yaml-config) is not used on this platform.
 PACKAGECONFIG:append = " dynamic-sensors"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog-host-powercycle.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog-host-powercycle.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Power Cycle Host on Watchdog Timeout
+After=xyz.openbmc_project.Chassis.Control.Power.service
+
+[Service]
+Type=oneshot
+ExecStart=busctl set-property \
+    xyz.openbmc_project.State.Chassis \
+    /xyz/openbmc_project/state/chassis0 \
+    xyz.openbmc_project.State.Chassis \
+    RequestedPowerTransition s \
+    xyz.openbmc_project.State.Chassis.Transition.PowerCycle
+ExecStart=busctl set-property \
+    xyz.openbmc_project.Control.Host.RestartCause \
+    /xyz/openbmc_project/control/host0/restart_cause \
+    xyz.openbmc_project.Control.Host.RestartCause \
+    RequestedRestartCause s \
+    xyz.openbmc_project.State.Host.RestartCause.WatchdogTimer
+SyslogIdentifier=phosphor-watchdog

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog-host-poweroff.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog-host-poweroff.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Shut Down Host on Watchdog Timeout
+After=xyz.openbmc_project.Chassis.Control.Power.service
+
+[Service]
+Type=oneshot
+ExecStart=busctl set-property \
+    xyz.openbmc_project.State.Chassis \
+    /xyz/openbmc_project/state/chassis0 \
+    xyz.openbmc_project.State.Chassis \
+    RequestedPowerTransition s \
+    xyz.openbmc_project.State.Chassis.Transition.Off
+SyslogIdentifier=phosphor-watchdog

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog-host-reset.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog-host-reset.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Warm Reset Host on Watchdog Timeout
+After=xyz.openbmc_project.Chassis.Control.Power.service
+
+[Service]
+Type=oneshot
+ExecStart=busctl set-property \
+    xyz.openbmc_project.State.Host \
+    /xyz/openbmc_project/state/host0 \
+    xyz.openbmc_project.State.Host \
+    RequestedHostTransition s \
+    xyz.openbmc_project.State.Host.Transition.ForceWarmReboot
+ExecStart=busctl set-property \
+    xyz.openbmc_project.Control.Host.RestartCause \
+    /xyz/openbmc_project/control/host0/restart_cause \
+    xyz.openbmc_project.Control.Host.RestartCause \
+    RequestedRestartCause s \
+    xyz.openbmc_project.State.Host.RestartCause.WatchdogTimer
+SyslogIdentifier=phosphor-watchdog

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Phosphor Watchdog
+
+[Service]
+ExecStart=/usr/bin/env phosphor-watchdog --continue \
+    --service=xyz.openbmc_project.Watchdog \
+    --path=/xyz/openbmc_project/watchdog/host0 \
+    --default_interval=300000 \
+    --action_target=xyz.openbmc_project.State.Watchdog.Action.HardReset=phosphor-watchdog-host-reset.service \
+    --action_target=xyz.openbmc_project.State.Watchdog.Action.PowerOff=phosphor-watchdog-host-poweroff.service \
+    --action_target=xyz.openbmc_project.State.Watchdog.Action.PowerCycle=phosphor-watchdog-host-powercycle.service
+
+SyslogIdentifier=phosphor-watchdog
+BusName=xyz.openbmc_project.Watchdog
+Type=dbus
+
+[Install]
+WantedBy=basic.target

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# Drop the template-service Conflicts drop-in; we use a non-template service.
+SYSTEMD_OVERRIDE:${PN}:remove = "poweron.conf:phosphor-watchdog@poweron.service.d/poweron.conf"
+
+SYSTEMD_SERVICE:${PN} = " \
+    phosphor-watchdog.service \
+    phosphor-watchdog-host-poweroff.service \
+    phosphor-watchdog-host-reset.service \
+    phosphor-watchdog-host-powercycle.service \
+    "

--- a/meta-canopy/meta-hpe/meta-gxp/conf/machine/include/gxp.inc
+++ b/meta-canopy/meta-hpe/meta-gxp/conf/machine/include/gxp.inc
@@ -52,3 +52,5 @@ PREFERRED_PROVIDER_virtual/obmc-fan-mgmt = "packagegroup-hpe-apps"
 PREFERRED_PROVIDER_virtual/obmc-flash-mgmt = "packagegroup-hpe-apps"
 PREFERRED_PROVIDER_virtual/obmc-system-mgmt = "packagegroup-hpe-apps"
 PREFERRED_PROVIDER_virtual/obmc-host-ipmi-hw = "phosphor-ipmi-kcs"
+
+VIRTUAL-RUNTIME_phosphor-ipmi-providers = ""


### PR DESCRIPTION
## FirmwareCI test cases

Test basic IPMI features on FirmwareCI for HPE ProLiant Gen11 machines.
_TODO: Add detailed test description_

Test files are validated with `fwci validate`

## Fixes

- Setup `phoshpor-watchdog`.
(tested on DL365 with `run-test` scripts)

- Enable `dynamic-sensors` for phosphor-ipmi-host
(tested on DL365 with `run-test` scripts)

- Patch `phosphor-ipmi-host` to fetch System GUID from SMBIOS
(tested on DL365 with `run-test` scripts)

- Fix IPMI FRU
(tested on DL365 with `run-test` scripts)

Upstream phosphor-ipmi-fru expects physical EEPROM chips (Discovered through FruDevice), but HPE systems implements baseboard FRU via DeviceTree VPD and CPU, DIMMs are provided by SMBIOS service. This patch implements a `fru-synthesizer` service to expose virtual FRU to FruDevice via bin file in `/etc/fru`.