### PR TITLE
ci: use runner-provided sstate/download cache and hashserve db

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,12 +11,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Configure bitbake shared folders
-      shell: bash
-      run: |
-        mkdir -p /home/runner/data/bitbake.downloads
-        mkdir -p /home/runner/data/bitbake.sstate
-
     - name: Init git submodules
       shell: bash
       run: git submodule update --init --recursive --checkout
@@ -31,9 +25,6 @@ runs:
     - name: Build OpenBMC
       shell: bash
       env:
-        BB_ENV_PASSTHROUGH_ADDITIONS: "DL_DIR SSTATE_DIR"
-        DL_DIR: "/home/runner/data/bitbake.downloads"
-        SSTATE_DIR: "/home/runner/data/bitbake.sstate"
         SIGNING_KEY_PATH: ${{ inputs.signing-key != '' && format('{0}/signing_key.pem', runner.temp) || '' }}
       run: |
         . setup ${{ inputs.board }}


### PR DESCRIPTION
Instead of using our own sstate and download cache (which might get erased), use the central one provided by the runner itself.

This also fixes the issue where the build process was not using a central hashserve db, causing the sstate to be rebuilt every time regardless of its state.

The mentioned link refers to the fix in the runner configuration.

Link: https://github.com/9elements/infrastructure/pull/235