### PR TITLE
HPE ProLiant Gen11: Add BIOS Update support

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+redfish_log() {
+	# Usage: redfish_log <message> <severity> [key value [key value ...]]
+	local message="$1" severity="$2"
+	shift 2
+	local pairs=() n=0
+	while [ $# -ge 2 ]; do
+		pairs+=("$1" "$2")
+		n=$((n + 1))
+		shift 2
+	done
+	busctl call \
+		xyz.openbmc_project.Logging /xyz/openbmc_project/logging \
+		xyz.openbmc_project.Logging.Create Create "ssa{ss}" \
+		"$message" "$severity" "$n" "${pairs[@]}" 2>/dev/null || true
+}
+
+die() {
+	logger -t obmc-flash-host-bios "Error: $*"
+	redfish_log "BIOS update failed" \
+		"xyz.openbmc_project.Logging.Entry.Level.Error" \
+		"REASON" "$*"
+	exit 1
+}
+
+info() { logger -t obmc-flash-host-bios "$*"; }
+
+BIOS_SIZE=$((32 * 1024 * 1024))
+HPE_FINGERPRINT_MAGIC="--=</"
+HPE_IMAGE_MAGIC="HPIMAGE"
+
+POWER_BUTTON_PATH="/xyz/openbmc_project/chassis/buttons/power"
+POWER_BUTTON_IFACE="xyz.openbmc_project.Chassis.Buttons"
+POWER_CONTROL_SERVICE="$(mapper get-service "$POWER_BUTTON_PATH")"
+
+HOSTSTATE_SVC="xyz.openbmc_project.State.Host"
+HOSTSTATE_PATH="/xyz/openbmc_project/state/host0"
+HOSTSTATE_IFACE="xyz.openbmc_project.State.Host"
+HOSTSTATE_PROP="CurrentHostState"
+HOSTSTATE_OFF="xyz.openbmc_project.State.Host.HostState.Off"
+
+check_host_off() {
+	local state
+	state="$(busctl get-property "$HOSTSTATE_SVC" "$HOSTSTATE_PATH" \
+		"$HOSTSTATE_IFACE" "$HOSTSTATE_PROP")" \
+		|| die "could not read host state from D-Bus"
+	[ "$state" = "s \"$HOSTSTATE_OFF\"" ] \
+		|| die "host must be off before performing BIOS update"
+}
+
+power_mask_set() {
+	if busctl set-property \
+			"$POWER_CONTROL_SERVICE" \
+			"$POWER_BUTTON_PATH" \
+			"$POWER_BUTTON_IFACE" \
+			ButtonMasked b true 2>/dev/null; then
+		info "power button masked"
+	else
+		info "WARNING: could not mask power button"
+	fi
+}
+
+power_mask_clear() {
+	if busctl set-property \
+			"$POWER_CONTROL_SERVICE" \
+			"$POWER_BUTTON_PATH" \
+			"$POWER_BUTTON_IFACE" \
+			ButtonMasked b false 2>/dev/null; then
+		info "power button unmasked"
+	else
+		info "WARNING: could not unmask power button"
+	fi
+}
+
+check_bios_image() {
+	local image_file="$1"
+	local file_size
+
+	[ -r "$image_file" ] || die "can't read BIOS image $image_file"
+
+	file_size="$(stat -c '%s' "$image_file")"
+	[ "$file_size" -ge "$BIOS_SIZE" ] \
+		|| die "invalid BIOS image (smaller than $BIOS_SIZE bytes)"
+}
+
+check_model() {
+	local image_dir="$1"
+	local manifest="$image_dir/MANIFEST"
+
+	[ -f "$manifest" ] || die "MANIFEST not found in $image_dir"
+
+	local target_model
+	target_model="$(grep '^TargetModel=' "$manifest" | cut -d= -f2-)"
+	[ -n "$target_model" ] || die "TargetModel not set in MANIFEST, refusing to flash"
+
+	local live_model
+	live_model="$(tr -d '\0' < /proc/device-tree/model)"
+	[ -n "$live_model" ] \
+		|| die "could not read model from /proc/device-tree/model"
+
+	[ "$target_model" = "$live_model" ] \
+		|| die "model mismatch: image is for '$target_model', hardware is '$live_model'"
+
+	info "hardware model check passed ('$live_model')"
+}
+
+find_imgfile() {
+	local image_dir="$1"
+	local img='' path name
+
+	for path in "$image_dir"/*; do
+		name="$(basename "$path")"
+		case "$name" in
+			MANIFEST|publickey|*.sig) continue ;;
+		esac
+		[ -f "$path" ] || continue
+		[ -z "$img" ] || die "multiple potential image files in $image_dir"
+		img="$path"
+	done
+
+	[ -n "$img" ] || die "no image file found in $image_dir"
+	echo "$img"
+}
+
+flash_bios_image() {
+	local image_file="$1"
+	local file_size header_size flash_image found=0 status=0
+
+	file_size="$(stat -c '%s' "$image_file")"
+	header_size=$((file_size - BIOS_SIZE))
+
+	if [ "$header_size" -gt 0 ]; then
+		local fingerprint hpimage_found
+		fingerprint="$(dd if="$image_file" bs=5 count=1 2>/dev/null)"
+		[ "$fingerprint" = "$HPE_FINGERPRINT_MAGIC" ] \
+			|| die "image is larger than $BIOS_SIZE bytes but lacks magic"
+		hpimage_found="$(dd if="$image_file" bs=1 count="$header_size" 2>/dev/null \
+			| grep -c "$HPE_IMAGE_MAGIC")" \
+			|| die "image header does not contain HPIMAGE block"
+		[ "$hpimage_found" -gt 0 ] \
+			|| die "image header does not contain HPIMAGE block"
+		flash_image="$(dirname "$image_file")/bios-stripped.bin"
+
+		info "stripping $header_size byte HPE header, writing to $flash_image"
+		dd if="$image_file" of="$flash_image" bs="$header_size" skip=1 2>/dev/null \
+			|| die "failed to strip HPE header from $image_file"
+	else
+		flash_image="$image_file"
+	fi
+
+	for partition in host-prime host-second; do
+		local mtd_dev="/dev/mtd/$partition"
+		if [ ! -e "$mtd_dev" ]; then
+			info "WARNING: $mtd_dev not found, skipping $partition"
+			continue
+		fi
+		found=$((found + 1))
+		info "writing $mtd_dev ..."
+		if flashcp -v -p "$flash_image" "$mtd_dev"; then
+			info "$partition done"
+		else
+			info "ERROR: failed to write $partition"
+			status=1
+		fi
+		info "$partition done"
+	done
+
+	[ "$found" -gt 0 ] || die "no MTD partitions found (host-prime / host-second)"
+	return "$status"
+}
+
+[ -n "$1" ] && [ -d "$1" ] || { echo "Usage: obmc-flash-host-bios <image-dir>" >&2; exit 1; }
+IMAGE_DIR="$1"
+
+info "Starting BIOS update from $IMAGE_DIR"
+
+info "Checking host state..."
+check_host_off
+
+info "Checking model compatibility..."
+check_model "$IMAGE_DIR"
+target_model="$(grep '^TargetModel=' "$IMAGE_DIR/MANIFEST" | cut -d= -f2-)"
+
+info "Locating image file..."
+image_file="$(find_imgfile "$IMAGE_DIR")"
+
+info "Checking BIOS image..."
+check_bios_image "$image_file"
+
+redfish_log "BIOS update started" \
+	"xyz.openbmc_project.Logging.Entry.Level.Informational" \
+	"IMAGE_DIR"    "$IMAGE_DIR" \
+	"TARGET_MODEL" "$target_model" \
+	"IMAGE_FILE"   "$(basename "$image_file")"
+
+power_mask_set
+trap 'power_mask_clear' EXIT
+
+info "Flashing BIOS..."
+if flash_bios_image "$image_file"; then
+	info "BIOS update complete."
+	redfish_log "BIOS update completed successfully" \
+		"xyz.openbmc_project.Logging.Entry.Level.Informational" \
+		"TARGET_MODEL" "$target_model" \
+		"IMAGE_FILE"   "$(basename "$image_file")"
+else
+	die "BIOS update failed on one or more partitions."
+fi

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Flash Host BIOS image %I to HPE ProLiant Gen11 SPI flash
+Wants=reboot-guard-enable.service
+After=reboot-guard-enable.service
+OnSuccess=reboot-guard-disable.service
+OnFailure=reboot-guard-disable.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/sbin/obmc-flash-host-bios /tmp/images/%i
+TimeoutStartSec=1800
+TimeoutStopSec=30

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,6 +1,28 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+    file://obmc-flash-host-bios@.service \
+    file://obmc-flash-host-bios \
+"
+
 PACKAGECONFIG:append = " flash_bios"
+RDEPENDS:${PN}-updater:append = " bash mtd-utils"
 
 # Without this GXP SROT would fail if u-boot changes after a non-all tarball
 # update because the old RSA signature is left on flash while u-boot.bin
 # is replaced.
 EXTRA_OEMESON:append = " -Doptional-images='image-uboot-sig'"
+
+do_install:append() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${UNPACKDIR}/obmc-flash-host-bios \
+        ${D}${sbindir}/obmc-flash-host-bios
+
+    install -m 0644 ${UNPACKDIR}/obmc-flash-host-bios@.service \
+        ${D}${systemd_system_unitdir}/obmc-flash-host-bios@.service
+}
+
+FILES:${PN}-bios += " \
+    ${sbindir}/obmc-flash-host-bios \
+    ${systemd_system_unitdir}/obmc-flash-host-bios@.service \
+"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/state/phosphor-state-manager_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/state/phosphor-state-manager_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " check-fwupdate-before-do-transition"

--- a/meta-canopy/recipes-phosphor/webui/webui-vue/0001-firmware-add-update-target-dropdown-to-form.patch
+++ b/meta-canopy/recipes-phosphor/webui/webui-vue/0001-firmware-add-update-target-dropdown-to-form.patch
@@ -1,0 +1,188 @@
+From e27e3810d5f7788e4cebfe52ccf3ad3425413ad6 Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Wed, 24 Jun 2026 23:57:45 +0200
+Subject: [PATCH] firmware: add update target dropdown to form
+
+The firmware update form always uses the BMC path as the Targets value
+in the multipart HTTP push request, breaking updates for other
+components such as BIOS (bios_active), SPI and CPLD modules.
+
+Fetch all members of /redfish/v1/UpdateService/FirmwareInventory and
+expose those with Updateable=true as selectable targets in a new
+dropdown, using the Description field as the display label. The
+dropdown defaults to the bmc_active entry to preserve existing
+behavior. The selected target is passed as Targets in the update
+request, replacing the previous hardcoded getBmcPath dispatch.
+
+This also enables updating firmware targets that are exposed as
+"xyz.openbmc_project.Configuration.SPIFlash".
+
+Upstream-Status: Pending
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ src/locales/en-US.json                        |  1 +
+ src/store/modules/Operations/FirmwareStore.js | 24 ++++++++++-
+ .../Firmware/FirmwareFormUpdate.vue           | 41 +++++++++++++++++++
+ 3 files changed, 65 insertions(+), 1 deletion(-)
+
+diff --git a/src/locales/en-US.json b/src/locales/en-US.json
+index c9f3822..a693ca0 100644
+--- a/src/locales/en-US.json
++++ b/src/locales/en-US.json
+@@ -362,6 +362,7 @@
+                 "fileSource": "File source",
+                 "imageFile": "Image file",
+                 "startUpdate": "Start update",
++                "updateTarget": "Update target",
+                 "workstation": "Workstation"
+             }
+         },
+diff --git a/src/store/modules/Operations/FirmwareStore.js b/src/store/modules/Operations/FirmwareStore.js
+index 07ce606..c279593 100644
+--- a/src/store/modules/Operations/FirmwareStore.js
++++ b/src/store/modules/Operations/FirmwareStore.js
+@@ -11,6 +11,7 @@ const FirmwareStore = {
+     applyTime: null,
+     multipartHttpPushUri: null,
+     httpPushUri: null,
++    updateableInventoryItems: [],
+   },
+   getters: {
+     isSingleFileUploadEnabled: (state) => state.biosFirmware.length === 0,
+@@ -34,6 +35,16 @@ const FirmwareStore = {
+         (firmware) => firmware.id !== state.biosActiveFirmwareId,
+       );
+     },
++    updateableInventoryItems: (state) => state.updateableInventoryItems,
++    defaultUpdateTarget: (state) => {
++      if (state.bmcActiveFirmwareId) {
++        const bmcItem = state.updateableInventoryItems.find((item) =>
++          item.location.endsWith('/' + state.bmcActiveFirmwareId),
++        );
++        if (bmcItem) return bmcItem.location;
++      }
++      return state.updateableInventoryItems[0]?.location || null;
++    },
+   },
+   mutations: {
+     setActiveBmcFirmwareId: (state, id) => (state.bmcActiveFirmwareId = id),
+@@ -44,6 +55,8 @@ const FirmwareStore = {
+     setHttpPushUri: (state, httpPushUri) => (state.httpPushUri = httpPushUri),
+     setMultipartHttpPushUri: (state, multipartHttpPushUri) =>
+       (state.multipartHttpPushUri = multipartHttpPushUri),
++    setUpdateableInventoryItems: (state, items) =>
++      (state.updateableInventoryItems = items),
+   },
+   actions: {
+     async getFirmwareInformation({ dispatch }) {
+@@ -81,6 +94,7 @@ const FirmwareStore = {
+         .then((response) => {
+           const bmcFirmware = [];
+           const biosFirmware = [];
++          const updateableInventoryItems = [];
+           response.forEach(({ data }) => {
+             const firmwareType = data?.RelatedItem?.[0]?.['@odata.id']
+               .split('/')
+@@ -96,9 +110,17 @@ const FirmwareStore = {
+             } else if (firmwareType === 'Bios') {
+               biosFirmware.push(item);
+             }
++            if (data?.Updateable === true) {
++              updateableInventoryItems.push({
++                location: data?.['@odata.id'],
++                description:
++                  data?.Description || data?.Name || data?.Id || data?.['@odata.id'],
++              });
++            }
+           });
+           commit('setBmcFirmware', bmcFirmware);
+           commit('setBiosFirmware', biosFirmware);
++          commit('setUpdateableInventoryItems', updateableInventoryItems);
+         })
+         .catch((error) => {
+           console.log(error);
+@@ -140,7 +162,7 @@ const FirmwareStore = {
+         });
+     },
+     async uploadFirmwareMultipartHttpPush(
+-      { state },
++      { state, getters },
+       { image, targets, forceUpdate, applyTime = 'Immediate' },
+     ) {
+       const formData = new FormData();
+diff --git a/src/views/Operations/Firmware/FirmwareFormUpdate.vue b/src/views/Operations/Firmware/FirmwareFormUpdate.vue
+index 30aca15..22d829a 100644
+--- a/src/views/Operations/Firmware/FirmwareFormUpdate.vue
++++ b/src/views/Operations/Firmware/FirmwareFormUpdate.vue
+@@ -2,6 +2,21 @@
+   <div>
+     <div class="form-background p-3">
+       <b-form @submit.prevent="onSubmitUpload">
++        <!-- Update target selection -->
++        <b-form-group
++          v-if="updateTargetOptions.length > 0"
++          :label="$t('pageFirmware.form.updateFirmware.updateTarget')"
++          label-for="update-target"
++          class="mb-3"
++        >
++          <b-form-select
++            id="update-target"
++            v-model="selectedTarget"
++            :options="updateTargetOptions"
++            :disabled="isPageDisabled"
++          />
++        </b-form-group>
++
+         <!-- Workstation Upload -->
+         <b-form-group
+           :label="$t('pageFirmware.form.updateFirmware.imageFile')"
+@@ -75,10 +90,34 @@ export default {
+       loading,
+       showUpdateModal: false,
+       file: null,
++      selectedTarget: null,
+       isServerPowerOffRequired:
+         import.meta.env.VITE_SERVER_OFF_REQUIRED === 'true',
+     };
+   },
++  computed: {
++    updateTargetOptions() {
++      return this.$store.getters['firmware/updateableInventoryItems'].map(
++        (item) => ({
++          value: item.location,
++          text: item.description,
++        }),
++      );
++    },
++    defaultUpdateTarget() {
++      return this.$store.getters['firmware/defaultUpdateTarget'];
++    },
++  },
++  watch: {
++    defaultUpdateTarget: {
++      immediate: true,
++      handler(newVal) {
++        if (newVal && this.selectedTarget === null) {
++          this.selectedTarget = newVal;
++        }
++      },
++    },
++  },
+   validations() {
+     return {
+       file: {
+@@ -109,9 +148,11 @@ export default {
+       this.dispatchWorkstationUpload(timerId);
+     },
+     dispatchWorkstationUpload(timerId) {
++      const targets = this.selectedTarget ? [this.selectedTarget] : undefined;
+       this.$store
+         .dispatch('firmware/uploadFirmware', {
+           image: this.file,
++          targets,
+         })
+         .catch(({ message }) => {
+           this.endLoader();
+-- 
+2.53.0
+

--- a/meta-canopy/recipes-phosphor/webui/webui-vue_%.bbappend
+++ b/meta-canopy/recipes-phosphor/webui/webui-vue_%.bbappend
@@ -15,6 +15,10 @@
 # upstream repo stays untouched.
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+SRC_URI:append = " \
+    file://0001-firmware-add-update-target-dropdown-to-form.patch \
+    "
+
 # Resolve the overlay directory at parse time
 CANOPY_WEBUI_OVERLAYS := "${THISDIR}/${BPN}"
 

--- a/meta-canopy/scripts/gen-hpe-bios-tar
+++ b/meta-canopy/scripts/gen-hpe-bios-tar
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script requires unencrypted, signed BIOS firmware files which are
+# not publicly distributed.
+# The structure is:
+# - Signature with PEM certificates (base64 + some ASCII)
+# - HPIMAGE metadata block
+# - BIOS payload
+#
+# This will strip the (for us) arbritrary data and write the BIOS payload
+# into a file that will be bundled into an archive.
+#
+# Usage:
+#	gen-hpe-bios-tar -i <input> -m <model> -v <version> [-k <privkey>] \
+#			 [-o <output.tar>]
+#
+# Arguments:
+#	-i <input>	Input file: HPE-signed (*.signed.flash) or raw 32 MiB image
+#				    (if dumped)
+#	-m <model>	Target model identifier
+#	-v <version>	Version string to embed in the MANIFEST (e.g. "2.92")
+#	-k <privkey>	Path to RSA private key for signing (PEM format).
+#			Defaults to the OpenBMC insecure dev key, searched in:
+#			1. $SIGNING_KEY environment variable
+#			2. $(dirname $0)/../../openbmc/meta-phosphor/
+#			   recipes-phosphor/flash/files/OpenBMC.priv
+#	-o <output>	Output tarball path. Default: ./<model>-bios-<version>.tar
+#	-h		Show this help message.
+#
+# Examples:
+#	# From an HPE-signed file (header stripped automatically):
+#	gen-hpe-bios-tar -i <T_Identifier>_<version>_<date>.signed.flash \
+#		-m dl360g11 -v 2.92
+#
+#	# From a raw SPI dump:
+#	gen-hpe-bios-tar -i dl365-g11-host-prime.img -m dl365g11 -v 3.14
+
+set -euo pipefail
+
+export BIOS_SIZE=33554432
+export HPE_HEADER_MAGIC="--=</"
+export IMAGE_NAME="ImageHost.bin"
+
+# These must match /proc/device-tree/model.
+declare -A MODEL_TARGET=(
+	[dl360g11]="HPE ProLiant DL360 Gen11"
+	[dl365g11]="HPE ProLiant DL365 Gen11"
+	[dl110g11]="HPE ProLiant DL110 Gen11"
+	[dl145g11]="HPE ProLiant DL145 Gen11"
+	[dl320g11]="HPE ProLiant DL320 Gen11"
+	[dl325g11]="HPE ProLiant DL325 Gen11"
+	[dl345g11]="HPE ProLiant DL345 Gen11"
+	[dl380g11]="HPE ProLiant DL380 Gen11"
+	[dl385g11]="HPE ProLiant DL385 Gen11"
+	[dl560g11]="HPE ProLiant DL560 Gen11"
+	[rl300g11]="HPE ProLiant RL300 Gen11"
+)
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+usage() {
+	sed -n '/^# Usage:/,/^[^#]/{ /^#/{ s/^# \{0,1\}//; p } }' "$0"
+}
+
+is_hpe_signed() {
+	local file="$1"
+	local magic
+	magic=$(dd if="$file" bs=5 count=1 2>/dev/null | cat)
+	[[ "$magic" == "$HPE_HEADER_MAGIC" ]]
+}
+
+strip_hpe_header() {
+	local src="$1"
+	local dst="$2"
+	local filesize
+	filesize=$(wc -c < "$src")
+	local overhead=$(( filesize - BIOS_SIZE ))
+
+	if (( overhead <= 0 )); then
+		die "File '$src' is not larger than $BIOS_SIZE bytes; cannot be HPE-signed"
+	fi
+
+	echo "	Stripping HPE header: ${overhead} bytes (0x$(printf '%x' $overhead))"
+
+	dd if="$src" of="$dst" bs="$overhead" skip=1 2>/dev/null
+}
+
+find_default_key() {
+	if [[ -n "${SIGNING_KEY:-}" && -f "$SIGNING_KEY" ]]; then
+		echo "$SIGNING_KEY"
+		return
+	fi
+
+	local script_dir
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local intree="${script_dir}/../../openbmc/meta-phosphor/recipes-phosphor/flash/files/OpenBMC.priv"
+	if [[ -f "$intree" ]]; then
+		echo "$intree"
+		return
+	fi
+
+	die "Cannot find OpenBMC private key. Set SIGNING_KEY or pass -k <path>."
+}
+
+derive_public_key() {
+	local privkey="$1"
+	local pubkey="$2"
+	openssl pkey -in "$privkey" -pubout -out "$pubkey"
+}
+
+sign_file() {
+	local privkey="$1"
+	local file="$2"
+	openssl dgst -sha256 -sign "$privkey" -out "${file}.sig" "$file"
+}
+
+INPUT=""
+MODEL=""
+MACHINENAME="hpe-proliant-g11"
+VERSION=""
+PRIVKEY=""
+OUTPUT=""
+
+while getopts ":i:m:v:k:o:h" opt; do
+	case "$opt" in
+		i) INPUT="$OPTARG" ;;
+		m) MODEL="$OPTARG" ;;
+		v) VERSION="$OPTARG" ;;
+		k) PRIVKEY="$OPTARG" ;;
+		o) OUTPUT="$OPTARG" ;;
+		h) usage; exit 0 ;;
+		:) die "Option -$OPTARG requires an argument." ;;
+		\?) die "Unknown option: -$OPTARG" ;;
+	esac
+done
+
+[[ -n "$INPUT" ]]	|| die "Missing required argument: -i <input>"
+[[ -n "$MODEL" ]]	|| die "Missing required argument: -m <model>"
+[[ -n "$VERSION" ]] || die "Missing required argument: -v <version>"
+[[ -f "$INPUT" ]]	|| die "Input file not found: $INPUT"
+
+if [[ -v MODEL_TARGET["$MODEL"] ]]; then
+	TARGET_MODEL="${MODEL_TARGET[$MODEL]}"
+else
+	die "Unknown model '$MODEL'. Add it to MODEL_TARGET in this script."
+fi
+
+if [[ -z "$OUTPUT" ]]; then
+	OUTPUT="./${MODEL}-bios-${VERSION}.tar"
+fi
+
+if [[ -z "$PRIVKEY" ]]; then
+	PRIVKEY="$(find_default_key)"
+fi
+[[ -f "$PRIVKEY" ]] || die "Private key not found: $PRIVKEY"
+
+echo "gen-hpe-bios-tar"
+echo "    Input:	$INPUT"
+echo "    Model:	$MODEL"
+echo "    Version:	$VERSION"
+echo "    Target:	$TARGET_MODEL"
+echo "    Key:		$PRIVKEY"
+echo "    Output:	$OUTPUT"
+
+TMPDIR=$(mktemp -d /tmp/gen-hpe-bios-tar.XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+RAWBIN="${TMPDIR}/${IMAGE_NAME}"
+
+echo ""
+echo "Extracting raw BIOS payload..."
+if is_hpe_signed "$INPUT"; then
+	echo "    Detected HPE signed file (magic: '${HPE_HEADER_MAGIC}...')"
+	strip_hpe_header "$INPUT" "$RAWBIN"
+else
+	echo "    Detected raw image (no HPE header)"
+	cp "$INPUT" "$RAWBIN"
+fi
+
+ACTUAL_SIZE=$(wc -c < "$RAWBIN")
+if (( ACTUAL_SIZE != BIOS_SIZE )); then
+	die "Extracted payload size is ${ACTUAL_SIZE} bytes, expected ${BIOS_SIZE}. Aborting."
+fi
+echo "    Payload size: ${ACTUAL_SIZE} bytes (32 MiB)"
+
+echo ""
+echo "Generating MANIFEST..."
+MANIFEST="${TMPDIR}/MANIFEST"
+cat > "$MANIFEST" <<EOF
+purpose=xyz.openbmc_project.Software.Version.VersionPurpose.Host
+version=${VERSION}
+MachineName=${MACHINENAME}
+TargetModel=${TARGET_MODEL}
+KeyType=OpenBMC
+HashType=RSA-SHA256
+EOF
+echo "    MANIFEST:"
+sed 's/^/     /' "$MANIFEST"
+
+echo ""
+echo "Signing..."
+PUBKEY="${TMPDIR}/publickey"
+derive_public_key "$PRIVKEY" "$PUBKEY"
+echo "    Public key derived from private key"
+
+sign_file "$PRIVKEY" "$RAWBIN"
+echo "    Signed: ${IMAGE_NAME}"
+sign_file "$PRIVKEY" "$MANIFEST"
+echo "    Signed: MANIFEST"
+sign_file "$PRIVKEY" "$PUBKEY"
+echo "    Signed: publickey"
+
+echo ""
+echo "Creating tarball..."
+tar -C "$TMPDIR" -cvf "$OUTPUT" \
+	"$IMAGE_NAME" "${IMAGE_NAME}.sig" \
+	MANIFEST MANIFEST.sig \
+	publickey publickey.sig \
+	2>&1 | sed 's/^/  /'
+
+TARSIZE=$(wc -c < "$OUTPUT")
+echo ""
+echo "Done: $OUTPUT (${TARSIZE} bytes)"


### PR DESCRIPTION
This series adds support to update the BIOS (both the primary and secondary memory-mapped flash) in a powered-off state.

- 9d97ab5 adds the bash script that's being triggered by `phosphor-bmc-code-mgmt` to update the BIOS
- da56b77 adds a script for us to package the HPE binaries into a tarball that can be used for Redfish, as well as in the Web UI
- 91aed2a adds a fix in the Web UI to allow the user to select the correct target

Closes #84 