### PR TITLE
feat: reserve canopy HPE-DL320 before each job

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/dut.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/dut.yaml
@@ -3,7 +3,8 @@ label: hpe-dl320
 attributes:
   BMC: dl320g11-bmc-fwci.lab.9e.network
   BMCPassword: 0penBmc
-  DutAgent: worker102.lab.9e.network:1024
+  Agent: worker102.lab.9e.network:1024
   Device: dl320
   Host: dl320g11-1.lab.9e.network
   HostUser: oscar
+reservation-system: dutctl

--- a/.firmwareci/duts/dut-hpe-dl320/post.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/post.yaml
@@ -3,7 +3,7 @@ post-stage:
   - cmd: newdutctl
     name: Power off DUT
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: power
       args: ["off"]

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -2,7 +2,7 @@ pre-stage:
   - cmd: newdutctl
     name: Power off DUT
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: power
       args: ["off"]
@@ -10,7 +10,7 @@ pre-stage:
   - cmd: newdutctl
     name: Emulate Flash
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: emulate-bmc
       args: ["[[input.Binary]]"]
@@ -18,7 +18,7 @@ pre-stage:
   - cmd: newdutctl
     name: Power on DUT
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: power
       args: ["on"]
@@ -28,7 +28,7 @@ pre-stage:
     options:
       timeout: 10m
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: serial
-      args: ["Phosphor OpenBMC"]
+      args: ["expect", "Phosphor OpenBMC"]

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
@@ -8,7 +8,7 @@ pre-stage:
   - cmd: newdutctl
     name: Power off DUT
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: power
       args: ["off"]
@@ -16,7 +16,7 @@ pre-stage:
   - cmd: newdutctl
     name: Emulate Flash
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: emulate-bmc
       args: ["[[input.Binary]]"]
@@ -24,7 +24,7 @@ pre-stage:
   - cmd: newdutctl
     name: Power on DUT
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: power
       args: ["on"]
@@ -34,10 +34,10 @@ pre-stage:
     options:
       timeout: 80s
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: serial
-      args: ["Phosphor OpenBMC"]
+      args: ["expect", "Phosphor OpenBMC"]
 
 stages:
   - name: SSH Readiness

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
@@ -75,7 +75,7 @@ stages:
       - cmd: newdutctl
         name: Power off DUT
         parameters:
-          agent: "[[attributes.DutAgent]]"
+          agent: "[[attributes.Agent]]"
           device: "[[attributes.Device]]"
           command: power
           args: ["off"]
@@ -88,7 +88,7 @@ stages:
       - cmd: newdutctl
         name: Power on DUT
         parameters:
-          agent: "[[attributes.DutAgent]]"
+          agent: "[[attributes.Agent]]"
           device: "[[attributes.Device]]"
           command: power
           args: ["on"]
@@ -97,10 +97,10 @@ stages:
         options:
           timeout: 10m
         parameters:
-          agent: "[[attributes.DutAgent]]"
+          agent: "[[attributes.Agent]]"
           device: "[[attributes.Device]]"
           command: serial
-          args: ["Phosphor OpenBMC"]
+          args: ["expect", "Phosphor OpenBMC"]
 
   - name: Wait for BMC After Reboot
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
@@ -18,7 +18,7 @@ pre-stage:
   - cmd: newdutctl
     name: Power off DUT
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: power
       args: ["off"]
@@ -26,7 +26,7 @@ pre-stage:
   - cmd: newdutctl
     name: Emulate Flash
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: emulate-bmc
       args: ["[[input.Binary]]"]
@@ -34,7 +34,7 @@ pre-stage:
   - cmd: newdutctl
     name: Power on DUT
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: power
       args: ["on"]
@@ -44,10 +44,10 @@ pre-stage:
     options:
       timeout: 10m
     parameters:
-      agent: "[[attributes.DutAgent]]"
+      agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: serial
-      args: ["Phosphor OpenBMC"]
+      args: ["expect", "Phosphor OpenBMC"]
 
 stages:
   - name: Wait for BMC


### PR DESCRIPTION
dut-hpe-dl320 now sets reservation-system: dutctl so a job locks the board on worker102's dutagent instead of racing another job. Renamed the DutAgent attribute to Agent (required by the dutctl reservation adapter) across the DUT and the boot-time, user-persistence and vuart-kernel tests. The QEMU DUT keeps virtual reservation.