### PR TITLE
meta-hpe: enable bios firmware update

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0005-schemas-firmware-allow-for-updating-spi-partition.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/0005-schemas-firmware-allow-for-updating-spi-partition.patch
@@ -1,0 +1,78 @@
+From 3a60aa4722f0ac38f8d1019d7ffd89b008ffca7e Mon Sep 17 00:00:00 2001
+From: Alexander Hansen <alexander.hansen@9elements.com>
+Date: Wed, 1 Jul 2026 14:18:29 +0200
+Subject: [PATCH] schemas/firmware: allow for updating spi partition
+
+Some SPI flashes are partitioned to allow for A/B firmware updates
+without requiring multiple chips.
+
+Devicetree example:
+```
+   flash@1 {
+    compatible = "jedec,spi-nor";
+    reg = <1>;
+    partitions {
+     compatible = "fixed-partitions";
+     #address-cells = <1>;
+     #size-cells = <1>;
+
+     host-prime@0 {
+      label = "host-prime";
+      reg = <0x0 0x2000000>;
+     };
+     host-second@2000000 {
+      label = "host-second";
+      reg = <0x2000000 0x2000000>;
+     };
+    };
+   };
+```
+
+This shows up in sysfs like below:
+
+```
+root@hpe-proliant-g11:~# ls /sys/class/spi_master/spi1/spi1.1/mtd/
+mtd11    mtd11ro  mtd12    mtd12ro
+root@hpe-proliant-g11:~# cat /sys/class/spi_master/spi1/spi1.1/mtd/mtd11/name
+host-prime
+root@hpe-proliant-g11:~# cat /sys/class/spi_master/spi1/spi1.1/mtd/mtd12/name
+host-second
+```
+
+Adjust the schema to allow for configuring the partition to be updated.
+
+Tested: TODO
+
+Change-Id: Ifd0fa059d7b4b597d860bb0f9509282f6202f372
+Signed-off-by: Alexander Hansen <alexander.hansen@9elements.com>
+---
+Upstream-Status: Pending
+ schemas/firmware.json | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/schemas/firmware.json b/schemas/firmware.json
+index ba32140..52da6be 100644
+--- a/schemas/firmware.json
++++ b/schemas/firmware.json
+@@ -95,6 +95,10 @@
+                     "description": "The index of the SPI device connected to that controller",
+                     "type": "number"
+                 },
++                "Partition": {
++                    "description": "The name of the partition to update. Leave empty if there is only a single partition without a name.",
++                    "type": "string"
++                },
+                 "MuxOutputs": {
+                     "$ref": "#/$defs/MuxOutputs"
+                 },
+@@ -107,6 +111,7 @@
+                 "Type",
+                 "SPIControllerIndex",
+                 "SPIDeviceIndex",
++                "Partition",
+                 "MuxOutputs",
+                 "FirmwareInfo"
+             ]
+-- 
+2.54.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
@@ -262,19 +262,6 @@
             "Name": "UEFIPrimary",
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
-            "Partition": "host-prime",
-            "Type": "SPIFlash"
-        },
-        {
-            "FirmwareInfo": {
-                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL320G11.SPI.Host",
-                "VendorIANA": 47196
-            },
-            "MuxOutputs": [
-            ],
-            "Name": "UEFISecondary",
-            "SPIControllerIndex": 1,
-            "SPIDeviceIndex": 1,
             "Partition": "host-second",
             "Type": "SPIFlash"
         }

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
@@ -155,7 +155,7 @@
         },
         {
             "Class": "temp",
-            "InputUnavailableAsFailed": false,
+            "IgnoreFailIfHostOff": true,
             "Inputs": [
                 "Die CPU1"
             ],

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
@@ -251,6 +251,32 @@
             "Name": "GenericContainPort",
             "PortType": "containing",
             "Type": "Port"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL320G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFIPrimary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-prime",
+            "Type": "SPIFlash"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL320G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFISecondary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-second",
+            "Type": "SPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl345g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl345g11_baseboard.json
@@ -437,6 +437,19 @@
             "Name": "GenericContainPort",
             "PortType": "containing",
             "Type": "Port"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL345G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFIPrimary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-second",
+            "Type": "SPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
@@ -155,6 +155,7 @@
         },
         {
             "Class": "temp",
+            "IgnoreFailIfHostOff": true,
             "Inputs": [
                 "Die CPU1"
             ],
@@ -189,6 +190,7 @@
         {
             "Class": "temp",
             "InputUnavailableAsFailed": false,
+            "IgnoreFailIfHostOff": true,
             "Inputs": [
                 "Die CPU2"
             ],

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
@@ -308,6 +308,32 @@
             "Name": "GenericContainPort",
             "PortType": "containing",
             "Type": "Port"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL360G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFIPrimary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-prime",
+            "Type": "SPIFlash"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL360G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFISecondary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-second",
+            "Type": "SPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
@@ -321,19 +321,6 @@
             "Name": "UEFIPrimary",
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
-            "Partition": "host-prime",
-            "Type": "SPIFlash"
-        },
-        {
-            "FirmwareInfo": {
-                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL360G11.SPI.Host",
-                "VendorIANA": 47196
-            },
-            "MuxOutputs": [
-            ],
-            "Name": "UEFISecondary",
-            "SPIControllerIndex": 1,
-            "SPIDeviceIndex": 1,
             "Partition": "host-second",
             "Type": "SPIFlash"
         }

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
@@ -909,6 +909,32 @@
             "Name": "GenericContainPort",
             "PortType": "containing",
             "Type": "Port"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL365G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFIPrimary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-prime",
+            "Type": "SPIFlash"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL365G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFISecondary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-second",
+            "Type": "SPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
@@ -920,19 +920,6 @@
             "Name": "UEFIPrimary",
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
-            "Partition": "host-prime",
-            "Type": "SPIFlash"
-        },
-        {
-            "FirmwareInfo": {
-                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL365G11.SPI.Host",
-                "VendorIANA": 47196
-            },
-            "MuxOutputs": [
-            ],
-            "Name": "UEFISecondary",
-            "SPIControllerIndex": 1,
-            "SPIDeviceIndex": 1,
             "Partition": "host-second",
             "Type": "SPIFlash"
         }

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380ag11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380ag11_baseboard.json
@@ -346,6 +346,19 @@
             "Name": "GenericContainPort",
             "PortType": "containing",
             "Type": "Port"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL380aG11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFIPrimary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-second",
+            "Type": "SPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380g11_baseboard.json
@@ -346,6 +346,19 @@
             "Name": "GenericContainPort",
             "PortType": "containing",
             "Type": "Port"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL380G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFIPrimary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-second",
+            "Type": "SPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl385g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl385g11_baseboard.json
@@ -492,6 +492,19 @@
             "Name": "GenericContainPort",
             "PortType": "containing",
             "Type": "Port"
+        },
+        {
+            "FirmwareInfo": {
+                "CompatibleHardware": "com.hpe.Hardware.ProLiantDL385G11.SPI.Host",
+                "VendorIANA": 47196
+            },
+            "MuxOutputs": [
+            ],
+            "Name": "UEFIPrimary",
+            "SPIControllerIndex": 1,
+            "SPIDeviceIndex": 1,
+            "Partition": "host-second",
+            "Type": "SPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager_git.bbappend
@@ -4,6 +4,7 @@ SRC_URI += "file://0001-devicetree-vpd-add-part-number-parsing.patch"
 SRC_URI += "file://0002-devicetree-vpd-add-manufacturer-parsing.patch"
 SRC_URI += "file://0003-entity-manager-move-D-Bus-name-and-path-to-shared-co.patch"
 SRC_URI += "file://0004-entity-manager-avoid-probing-own-D-Bus-name.patch"
+SRC_URI += "file://0005-schemas-firmware-allow-for-updating-spi-partition.patch"
 ERROR_QA:remove = "patch-status"
 
 # Enable devicetree VPD parser for platform identification

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/0001-bios-no-not-require-mux-GPIOs.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/0001-bios-no-not-require-mux-GPIOs.patch
@@ -1,0 +1,236 @@
+From 7285b68bd6c1c78ab24d081a3a422921d9a2a86b Mon Sep 17 00:00:00 2001
+From: Alexander Hansen <alexander.hansen@9elements.com>
+Date: Thu, 25 Jun 2026 18:15:05 +0200
+Subject: [PATCH 1/2] bios: no not require mux GPIOs
+
+Not every platform has their SPI flash behind a gpio Mux, we should not
+stop the update process because no lines were configured.
+
+For example HPE ProLiant Gen11 does not have a gpio mux for the SPI
+flash.
+
+Also we should not assume a specific driver. In this patch, the step of
+binding the flash to the driver is skipped if the flash is already
+bound. In case of HPE ProLiant Gen11 it is already bound via devicetree
+and not using aspeed spi smc driver either, so binding that would not
+work since it is using an HPE GXP SoC for BMC.
+
+```
+root@hpe-proliant-g11:~# ls /sys/bus/spi/drivers/spi-nor/
+bind    spi0.0  spi1.0  spi1.1  uevent  unbind
+
+root@hpe-proliant-g11:~# zcat /proc/config.gz | grep -i HPE
+CONFIG_ARCH_HPE=y
+CONFIG_ARCH_HPE_GXP=y
+CONFIG_SOC_HPE=y
+CONFIG_SOC_HPE_GXP=y
+CONFIG_NVMEM_HPE_GXP=y
+```
+
+Tested: on HPE ProLiant Gen11 D360
+
+```
+root@hpe-proliant-g11:~# busctl introspect xyz.openbmc_project.EntityManager /xyz/openbmc_project/inventory/system/chassis/chassis/HostSPIFlash
+...
+xyz.openbmc_project.Configuration.... interface -         -                      -
+.Name                                 property  s         "HostSPIFlash"         emits-change
+.SPIControllerIndex                   property  t         1                      emits-change
+.SPIDeviceIndex                       property  t         1                      emits-change
+.Type                                 property  s         "SPIFlash"             emits-change
+xyz.openbmc_project.Configuration.... interface -         -                      -
+.CompatibleHardware                   property  s         "com.hpe.proliant.g11" emits-change
+.VendorIANA                           property  t         47196                  emits-change
+root@hpe-proliant-g11:~# busctl tree xyz.openbmc_project.Software.BIOS
+`- /xyz
+  `- /xyz/openbmc_project
+    `- /xyz/openbmc_project/software
+      `- /xyz/openbmc_project/software/HostSPIFlash_146
+```
+
+The fw inventory item shows up
+
+```
+curl --silent --show-error --insecure --user root:0penBmc https://hpe-dl360-g11-bmc.dut.lab.bs.9e.network:443/redfish/v1/UpdateService/FirmwareInventory
+{
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/76399742"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/HostSPIFlash_146"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/bios_active"
+    }
+  ],
+  "Members@odata.count": 3,
+  "Name": "Software Inventory Collection"
+}
+```
+
+Starting the update request:
+
+```
+curl -k --insecure --user root:0penBmc -H Content-Type:multipart/form-data -X POST -F 'UpdateParameters={"Targets":["/redfish/v1/UpdateService/FirmwareInventory/HostSPIFlash_146"],"@Redfish.OperationApplyTime":"Immediate"};type=application/json' -F 'UpdateFile=@pldm-package-hpe-proliant-g11-d360-host.bin;type=application/octet-stream' https://hpe-dl360-g11-bmc.dut.lab.bs.9e.network:443/redfish/v1/UpdateService/update-multipart
+{
+  "@odata.id": "/redfish/v1/TaskService/Tasks/1",
+  "@odata.type": "#Task.v1_4_3.Task",
+  "HidePayload": false,
+  "Id": "1",
+  "Messages": [
+    {
+      "@odata.type": "#Message.v1_1_1.Message",
+      "Message": "The task with Id '1' has started.",
+      "MessageArgs": [
+        "1"
+      ],
+      "MessageId": "TaskEvent.1.0.TaskStarted",
+      "MessageSeverity": "OK",
+      "Resolution": "None."
+    }
+  ],
+  "Name": "Task 1",
+  "Payload": {
+    "HttpHeaders": [],
+    "HttpOperation": "POST",
+    "TargetUri": "/redfish/v1/UpdateService/update-multipart"
+  },
+  "PercentComplete": 0,
+  "StartTime": "2026-06-30T14:54:36+00:00",
+  "TaskMonitor": "/redfish/v1/TaskService/TaskMonitors/1",
+  "TaskState": "Running",
+  "TaskStatus": "OK"
+}
+```
+
+After completing the update, the new host fw version shows up in fw
+inventory:
+```
+{
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/22ba1852"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/HostSPIFlash_9805"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/bios_active"
+    }
+  ],
+  "Members@odata.count": 3,
+  "Name": "Software Inventory Collection"
+}
+```
+
+Change-Id: I7e24011890b4e28fbe832746de877078864a41a6
+Signed-off-by: Alexander Hansen <alexander.hansen@9elements.com>
+---
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/phosphor-bmc-code-mgmt/+/91736]
+ bios/spi_device.cpp | 73 ++++++++++++++++++++++++++++-----------------
+ 1 file changed, 45 insertions(+), 28 deletions(-)
+
+diff --git a/bios/spi_device.cpp b/bios/spi_device.cpp
+index b1ba4a4..cfc5f5c 100644
+--- a/bios/spi_device.cpp
++++ b/bios/spi_device.cpp
+@@ -233,47 +233,64 @@ sdbusplus::async::task<bool> SPIDevice::writeSPIFlash(const uint8_t* image,
+     }
+     else
+     {
+-        error("No GPIO lines configured for SPI muxing");
++        info("No GPIO lines configured for SPI muxing, proceeding.");
++    }
++
++    bool success = true;
++    bool needsUnbind = false;
++
++    if (!isSPIFlashBound())
++    {
++        needsUnbind = true;
++        success = co_await SPIDevice::bindSPIFlash();
++    }
++    else
++    {
++        debug("SPI flash already bound, skipping binding step.");
++    }
++
++    if (!success)
++    {
+         co_return false;
+     }
+ 
+-    bool success = co_await SPIDevice::bindSPIFlash();
+-    if (success)
++    if (dryRun)
++    {
++        info("dry run, NOT writing to the chip");
++    }
++    else
+     {
+-        if (dryRun)
++        if (tool == flashToolFlashrom)
+         {
+-            info("dry run, NOT writing to the chip");
++            success = co_await SPIDevice::writeSPIFlashWithFlashrom(
++                image, image_size);
++            if (!success)
++            {
++                error(
++                    "Error writing to SPI flash {CONTROLLERINDEX}:{DEVICEINDEX}",
++                    "CONTROLLERINDEX", spiControllerIndex, "DEVICEINDEX",
++                    spiDeviceIndex);
++            }
++        }
++        else if (tool == flashToolFlashcp)
++        {
++            success =
++                co_await SPIDevice::writeSPIFlashWithFlashcp(image, image_size);
+         }
+         else
+         {
+-            if (tool == flashToolFlashrom)
+-            {
+-                success = co_await SPIDevice::writeSPIFlashWithFlashrom(
+-                    image, image_size);
+-                if (!success)
+-                {
+-                    error(
+-                        "Error writing to SPI flash {CONTROLLERINDEX}:{DEVICEINDEX}",
+-                        "CONTROLLERINDEX", spiControllerIndex, "DEVICEINDEX",
+-                        spiDeviceIndex);
+-                }
+-            }
+-            else if (tool == flashToolFlashcp)
+-            {
+-                success = co_await SPIDevice::writeSPIFlashWithFlashcp(
+-                    image, image_size);
+-            }
+-            else
+-            {
+-                success =
+-                    co_await SPIDevice::writeSPIFlashDefault(image, image_size);
+-            }
++            success =
++                co_await SPIDevice::writeSPIFlashDefault(image, image_size);
+         }
++    }
+ 
++    lg2::info("Successfully updated SPI flash");
++
++    if (needsUnbind)
++    {
+         success = success && co_await SPIDevice::unbindSPIFlash();
+     }
+ 
+-    lg2::info("Successfully updated SPI flash");
+     co_return success;
+ }
+ 
+-- 
+2.54.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/0002-allow-for-updating-spi-partitions.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager/0002-allow-for-updating-spi-partitions.patch
@@ -1,0 +1,201 @@
+From be589e9299c29c55d19e764b907dc2beaf8cbffe Mon Sep 17 00:00:00 2001
+From: Alexander Hansen <alexander.hansen@9elements.com>
+Date: Wed, 1 Jul 2026 15:24:18 +0200
+Subject: [PATCH 2/2] allow for updating spi partitions
+
+Some SPI flashes are partitioned to allow for A/B firmware updates
+without requiring multiple chips.
+
+Devicetree example:
+```
+flash@1 {
+compatible = "jedec,spi-nor";
+reg = <1>;
+partitions {
+ compatible = "fixed-partitions";
+ #address-cells = <1>;
+ #size-cells = <1>;
+
+ host-prime@0 {
+  label = "host-prime";
+  reg = <0x0 0x2000000>;
+ };
+ host-second@2000000 {
+  label = "host-second";
+  reg = <0x2000000 0x2000000>;
+ };
+};
+};
+```
+
+This shows up in sysfs like below:
+
+```
+root@hpe-proliant-g11:~# ls /sys/class/spi_master/spi1/spi1.1/mtd/
+mtd11    mtd11ro  mtd12    mtd12ro
+root@hpe-proliant-g11:~# cat /sys/class/spi_master/spi1/spi1.1/mtd/mtd11/name
+host-prime
+root@hpe-proliant-g11:~# cat /sys/class/spi_master/spi1/spi1.1/mtd/mtd12/name
+host-second
+```
+
+Adjust the code to allow for configuring the partition to be updated.
+In case no partition is configured (empty string property value), the
+update should work as before.
+
+Tested: TODO
+
+Change-Id: I42eaf85c925cde3d5029fb6b9165d2572ca13978
+Signed-off-by: Alexander Hansen <alexander.hansen@9elements.com>
+---
+Upstream-Status: Pending
+ bios/bios_software_manager.cpp | 23 +++++++++++++++----
+ bios/spi_device.cpp            | 42 ++++++++++++++++++++++++++--------
+ bios/spi_device.hpp            |  5 +++-
+ 3 files changed, 56 insertions(+), 14 deletions(-)
+
+diff --git a/bios/bios_software_manager.cpp b/bios/bios_software_manager.cpp
+index c441284..d1b3c87 100644
+--- a/bios/bios_software_manager.cpp
++++ b/bios/bios_software_manager.cpp
+@@ -46,6 +46,19 @@ sdbusplus::async::task<bool> BIOSSoftwareManager::initDevice(
+         co_return false;
+     }
+ 
++    std::optional<std::string> partition =
++        co_await dbusGetRequiredProperty<std::string>(ctx, service, path,
++                                                      configIface, "Partition");
++
++    if (!partition.has_value())
++    {
++        error("Missing property: Partition");
++        co_return false;
++    }
++
++    // empty string means no partition configured
++    partition = (partition == "") ? std::nullopt : partition;
++
+     enum FlashTool tool = flashToolNone;
+ 
+     if (config.configType == "IntelSPIFlash")
+@@ -85,15 +98,17 @@ sdbusplus::async::task<bool> BIOSSoftwareManager::initDevice(
+ 
+     enum FlashLayout layout = flashLayoutFlat;
+ 
+-    debug("SPI device: {INDEX1}:{INDEX2}", "INDEX1", spiControllerIndex.value(),
+-          "INDEX2", spiDeviceIndex.value());
++    debug("SPI device: {INDEX1}:{INDEX2}, Partition {PARTITION}", "INDEX1",
++          spiControllerIndex.value(), "INDEX2", spiDeviceIndex.value(),
++          "PARTITION", partition.value());
+ 
+     std::unique_ptr<SPIDevice> spiDevice;
+     try
+     {
+         spiDevice = std::make_unique<SPIDevice>(
+-            ctx, spiControllerIndex.value(), spiDeviceIndex.value(), dryRun,
+-            names, values, config, this, layout, tool);
++            ctx, spiControllerIndex.value(), spiDeviceIndex.value(),
++            partition.value(), dryRun, names, values, config, this, layout,
++            tool);
+     }
+     catch (std::exception& e)
+     {
+diff --git a/bios/spi_device.cpp b/bios/spi_device.cpp
+index cfc5f5c..0608f5b 100644
+--- a/bios/spi_device.cpp
++++ b/bios/spi_device.cpp
+@@ -56,20 +56,20 @@ static std::optional<std::string> getSPIDevAddr(uint64_t spiControllerIndex)
+     return std::nullopt;
+ }
+ 
+-SPIDevice::SPIDevice(sdbusplus::async::context& ctx,
+-                     uint64_t spiControllerIndex, uint64_t spiDeviceIndex,
+-                     bool dryRun, const std::vector<std::string>& gpioLinesIn,
+-                     const std::vector<bool>& gpioValuesIn,
+-                     SoftwareConfig& config, SoftwareManager* parent,
+-                     enum FlashLayout layout, enum FlashTool tool,
+-                     const std::string& versionDirPath) :
++SPIDevice::SPIDevice(
++    sdbusplus::async::context& ctx, uint64_t spiControllerIndex,
++    uint64_t spiDeviceIndex, const std::optional<std::string>& partition,
++    bool dryRun, const std::vector<std::string>& gpioLinesIn,
++    const std::vector<bool>& gpioValuesIn, SoftwareConfig& config,
++    SoftwareManager* parent, enum FlashLayout layout, enum FlashTool tool,
++    const std::string& versionDirPath) :
+     Device(ctx, config, parent,
+            {RequestedApplyTimes::Immediate, RequestedApplyTimes::OnReset}),
+     NotifyWatchIntf(ctx, versionDirPath), dryRun(dryRun),
+     gpioLines(gpioLinesIn),
+     gpioValues(gpioValuesIn.begin(), gpioValuesIn.end()),
+     spiControllerIndex(spiControllerIndex), spiDeviceIndex(spiDeviceIndex),
+-    layout(layout), tool(tool)
++    partition(partition), layout(layout), tool(tool)
+ {
+     auto optAddr = getSPIDevAddr(spiControllerIndex);
+ 
+@@ -511,6 +511,20 @@ auto SPIDevice::processUpdate(std::string versionFileName)
+     co_return;
+ }
+ 
++// @returns empty string if no name was found
++static std::string getMTDName(const std::filesystem::path& mtdPath)
++{
++    const std::filesystem::path namePath = mtdPath / "name";
++    std::string partitionName = "";
++
++    if (std::filesystem::exists(namePath))
++    {
++        std::ifstream nameFile(namePath);
++        nameFile >> partitionName;
++    }
++    return partitionName;
++}
++
+ std::optional<std::string> SPIDevice::getMTDDevicePath() const
+ {
+     const std::string spiPath =
+@@ -528,7 +542,17 @@ std::optional<std::string> SPIDevice::getMTDDevicePath() const
+     {
+         const std::string mtdName = entry.path().filename().string();
+ 
+-        if (mtdName.starts_with("mtd") && !mtdName.ends_with("ro"))
++        if (!mtdName.starts_with("mtd") || mtdName.ends_with("ro"))
++        {
++            continue;
++        }
++
++        if (!partition.has_value())
++        {
++            return "/dev/" + mtdName;
++        }
++
++        if (getMTDName(entry.path()) == partition.value())
+         {
+             return "/dev/" + mtdName;
+         }
+diff --git a/bios/spi_device.hpp b/bios/spi_device.hpp
+index a0b1b62..daed61a 100644
+--- a/bios/spi_device.hpp
++++ b/bios/spi_device.hpp
+@@ -43,7 +43,8 @@ class SPIDevice : public Device, public NotifyWatchIntf
+   public:
+     using Device::softwareCurrent;
+     SPIDevice(sdbusplus::async::context& ctx, uint64_t spiControllerIndex,
+-              uint64_t spiDeviceIndex, bool dryRun,
++              uint64_t spiDeviceIndex,
++              const std::optional<std::string>& partition, bool dryRun,
+               const std::vector<std::string>& gpioLinesIn,
+               const std::vector<bool>& gpioValuesIn, SoftwareConfig& config,
+               SoftwareManager* parent, enum FlashLayout layout,
+@@ -68,6 +69,8 @@ class SPIDevice : public Device, public NotifyWatchIntf
+ 
+     uint64_t spiControllerIndex;
+     uint64_t spiDeviceIndex;
++    // optional name of the flash partition as listed in /dev/mtd/by-name/
++    std::optional<std::string> partition;
+ 
+     // e.g. "1e631000.spi"
+     std::string spiDev;
+-- 
+2.54.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,4 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+    file://0001-bios-no-not-require-mux-GPIOs.patch \
+    file://0002-allow-for-updating-spi-partitions.patch \
+    "
+
 PACKAGECONFIG:append = " flash_bios"
+PACKAGECONFIG:append = " bios-software-update"
 
 # Without this GXP SROT would fail if u-boot changes after a non-all tarball
 # update because the old RSA signature is left on flash while u-boot.bin

--- a/meta-canopy/recipes-phosphor/webui/webui-vue/0001-firmware-add-update-target-dropdown-to-form.patch
+++ b/meta-canopy/recipes-phosphor/webui/webui-vue/0001-firmware-add-update-target-dropdown-to-form.patch
@@ -1,0 +1,215 @@
+From 7afec83a5361a12ffca9e81b76df326bfcf22d5a Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Wed, 24 Jun 2026 23:57:45 +0200
+Subject: [PATCH] firmware: add update target dropdown to form
+
+The firmware update form always uses the BMC path as the Targets value
+in the multipart HTTP push request, breaking updates for other
+components such as BIOS (bios_active), SPI and CPLD modules.
+
+Fetch all members of /redfish/v1/UpdateService/FirmwareInventory and
+expose those with Updateable=true as selectable targets in a new
+dropdown, using the Description field with the ID as the display label.
+(or falling back to the ID only if the description is not set.)
+The dropdown defaults to the bmc_active entry to preserve existing
+behavior. The selected target is passed as Targets in the update
+request.
+
+This also enables updating firmware targets that are exposed via the
+"xyz.openbmc_project.Configuration.SPIFlash" interface.
+
+Tested: Ensure that BMC update target is selected by default, that all
+        available targets from the firmware inventory are listed (with
+        updatable being true) and that selecting e.g. "Host firmware
+        (UEFIPrimary_8497)" sends the upload POST with the selected
+        target.
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/webui-vue/+/91863]
+Change-Id: I94063a2fff689c7c2e2625c625c250dac757ce5b
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ src/locales/en-US.json                        |  1 +
+ src/locales/ka-GE.json                        |  1 +
+ src/locales/ru-RU.json                        |  1 +
+ src/store/modules/Operations/FirmwareStore.js | 22 ++++++++++
+ .../Firmware/FirmwareFormUpdate.vue           | 43 +++++++++++++++++++
+ 5 files changed, 68 insertions(+)
+
+diff --git a/src/locales/en-US.json b/src/locales/en-US.json
+index b4e1df0..4ee32c7 100644
+--- a/src/locales/en-US.json
++++ b/src/locales/en-US.json
+@@ -365,6 +365,7 @@
+                 "fileSource": "File source",
+                 "imageFile": "Image file",
+                 "startUpdate": "Start update",
++                "updateTarget": "Update target",
+                 "workstation": "Workstation"
+             }
+         },
+diff --git a/src/locales/ka-GE.json b/src/locales/ka-GE.json
+index 20cc17d..cfa48bc 100644
+--- a/src/locales/ka-GE.json
++++ b/src/locales/ka-GE.json
+@@ -365,6 +365,7 @@
+                 "fileSource": "ფაილის წყარო",
+                 "imageFile": "ასლის ფაილი",
+                 "startUpdate": "განახლების დაწყება",
++                "updateTarget": "განახლების სამიზნე",
+                 "workstation": "სამუშაო სადგური"
+             }
+         },
+diff --git a/src/locales/ru-RU.json b/src/locales/ru-RU.json
+index 663ebce..ee14ff5 100644
+--- a/src/locales/ru-RU.json
++++ b/src/locales/ru-RU.json
+@@ -365,6 +365,7 @@
+                 "fileSource": "Источник файла",
+                 "imageFile": "Файл образа",
+                 "startUpdate": "Начать обновление",
++                "updateTarget": "Объект обновления",
+                 "workstation": "Рабочая станция"
+             }
+         },
+diff --git a/src/store/modules/Operations/FirmwareStore.js b/src/store/modules/Operations/FirmwareStore.js
+index 07ce606..3e2a082 100644
+--- a/src/store/modules/Operations/FirmwareStore.js
++++ b/src/store/modules/Operations/FirmwareStore.js
+@@ -11,6 +11,7 @@ const FirmwareStore = {
+     applyTime: null,
+     multipartHttpPushUri: null,
+     httpPushUri: null,
++    updateableInventoryItems: [],
+   },
+   getters: {
+     isSingleFileUploadEnabled: (state) => state.biosFirmware.length === 0,
+@@ -34,6 +35,16 @@ const FirmwareStore = {
+         (firmware) => firmware.id !== state.biosActiveFirmwareId,
+       );
+     },
++    updateableInventoryItems: (state) => state.updateableInventoryItems,
++    defaultUpdateTarget: (state) => {
++      if (state.bmcActiveFirmwareId) {
++        const bmcItem = state.updateableInventoryItems.find((item) =>
++          item.location.endsWith('/' + state.bmcActiveFirmwareId),
++        );
++        if (bmcItem) return bmcItem.location;
++      }
++      return state.updateableInventoryItems[0]?.location || null;
++    },
+   },
+   mutations: {
+     setActiveBmcFirmwareId: (state, id) => (state.bmcActiveFirmwareId = id),
+@@ -44,6 +55,8 @@ const FirmwareStore = {
+     setHttpPushUri: (state, httpPushUri) => (state.httpPushUri = httpPushUri),
+     setMultipartHttpPushUri: (state, multipartHttpPushUri) =>
+       (state.multipartHttpPushUri = multipartHttpPushUri),
++    setUpdateableInventoryItems: (state, items) =>
++      (state.updateableInventoryItems = items),
+   },
+   actions: {
+     async getFirmwareInformation({ dispatch }) {
+@@ -81,6 +94,7 @@ const FirmwareStore = {
+         .then((response) => {
+           const bmcFirmware = [];
+           const biosFirmware = [];
++          const updateableInventoryItems = [];
+           response.forEach(({ data }) => {
+             const firmwareType = data?.RelatedItem?.[0]?.['@odata.id']
+               .split('/')
+@@ -96,9 +110,17 @@ const FirmwareStore = {
+             } else if (firmwareType === 'Bios') {
+               biosFirmware.push(item);
+             }
++            if (data?.Updateable === true) {
++              updateableInventoryItems.push({
++                location: data?.['@odata.id'],
++                id: data?.Id,
++                description: data?.Description,
++              });
++            }
+           });
+           commit('setBmcFirmware', bmcFirmware);
+           commit('setBiosFirmware', biosFirmware);
++          commit('setUpdateableInventoryItems', updateableInventoryItems);
+         })
+         .catch((error) => {
+           console.log(error);
+diff --git a/src/views/Operations/Firmware/FirmwareFormUpdate.vue b/src/views/Operations/Firmware/FirmwareFormUpdate.vue
+index 30aca15..0212c70 100644
+--- a/src/views/Operations/Firmware/FirmwareFormUpdate.vue
++++ b/src/views/Operations/Firmware/FirmwareFormUpdate.vue
+@@ -2,6 +2,21 @@
+   <div>
+     <div class="form-background p-3">
+       <b-form @submit.prevent="onSubmitUpload">
++        <!-- Update target selection -->
++        <b-form-group
++          v-if="updateTargetOptions.length > 0"
++          :label="$t('pageFirmware.form.updateFirmware.updateTarget')"
++          label-for="update-target"
++          class="mb-3"
++        >
++          <b-form-select
++            id="update-target"
++            v-model="selectedTarget"
++            :options="updateTargetOptions"
++            :disabled="isPageDisabled"
++          />
++        </b-form-group>
++
+         <!-- Workstation Upload -->
+         <b-form-group
+           :label="$t('pageFirmware.form.updateFirmware.imageFile')"
+@@ -75,10 +90,36 @@ export default {
+       loading,
+       showUpdateModal: false,
+       file: null,
++      selectedTarget: null,
+       isServerPowerOffRequired:
+         import.meta.env.VITE_SERVER_OFF_REQUIRED === 'true',
+     };
+   },
++  computed: {
++    updateTargetOptions() {
++      return this.$store.getters['firmware/updateableInventoryItems'].map(
++        (item) => ({
++          value: item.location,
++          text: item.description
++            ? `${item.description} (${item.id})`
++            : item.id,
++        }),
++      );
++    },
++    defaultUpdateTarget() {
++      return this.$store.getters['firmware/defaultUpdateTarget'];
++    },
++  },
++  watch: {
++    defaultUpdateTarget: {
++      immediate: true,
++      handler(newVal) {
++        if (newVal && this.selectedTarget === null) {
++          this.selectedTarget = newVal;
++        }
++      },
++    },
++  },
+   validations() {
+     return {
+       file: {
+@@ -109,9 +150,11 @@ export default {
+       this.dispatchWorkstationUpload(timerId);
+     },
+     dispatchWorkstationUpload(timerId) {
++      const targets = this.selectedTarget ? [this.selectedTarget] : undefined;
+       this.$store
+         .dispatch('firmware/uploadFirmware', {
+           image: this.file,
++          targets,
+         })
+         .catch(({ message }) => {
+           this.endLoader();
+-- 
+2.53.0
+

--- a/meta-canopy/recipes-phosphor/webui/webui-vue_%.bbappend
+++ b/meta-canopy/recipes-phosphor/webui/webui-vue_%.bbappend
@@ -15,6 +15,10 @@
 # upstream repo stays untouched.
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+SRC_URI:append = " \
+    file://0001-firmware-add-update-target-dropdown-to-form.patch \
+    "
+
 # Resolve the overlay directory at parse time
 CANOPY_WEBUI_OVERLAYS := "${THISDIR}/${BPN}"
 

--- a/meta-canopy/scripts/gen-hpe-bios-pldm
+++ b/meta-canopy/scripts/gen-hpe-bios-pldm
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script requires unencrypted, signed BIOS firmware files which are
+# not publicly distributed.
+# The structure is:
+# - Signature with PEM certificates (base64 + some ASCII)
+# - HPIMAGE metadata block
+# - BIOS payload
+#
+# This will strip the (for us) arbritrary data and write the BIOS payload
+# into a PLDM firmware package that can be used to update the system
+# afterwards.
+#
+# The ROM version is auto-detected from the [ROM_INFO] block embedded
+# in the binary. Use `-v` to override it.
+#
+# Usage:
+#	gen-hpe-bios-pldm‎ -i <input> [-m <model>] [-v <version>] [-o <output>]
+#
+# Arguments:
+#	-i <input>	Input file: HPE-signed (*.signed.flash) or raw 32 MiB image
+#				    (if dumped)
+#	-m <model>	Target model identifier (auto-detected for known SYSIDs)
+#	-v <version>	Override version string (default: auto-detect from binary)
+#	-o <output>	Output file path (default: ./<model>-bios-<version>.pldm)
+#	-h		Show this help message.
+#
+# Requirements:
+#	jq, python3, bitarray (pip install bitarray), strings (binutils)
+#
+# Examples:
+#	gen-hpe-bios-tar -i U63_2.92_05_28_2026.unencrypted.signed.flash  # model from SYSID
+#	gen-hpe-bios-tar -i U54_2.92_05_28_2026.unencrypted.signed.flash -m dl360g11
+#	gen-hpe-bios-tar -i host-prime.img -m dl365g11 -v 3.14
+
+set -euo pipefail
+
+export BIOS_SIZE=33554432
+export HPE_HEADER_MAGIC="--=</"
+export IMAGE_NAME="ImageHost.bin"
+# HPE IANA ID
+export IANA_HEX="5CB80000"
+# Must match with https://github.com/openbmc/pldm/blob/master/fw-update/package_parser.cpp#L294
+export PACKAGE_UUID="F018878CCB7D49439800A02F059ACA02"
+export PKG_FORMAT_VERSION=1
+export COMPONENT_CLASSIFICATION=10
+export COMPONENT_IDENTIFIER=1
+export ACTIVATION_METHOD='[0]'
+
+# Compatible string format: com.hpe.Hardware.<ModelTag>.SPI.Host
+declare -A MODEL_COMPAT_TAG=(
+	[dl360g11]="ProLiantDL360G11"
+	[dl365g11]="ProLiantDL365G11"
+	[dl110g11]="ProLiantDL110G11"
+	[dl145g11]="ProLiantDL145G11"
+	[dl320g11]="ProLiantDL320G11"
+	[dl325g11]="ProLiantDL325G11"
+	[dl345g11]="ProLiantDL345G11"
+	[dl380g11]="ProLiantDL380G11"
+	[dl385g11]="ProLiantDL385G11"
+	[dl560g11]="ProLiantDL560G11"
+	[rl300g11]="ProLiantRL300G11"
+)
+
+# From [ROM_INFO] (ROM_SYSID). SYSIDs can support multiple models.
+declare -A SYSID_MODELS=(
+	[U63]="dl320g11"
+	[U54]="dl360g11 dl380g11"
+	[A55]="dl365g11 dl385g11"
+)
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+usage() {
+	grep '^#' "$0" | sed -n '/^# Usage:/,/^# Requirements:/p' | sed 's/^# \{0,1\}//'
+	echo ""
+	echo "Supported models:"
+	for k in "${!MODEL_COMPAT_TAG[@]}"; do
+		printf "  %-12s %s\n" "$k" "${MODEL_COMPAT_TAG[$k]}"
+	done | sort
+}
+
+is_hpe_signed() {
+	local file="$1"
+	local magic
+	magic=$(dd if="$file" bs=5 count=1 2>/dev/null | cat)
+	[[ "$magic" == "$HPE_HEADER_MAGIC" ]]
+}
+
+strip_hpe_header() {
+	local src="$1"
+	local dst="$2"
+	local filesize=$(wc -c < "$src")
+	local overhead=$(( filesize - BIOS_SIZE ))
+	(( overhead > 0 )) || die "'$src' is not larger than $BIOS_SIZE bytes"
+	echo "  Stripping HPE header: ${overhead} bytes"
+	dd if="$src" of="$dst" bs="$overhead" skip=1 2>/dev/null
+}
+
+rom_info_get() {
+	local file="$1"
+	local key="$2"
+	{ strings "$file" || true; } | awk "
+		/^\[ROM_INFO\]/ { in_block=1; next }
+		in_block && /^\[/  { in_block=0 }
+		in_block && /^${key}=/ { sub(/^${key}=/, \"\"); print; exit }
+	" || true
+}
+
+INPUT=""
+MODEL=""
+VERSION_OVERRIDE=""
+OUTPUT=""
+
+while getopts ":i:m:v:o:h" opt; do
+	case "$opt" in
+		i) INPUT="$OPTARG" ;;
+		m) MODEL="$OPTARG" ;;
+		v) VERSION_OVERRIDE="$OPTARG" ;;
+		o) OUTPUT="$OPTARG" ;;
+		h) usage; exit 0 ;;
+		:) die "Option -$OPTARG requires an argument." ;;
+		\?) die "Unknown option: -$OPTARG" ;;
+	esac
+done
+
+[[ -n "$INPUT" ]] || die "Missing required argument: -i <input>"
+[[ -f "$INPUT" ]] || die "Input file not found: $INPUT"
+
+ROM_SYSID="$(rom_info_get "$INPUT" ROM_SYSID)"
+
+if [[ -n "$MODEL" ]]; then
+	if [[ ! -v MODEL_COMPAT_TAG["$MODEL"] ]]; then
+		die "Unknown model '$MODEL'. Supported: ${!MODEL_COMPAT_TAG[*]}"
+	fi
+	MODELS=("$MODEL")
+	echo "  Model:      $MODEL (explicit)"
+else
+	if [[ -z "$ROM_SYSID" ]]; then
+		die "Could not detect ROM_SYSID from binary. Pass -m <model> explicitly."
+	fi
+	if [[ ! -v SYSID_MODELS["$ROM_SYSID"] ]]; then
+		die "Unknown ROM_SYSID '$ROM_SYSID'. Add it to SYSID_MODELS or pass -m explicitly."
+	fi
+	read -ra MODELS <<< "${SYSID_MODELS[$ROM_SYSID]}"
+	echo "  Models:     ${MODELS[*]} (auto-detected from ROM_SYSID=$ROM_SYSID)"
+fi
+
+if [[ -n "$VERSION_OVERRIDE" ]]; then
+	VERSION="$VERSION_OVERRIDE"
+	echo "  Version:    $VERSION (from -v)"
+else
+	ROM_VER_X="$(rom_info_get "$INPUT" ROM_MAJOR_VER)"
+	ROM_VER_Y="$(rom_info_get "$INPUT" ROM_MINOR_VER)"
+	[ -n "$ROM_VER_X" || -n "$ROM_VER_Y" ]] || \
+		die "Could not find [ROM_INFO]/ROM_VER_* in '$INPUT'. Use -v to specify version."
+	VERSION="$ROM_VER_X.$ROM_VER_Y"
+	echo "  Version:    $VERSION (auto-detected from ROM_INFO)"
+fi
+
+if [[ -z "$OUTPUT" ]]; then
+	VERSION_SAFE="${VERSION// /_}"
+	VERSION_SAFE="${VERSION_SAFE//\//-}"
+	NAME_PREFIX="${ROM_SYSID:-${MODELS[0]}}"
+	OUTPUT="./${NAME_PREFIX}-bios-${VERSION_SAFE}.pldm"
+fi
+
+echo "  Input:      $INPUT"
+echo "  Output:     $OUTPUT"
+
+TMPDIR=$(mktemp -d /tmp/gen-hpe-bios-tar.XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+RAWBIN="${TMPDIR}/${IMAGE_NAME}"
+
+echo ""
+echo "Extracting raw BIOS payload..."
+if is_hpe_signed "$INPUT"; then
+	echo "  Detected HPE signed file (magic: '${HPE_HEADER_MAGIC}...')"
+	strip_hpe_header "$INPUT" "$RAWBIN"
+else
+	echo "  Detected raw image (no HPE header)"
+	cp "$INPUT" "$RAWBIN"
+fi
+
+ACTUAL_SIZE=$(wc -c < "$RAWBIN")
+(( ACTUAL_SIZE == BIOS_SIZE )) || \
+	die "Payload size is ${ACTUAL_SIZE} bytes, expected ${BIOS_SIZE}"
+echo "  Payload size: ${ACTUAL_SIZE} bytes (32 MiB)"
+
+METADATA_JSON="${TMPDIR}/metadata.json"
+
+COMPAT_JSON="{"
+for k in "${!MODEL_COMPAT_TAG[@]}"; do
+	COMPAT_JSON+="$(printf '"%s":"%s",' "$k" "${MODEL_COMPAT_TAG[$k]}")"
+done
+COMPAT_JSON="${COMPAT_JSON%,}}"
+
+COMPAT_STR_JSON="{"
+for k in "${!MODEL_COMPAT_TAG[@]}"; do
+	tag="${MODEL_COMPAT_TAG[$k]}"
+	compatible="com.hpe.Hardware.${tag}.SPI.Host"
+	COMPAT_STR_JSON+="$(printf '"%s":"%s",' "$k" "$compatible")"
+done
+COMPAT_STR_JSON="${COMPAT_STR_JSON%,}}"
+
+jq -n \
+	--arg      iana_hex      "$IANA_HEX" \
+	--arg      version       "$VERSION" \
+	--argjson  models        "$(printf '%s\n' "${MODELS[@]}" | jq -R . | jq -s .)" \
+	--argjson  compat_tags   "$COMPAT_JSON" \
+	--argjson  compat_str    "$COMPAT_STR_JSON" \
+	--arg      pkg_uuid      "$PACKAGE_UUID" \
+	--argjson  pkg_fmt_ver   "$PKG_FORMAT_VERSION" \
+	--argjson  comp_class    "$COMPONENT_CLASSIFICATION" \
+	--argjson  comp_id       "$COMPONENT_IDENTIFIER" \
+	--argjson  activation    "$ACTIVATION_METHOD" \
+'{
+    PackageHeaderInformation: {
+        PackageHeaderIdentifier:    $pkg_uuid,
+        PackageHeaderFormatVersion: $pkg_fmt_ver,
+        PackageVersionString:       $version
+    },
+    FirmwareDeviceIdentificationArea: [
+        $models[] | . as $model |
+        if $compat_tags[$model] == null then error("no compat tag for model \($model)") else . end |
+        {
+            DeviceUpdateOptionFlags:         [0],
+            ComponentImageSetVersionString:  $version,
+            ApplicableComponents:            [0],
+            Descriptors: [
+                { DescriptorType: 1,     DescriptorData: $iana_hex },
+                { DescriptorType: 65535, VendorDefinedDescriptorTitleString: $compat_str[$model],
+                                         VendorDefinedDescriptorData: "00" }
+            ]
+        }
+    ],
+    ComponentImageInformationArea: [{
+        ComponentClassification:            $comp_class,
+        ComponentIdentifier:                $comp_id,
+        ComponentOptions:                   [],
+        RequestedComponentActivationMethod: $activation,
+        ComponentVersionString:             $version
+    }]
+}' > "$METADATA_JSON"
+
+echo ""
+echo "PLDM metadata:"
+sed 's/^/  /' "$METADATA_JSON"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLDM_CREATOR="${SCRIPT_DIR}/pldm_fwup_pkg_creator.py"
+if [[ ! -f "$PLDM_CREATOR" ]]; then
+	die "pldm_fwup_pkg_creator.py not found at $PLDM_CREATOR"
+fi
+
+echo ""
+echo "Creating PLDM package..."
+python3 "$PLDM_CREATOR" "$OUTPUT" "$METADATA_JSON" "$RAWBIN"
+
+PKGSIZE=$(wc -c < "$OUTPUT")
+echo ""
+echo "Done: $OUTPUT (${PKGSIZE} bytes)"

--- a/meta-canopy/scripts/pldm_fwup_pkg_creator.py
+++ b/meta-canopy/scripts/pldm_fwup_pkg_creator.py
@@ -1,0 +1,1019 @@
+#!/usr/bin/env python3
+# Copied from: https://github.com/openbmc/pldm/blob/13b4eeb94f25e8314a7a6f4e26cef24788451b05/tools/fw-update/pldm_fwup_pkg_creator.py
+
+"""Script to create PLDM FW update package"""
+
+import argparse
+import binascii
+import enum
+import json
+import math
+import os
+import struct
+import sys
+from datetime import datetime
+
+from bitarray import bitarray
+from bitarray.util import ba2int
+
+string_types = dict(
+    [
+        ("Unknown", 0),
+        ("ASCII", 1),
+        ("UTF8", 2),
+        ("UTF16", 3),
+        ("UTF16LE", 4),
+        ("UTF16BE", 5),
+    ]
+)
+
+initial_descriptor_type_name_length = {
+    0x0000: ["PCI Vendor ID", 2],
+    0x0001: ["IANA Enterprise ID", 4],
+    0x0002: ["UUID", 16],
+    0x0003: ["PnP Vendor ID", 3],
+    0x0004: ["ACPI Vendor ID", 4],
+}
+
+descriptor_type_name_length = {
+    0x0000: ["PCI Vendor ID", 2],
+    0x0001: ["IANA Enterprise ID", 4],
+    0x0002: ["UUID", 16],
+    0x0003: ["PnP Vendor ID", 3],
+    0x0004: ["ACPI Vendor ID", 4],
+    0x0005: ["IEEE Assigned Company ID", 3],
+    0x0006: ["SCSI Vendor ID", 8],
+    0x0100: ["PCI Device ID", 2],
+    0x0101: ["PCI Subsystem Vendor ID", 2],
+    0x0102: ["PCI Subsystem ID", 2],
+    0x0103: ["PCI Revision ID", 1],
+    0x0104: ["PnP Product Identifier", 4],
+    0x0105: ["ACPI Product Identifier", 4],
+    0x0106: ["ASCII Model Number (Long String)", 40],
+    0x0107: ["ASCII Model Number (Short String)", 10],
+    0x0108: ["SCSI Product ID", 16],
+    0x0109: ["UBM Controller Device Code", 4],
+    0x010A: ["IEEE EUI-64 ID", 8],
+    0x010B: ["PCI Revision ID Range", 2],
+}
+
+expected_package_format_versions = [
+    1,  # DSP0267 1.0.0
+    2,  # DSP0267 1.1.0
+    3,  # DSP0267 1.2.0
+    4,  # DSP0267 1.3.0
+]
+
+
+class ComponentOptions(enum.IntEnum):
+    """
+    Enum to represent ComponentOptions
+    """
+
+    ForceUpdate = 0
+    UseComponentCompStamp = 1
+
+
+def check_string_length(string):
+    """Check if the length of the string is not greater than 255."""
+    if len(string) > 255:
+        sys.exit("ERROR: Max permitted string length is 255")
+
+
+def write_pkg_release_date_time(pldm_fw_up_pkg, release_date_time):
+    """
+    Write the timestamp into the package header. The timestamp is formatted as
+    series of 13 bytes defined in DSP0240 specification.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            release_date_time: Package Release Date Time
+    """
+    time = release_date_time.time()
+    date = release_date_time.date()
+    us_bytes = time.microsecond.to_bytes(3, byteorder="little")
+    pldm_fw_up_pkg.write(
+        struct.pack(
+            "<hBBBBBBBBHB",
+            0,
+            us_bytes[0],
+            us_bytes[1],
+            us_bytes[2],
+            time.second,
+            time.minute,
+            time.hour,
+            date.day,
+            date.month,
+            date.year,
+            0,
+        )
+    )
+
+
+def write_package_version_string(pldm_fw_up_pkg, metadata):
+    """
+    Write PackageVersionStringType, PackageVersionStringLength and
+    PackageVersionString to the package header.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            metadata: metadata about PLDM FW update package
+    """
+    # Hardcoded string type to ASCII
+    string_type = string_types["ASCII"]
+    package_version_string = metadata["PackageHeaderInformation"][
+        "PackageVersionString"
+    ]
+    check_string_length(package_version_string)
+    format_string = "<BB" + str(len(package_version_string)) + "s"
+    pldm_fw_up_pkg.write(
+        struct.pack(
+            format_string,
+            string_type,
+            len(package_version_string),
+            package_version_string.encode("ascii"),
+        )
+    )
+
+
+def write_component_bitmap_bit_length(pldm_fw_up_pkg, metadata):
+    """
+    ComponentBitmapBitLength in the package header indicates the number of bits
+    that will be used represent the bitmap in the ApplicableComponents field
+    for a matching device. The value shall be a multiple of 8 and be large
+    enough to contain a bit for each component in the package. The number of
+    components in the JSON file is used to populate the bitmap length.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            metadata: metadata about PLDM FW update package
+
+        Returns:
+            ComponentBitmapBitLength: number of bits that will be used
+            represent the bitmap in the ApplicableComponents field for a
+            matching device
+    """
+    # The script supports up to 32 components now
+    max_components = 32
+    bitmap_multiple = 8
+
+    num_components = len(metadata["ComponentImageInformationArea"])
+    if num_components > max_components:
+        sys.exit("ERROR: only up to 32 components supported now")
+    component_bitmap_bit_length = bitmap_multiple * math.ceil(
+        num_components / bitmap_multiple
+    )
+    pldm_fw_up_pkg.write(struct.pack("<H", int(component_bitmap_bit_length)))
+    return component_bitmap_bit_length
+
+
+def write_pkg_header_info(pldm_fw_up_pkg, metadata):
+    """
+    ComponentBitmapBitLength in the package header indicates the number of bits
+    that will be used represent the bitmap in the ApplicableComponents field
+    for a matching device. The value shall be a multiple of 8 and be large
+    enough to contain a bit for each component in the package. The number of
+    components in the JSON file is used to populate the bitmap length.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            metadata: metadata about PLDM FW update package
+
+        Returns:
+            ComponentBitmapBitLength: number of bits that will be used
+            represent the bitmap in the ApplicableComponents field for a
+            matching device
+    """
+    uuid = metadata["PackageHeaderInformation"]["PackageHeaderIdentifier"]
+    package_header_identifier = bytearray.fromhex(uuid)
+    pldm_fw_up_pkg.write(package_header_identifier)
+
+    package_header_format_revision = metadata["PackageHeaderInformation"][
+        "PackageHeaderFormatVersion"
+    ]
+    # Size will be computed and updated subsequently
+    package_header_size = 0
+    pldm_fw_up_pkg.write(
+        struct.pack("<BH", package_header_format_revision, package_header_size)
+    )
+
+    release_date_time_str = metadata["PackageHeaderInformation"].get(
+        "PackageReleaseDateTime", None
+    )
+
+    if release_date_time_str is not None:
+        formats = [
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%d/%m/%Y %H:%M:%S",
+        ]
+        release_date_time = None
+        for fmt in formats:
+            try:
+                release_date_time = datetime.strptime(
+                    release_date_time_str, fmt
+                )
+                break
+            except ValueError:
+                pass
+        if release_date_time is None:
+            sys.exit("Can't parse release date '%s'" % release_date_time_str)
+    else:
+        release_date_time = datetime.now()
+
+    write_pkg_release_date_time(pldm_fw_up_pkg, release_date_time)
+
+    component_bitmap_bit_length = write_component_bitmap_bit_length(
+        pldm_fw_up_pkg, metadata
+    )
+    write_package_version_string(pldm_fw_up_pkg, metadata)
+    return package_header_format_revision, component_bitmap_bit_length
+
+
+def get_applicable_components(device, components, component_bitmap_bit_length):
+    """
+    This function figures out the components applicable for the device and sets
+    the ApplicableComponents bitfield accordingly.
+
+        Parameters:
+            device: device information
+            components: list of components in the package
+            component_bitmap_bit_length: length of the ComponentBitmapBitLength
+
+        Returns:
+            The ApplicableComponents bitfield
+    """
+    applicable_components_list = device["ApplicableComponents"]
+    applicable_components = bitarray(
+        component_bitmap_bit_length, endian="little"
+    )
+    applicable_components.setall(0)
+    for component_index in applicable_components_list:
+        if 0 <= component_index < len(components):
+            applicable_components[component_index] = 1
+        else:
+            sys.exit("ERROR: Applicable Component index not found.")
+    return applicable_components
+
+
+def prepare_record_descriptors(descriptors):
+    """
+    This function processes the Descriptors and prepares the RecordDescriptors
+    section of the the firmware device ID record.
+
+        Parameters:
+            descriptors: Descriptors entry
+
+        Returns:
+            RecordDescriptors, DescriptorCount
+    """
+    record_descriptors = bytearray()
+    vendor_defined_desc_type = 65535
+    vendor_desc_title_str_type_len = 1
+    vendor_desc_title_str_len_len = 1
+    descriptor_count = 0
+
+    for descriptor in descriptors:
+        descriptor_type = descriptor["DescriptorType"]
+        if descriptor_count == 0:
+            if (
+                initial_descriptor_type_name_length.get(descriptor_type)
+                is None
+            ):
+                sys.exit("ERROR: Initial descriptor type not supported")
+        else:
+            if (
+                descriptor_type_name_length.get(descriptor_type) is None
+                and descriptor_type != vendor_defined_desc_type
+            ):
+                sys.exit("ERROR: Descriptor type not supported")
+
+        if descriptor_type == vendor_defined_desc_type:
+            vendor_desc_title_str = descriptor[
+                "VendorDefinedDescriptorTitleString"
+            ]
+            vendor_desc_data = descriptor["VendorDefinedDescriptorData"]
+            check_string_length(vendor_desc_title_str)
+            vendor_desc_title_str_type = string_types["ASCII"]
+            descriptor_length = (
+                vendor_desc_title_str_type_len
+                + vendor_desc_title_str_len_len
+                + len(vendor_desc_title_str)
+                + len(bytearray.fromhex(vendor_desc_data))
+            )
+            format_string = "<HHBB" + str(len(vendor_desc_title_str)) + "s"
+            record_descriptors.extend(
+                struct.pack(
+                    format_string,
+                    descriptor_type,
+                    descriptor_length,
+                    vendor_desc_title_str_type,
+                    len(vendor_desc_title_str),
+                    vendor_desc_title_str.encode("ascii"),
+                )
+            )
+            record_descriptors.extend(bytearray.fromhex(vendor_desc_data))
+            descriptor_count += 1
+        else:
+            descriptor_type = descriptor["DescriptorType"]
+            descriptor_data = descriptor["DescriptorData"]
+            descriptor_length = len(bytearray.fromhex(descriptor_data))
+            if (
+                descriptor_length
+                != descriptor_type_name_length.get(descriptor_type)[1]
+            ):
+                err_string = (
+                    "ERROR: Descriptor type - "
+                    + descriptor_type_name_length.get(descriptor_type)[0]
+                    + " length is incorrect"
+                )
+                sys.exit(err_string)
+            format_string = "<HH"
+            record_descriptors.extend(
+                struct.pack(format_string, descriptor_type, descriptor_length)
+            )
+            record_descriptors.extend(bytearray.fromhex(descriptor_data))
+            descriptor_count += 1
+    return record_descriptors, descriptor_count
+
+
+def write_fw_device_identification_area(
+    pldm_fw_up_pkg,
+    metadata,
+    package_header_format_revision,
+    component_bitmap_bit_length,
+):
+    """
+    Write firmware device ID records into the PLDM package header
+
+    This function writes the DeviceIDRecordCount and the
+    FirmwareDeviceIDRecords into the firmware update package by processing the
+    metadata JSON. Currently there is no support for optional
+    FirmwareDevicePackageData and ReferenceManifestData.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            metadata: metadata about PLDM FW update package
+            package_header_format_revision: Format Revision of the package
+            component_bitmap_bit_length: length of the ComponentBitmapBitLength
+    """
+    # The spec limits the number of firmware device ID records to 255
+    max_device_id_record_count = 255
+    devices = metadata["FirmwareDeviceIdentificationArea"]
+    device_id_record_count = len(devices)
+    if device_id_record_count > max_device_id_record_count:
+        sys.exit(
+            "ERROR: there can be only up to 255 entries in the                "
+            " FirmwareDeviceIdentificationArea section"
+        )
+
+    # DeviceIDRecordCount
+    pldm_fw_up_pkg.write(struct.pack("<B", device_id_record_count))
+
+    for device in devices:
+        # RecordLength size
+        record_length = 2
+
+        # DescriptorCount
+        record_length += 1
+
+        # DeviceUpdateOptionFlags
+        device_update_option_flags = bitarray(32, endian="little")
+        device_update_option_flags.setall(0)
+        # Continue component updates after failure
+        supported_device_update_option_flags = [0]
+        for option in device["DeviceUpdateOptionFlags"]:
+            if option not in supported_device_update_option_flags:
+                sys.exit("ERROR: unsupported DeviceUpdateOptionFlag entry")
+            device_update_option_flags[option] = 1
+        record_length += 4
+
+        # ComponentImageSetVersionStringType supports only ASCII for now
+        component_image_set_version_string_type = string_types["ASCII"]
+        record_length += 1
+
+        # ComponentImageSetVersionStringLength
+        component_image_set_version_string = device[
+            "ComponentImageSetVersionString"
+        ]
+        check_string_length(component_image_set_version_string)
+        record_length += len(component_image_set_version_string)
+        record_length += 1
+
+        # Optional FirmwareDevicePackageData not supported now,
+        # FirmwareDevicePackageDataLength is set to 0x0000
+        fw_device_pkg_data_length = 0
+        record_length += 2
+
+        # Optional ReferenceManifestData - read from JSON if provided
+        reference_manifest_data = None
+        reference_manifest_length = 0
+        if package_header_format_revision >= 4:
+            if "ReferenceManifestData" in device:
+                reference_manifest_data_str = device["ReferenceManifestData"]
+                reference_manifest_data = bytearray.fromhex(
+                    reference_manifest_data_str
+                )
+                reference_manifest_length = len(reference_manifest_data)
+                record_length += reference_manifest_length
+            record_length += 4
+
+        # ApplicableComponents
+        components = metadata["ComponentImageInformationArea"]
+        applicable_components = get_applicable_components(
+            device, components, component_bitmap_bit_length
+        )
+        applicable_components_bitfield_length = round(
+            len(applicable_components) / 8
+        )
+        record_length += applicable_components_bitfield_length
+
+        # RecordDescriptors
+        descriptors = device["Descriptors"]
+        record_descriptors, descriptor_count = prepare_record_descriptors(
+            descriptors
+        )
+        record_length += len(record_descriptors)
+
+        if 1 <= package_header_format_revision <= 3:
+            format_string = (
+                "<HBIBBH"
+                + str(applicable_components_bitfield_length)
+                + "s"
+                + str(len(component_image_set_version_string))
+                + "s"
+            )
+            pldm_fw_up_pkg.write(
+                struct.pack(
+                    format_string,
+                    record_length,
+                    descriptor_count,
+                    ba2int(device_update_option_flags),
+                    component_image_set_version_string_type,
+                    len(component_image_set_version_string),
+                    fw_device_pkg_data_length,
+                    applicable_components.tobytes(),
+                    component_image_set_version_string.encode("ascii"),
+                )
+            )
+        elif package_header_format_revision >= 4:
+            format_string = (
+                "<HBIBBHI"
+                + str(applicable_components_bitfield_length)
+                + "s"
+                + str(len(component_image_set_version_string))
+                + "s"
+            )
+            pldm_fw_up_pkg.write(
+                struct.pack(
+                    format_string,
+                    record_length,
+                    descriptor_count,
+                    ba2int(device_update_option_flags),
+                    component_image_set_version_string_type,
+                    len(component_image_set_version_string),
+                    fw_device_pkg_data_length,
+                    reference_manifest_length,
+                    applicable_components.tobytes(),
+                    component_image_set_version_string.encode("ascii"),
+                )
+            )
+        pldm_fw_up_pkg.write(record_descriptors)
+        # Write ReferenceManifestData if provided (only for format version >= 4)
+        if (
+            package_header_format_revision >= 4
+            and reference_manifest_data is not None
+        ):
+            pldm_fw_up_pkg.write(reference_manifest_data)
+
+
+def write_downstream_device_identification_area(
+    pldm_fw_up_pkg,
+    metadata,
+    package_header_format_revision,
+    component_bitmap_bit_length,
+):
+    """
+    Write downstream device ID records into the PLDM package header
+
+    This function writes the DownstreamDeviceIDRecordCount and the
+    DownstreamDeviceIDRecords into the firmware update package by processing the
+    metadata JSON. Currently there is no support for optional
+    DownstreamDevicePackageData and DownstreamDeviceReferenceManifestData.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            metadata: metadata about PLDM FW update package
+            component_bitmap_bit_length: length of the ComponentBitmapBitLength
+    """
+    # The spec limits the number of firmware device ID records to 255
+    max_downstream_device_id_record_count = 255
+    # check if metadata["DownstreamDeviceIdentificationArea"] exists first
+    if "DownstreamDeviceIdentificationArea" not in metadata.keys():
+        downstream_device_id_record_count = 0
+        pldm_fw_up_pkg.write(
+            struct.pack("<B", downstream_device_id_record_count)
+        )
+        return
+    downstream_devices = metadata["DownstreamDeviceIdentificationArea"]
+    downstream_device_id_record_count = len(downstream_devices)
+    if (
+        downstream_device_id_record_count
+        > max_downstream_device_id_record_count
+    ):
+        sys.exit(
+            "ERROR: there can be only upto 255 entries in the                "
+            " FirmwareDeviceIdentificationArea section"
+        )
+
+    # DeviceIDRecordCount
+    pldm_fw_up_pkg.write(struct.pack("<B", downstream_device_id_record_count))
+
+    for downstream_device in downstream_devices:
+        # RecordLength size
+        downstream_device_record_length = 2
+
+        # DescriptorCount
+        downstream_device_record_length += 1
+
+        # DownstreamDeviceUpdateOptionFlags
+        downstream_device_update_option_flags = bitarray(32, endian="little")
+        downstream_device_update_option_flags.setall(0)
+        # Continue component updates after failure
+        supported_downstream_device_update_option_flags = [0]
+        for option in downstream_device["DownstreamDeviceUpdateOptionFlags"]:
+            if option not in supported_downstream_device_update_option_flags:
+                sys.exit(
+                    "ERROR: unsupported DownstreamDeviceUpdateOptionFlag entry"
+                )
+            downstream_device_update_option_flags[option] = 1
+        downstream_device_record_length += 4
+
+        # ComponentImageSetVersionStringType supports only ASCII for now
+        downstream_device_self_contained_activation_min_version_string_type = (
+            string_types["ASCII"]
+        )
+        downstream_device_record_length += 1
+
+        if downstream_device_update_option_flags[0]:
+            # Downstream Device can support self-contained activation with minimal version level defined by
+            # DownstreamDeviceSelfContainedActivationMinVersion fields
+
+            downstream_device_self_contained_activation_min_version_string = (
+                downstream_device[
+                    "DownstreamDeviceSelfContainedActivationMinVersionString"
+                ]
+            )
+            check_string_length(
+                downstream_device_self_contained_activation_min_version_string
+            )
+            downstream_device_record_length += len(
+                downstream_device_self_contained_activation_min_version_string
+            )
+            downstream_device_self_contained_activation_min_version_comparison_stamp = downstream_device[
+                "DownstreamDeviceSelfContainedActivationMinVersionComparisonStamp"
+            ]
+            downstream_device_record_length += 4
+        else:
+            downstream_device_self_contained_activation_min_version_string_type = (
+                0
+            )
+            downstream_device_self_contained_activation_min_version_string = ""
+        # DownstreamDeviceSelfContainedActivationMinVersionStringLength
+        downstream_device_record_length += 1
+
+        # Optional DownstreamDevicePackageData not supported now,
+        # DownstreamDevicePackageDataLength is set to 0x0000
+        downstream_device_pkg_data_length = 0
+        downstream_device_record_length += 2
+
+        # Optional DownstreamDeviceReferenceManifestData - read from JSON if provided
+        downstream_device_reference_manifest_data = None
+        downstream_device_reference_manifest_length = 0
+        if package_header_format_revision >= 4:
+            if "DownstreamDeviceReferenceManifestData" in downstream_device:
+                downstream_device_reference_manifest_data_str = (
+                    downstream_device["DownstreamDeviceReferenceManifestData"]
+                )
+                downstream_device_reference_manifest_data = bytearray.fromhex(
+                    downstream_device_reference_manifest_data_str
+                )
+                downstream_device_reference_manifest_length = len(
+                    downstream_device_reference_manifest_data
+                )
+                downstream_device_record_length += (
+                    downstream_device_reference_manifest_length
+                )
+            downstream_device_record_length += 4
+
+        # ApplicableComponents
+        components = metadata["ComponentImageInformationArea"]
+        downstream_device_applicable_components = get_applicable_components(
+            downstream_device, components, component_bitmap_bit_length
+        )
+        downstream_device_applicable_components_bitfield_length = round(
+            len(downstream_device_applicable_components) / 8
+        )
+        downstream_device_record_length += (
+            downstream_device_applicable_components_bitfield_length
+        )
+
+        # RecordDescriptors
+        descriptors = downstream_device["Descriptors"]
+        record_descriptors, descriptor_count = prepare_record_descriptors(
+            descriptors
+        )
+        downstream_device_record_length += len(record_descriptors)
+        if package_header_format_revision <= 3:
+            format_string = (
+                "<HBIBBH"
+                + str(downstream_device_applicable_components_bitfield_length)
+                + "s"
+                + str(
+                    len(
+                        downstream_device_self_contained_activation_min_version_string
+                    )
+                )
+                + "s"
+            )
+            pldm_fw_up_pkg.write(
+                struct.pack(
+                    format_string,
+                    downstream_device_record_length,
+                    descriptor_count,
+                    ba2int(downstream_device_update_option_flags),
+                    downstream_device_self_contained_activation_min_version_string_type,
+                    len(
+                        downstream_device_self_contained_activation_min_version_string
+                    ),
+                    downstream_device_pkg_data_length,
+                    downstream_device_applicable_components.tobytes(),
+                    downstream_device_self_contained_activation_min_version_string.encode(
+                        "ascii"
+                    ),
+                )
+            )
+        elif package_header_format_revision >= 4:
+            format_string = (
+                "<HBIBBHI"
+                + str(downstream_device_applicable_components_bitfield_length)
+                + "s"
+                + str(
+                    len(
+                        downstream_device_self_contained_activation_min_version_string
+                    )
+                )
+                + "s"
+            )
+            pldm_fw_up_pkg.write(
+                struct.pack(
+                    format_string,
+                    downstream_device_record_length,
+                    descriptor_count,
+                    ba2int(downstream_device_update_option_flags),
+                    downstream_device_self_contained_activation_min_version_string_type,
+                    len(
+                        downstream_device_self_contained_activation_min_version_string
+                    ),
+                    downstream_device_pkg_data_length,
+                    downstream_device_reference_manifest_length,
+                    downstream_device_applicable_components.tobytes(),
+                    downstream_device_self_contained_activation_min_version_string.encode(
+                        "ascii"
+                    ),
+                )
+            )
+        if downstream_device_update_option_flags[0]:
+            pldm_fw_up_pkg.write(
+                struct.pack(
+                    "<I",
+                    downstream_device_self_contained_activation_min_version_comparison_stamp,
+                )
+            )
+        pldm_fw_up_pkg.write(record_descriptors)
+        # Write DownstreamDeviceReferenceManifestData if provided (only for format version >= 4)
+        if (
+            package_header_format_revision >= 4
+            and downstream_device_reference_manifest_data is not None
+        ):
+            pldm_fw_up_pkg.write(downstream_device_reference_manifest_data)
+
+
+def get_component_comparison_stamp(component):
+    """
+    Get component comparison stamp from metadata file.
+
+    This function checks if ComponentOptions field is having value 1. For
+    ComponentOptions 1, ComponentComparisonStamp value from metadata file
+    is used and Default value 0xFFFFFFFF is used for other Component Options.
+
+    Parameters:
+        component: Component image info
+    Returns:
+        component_comparison_stamp: Component Comparison stamp
+    """
+    component_comparison_stamp = 0xFFFFFFFF
+    if (
+        int(ComponentOptions.UseComponentCompStamp)
+        in component["ComponentOptions"]
+    ):
+        # Use FD vendor selected value from metadata file
+        if "ComponentComparisonStamp" not in component.keys():
+            sys.exit(
+                "ERROR: ComponentComparisonStamp is required"
+                " when value '1' is specified in ComponentOptions field"
+            )
+        else:
+            try:
+                tmp_component_cmp_stmp = int(
+                    component["ComponentComparisonStamp"], 16
+                )
+                if 0 < tmp_component_cmp_stmp < 0xFFFFFFFF:
+                    component_comparison_stamp = tmp_component_cmp_stmp
+                else:
+                    sys.exit(
+                        "ERROR: Value for ComponentComparisonStamp "
+                        " should be  [0x01 - 0xFFFFFFFE] when "
+                        "ComponentOptions bit is set to"
+                        "'1'(UseComponentComparisonStamp)"
+                    )
+            except ValueError:  # invalid hext format
+                sys.exit("ERROR: Invalid hex for ComponentComparisonStamp")
+    return component_comparison_stamp
+
+
+def write_component_image_info_area(
+    pldm_fw_up_pkg, metadata, package_header_format_revision, image_files
+):
+    """
+    Write component image information area into the PLDM package header
+
+    This function writes the ComponentImageCount and the
+    ComponentImageInformation into the firmware update package by processing
+    the metadata JSON. Currently, there is no support for ComponentOpaqueData.
+
+    Parameters:
+        pldm_fw_up_pkg: PLDM FW update package
+        metadata: metadata about PLDM FW update package
+        image_files: component images
+    """
+    components = metadata["ComponentImageInformationArea"]
+    # ComponentImageCount
+    pldm_fw_up_pkg.write(struct.pack("<H", len(components)))
+    component_location_offsets = []
+    # ComponentLocationOffset position in individual component image
+    # information
+    component_location_offset_pos = 12
+
+    for component in components:
+        # Record the location of the ComponentLocationOffset to be updated
+        # after appending images to the firmware update package
+        component_location_offsets.append(
+            pldm_fw_up_pkg.tell() + component_location_offset_pos
+        )
+
+        # ComponentClassification
+        component_classification = component["ComponentClassification"]
+        if component_classification < 0 or component_classification > 0xFFFF:
+            sys.exit(
+                "ERROR: ComponentClassification should be [0x0000 - 0xFFFF]"
+            )
+
+        # ComponentIdentifier
+        component_identifier = component["ComponentIdentifier"]
+        if component_identifier < 0 or component_identifier > 0xFFFF:
+            sys.exit("ERROR: ComponentIdentifier should be [0x0000 - 0xFFFF]")
+
+        # ComponentComparisonStamp
+        component_comparison_stamp = get_component_comparison_stamp(component)
+
+        # ComponentOptions
+        component_options = bitarray(16, endian="little")
+        component_options.setall(0)
+        supported_component_options = [0, 1, 2]
+        for option in component["ComponentOptions"]:
+            if option not in supported_component_options:
+                sys.exit(
+                    "ERROR: unsupported ComponentOption in                   "
+                    " ComponentImageInformationArea section"
+                )
+            component_options[option] = 1
+
+        # RequestedComponentActivationMethod
+        requested_component_activation_method = bitarray(16, endian="little")
+        requested_component_activation_method.setall(0)
+        supported_requested_component_activation_method = [0, 1, 2, 3, 4, 5]
+        for option in component["RequestedComponentActivationMethod"]:
+            if option not in supported_requested_component_activation_method:
+                sys.exit(
+                    "ERROR: unsupported RequestedComponent                    "
+                    "    ActivationMethod entry"
+                )
+            requested_component_activation_method[option] = 1
+
+        # ComponentLocationOffset
+        component_location_offset = 0
+        # ComponentSize
+        component_size = 0
+        # ComponentVersionStringType
+        component_version_string_type = string_types["ASCII"]
+        # ComponentVersionStringlength
+        # ComponentVersionString
+        component_version_string = component["ComponentVersionString"]
+        check_string_length(component_version_string)
+
+        format_string = "<HHIHHIIBB" + str(len(component_version_string)) + "s"
+        pldm_fw_up_pkg.write(
+            struct.pack(
+                format_string,
+                component_classification,
+                component_identifier,
+                component_comparison_stamp,
+                ba2int(component_options),
+                ba2int(requested_component_activation_method),
+                component_location_offset,
+                component_size,
+                component_version_string_type,
+                len(component_version_string),
+                component_version_string.encode("ascii"),
+            )
+        )
+        if package_header_format_revision >= 3:
+            # ComponentOpaqueDataLength
+            component_opaque_data_length = 0
+            # ComponentOpaqueData
+            pldm_fw_up_pkg.write(
+                struct.pack("<I", component_opaque_data_length)
+            )
+
+    index = 0
+    pkg_header_checksum_size = 4
+    start_offset = pldm_fw_up_pkg.tell() + pkg_header_checksum_size
+    if package_header_format_revision >= 4:
+        pkg_payload_checksum_size = 4
+        start_offset += pkg_payload_checksum_size
+    # Update ComponentLocationOffset and ComponentSize for all the components
+    for offset in component_location_offsets:
+        file_size = os.stat(image_files[index]).st_size
+        pldm_fw_up_pkg.seek(offset)
+        pldm_fw_up_pkg.write(struct.pack("<II", start_offset, file_size))
+        start_offset += file_size
+        index += 1
+    pldm_fw_up_pkg.seek(0, os.SEEK_END)
+
+
+def write_pkg_header_checksum(pldm_fw_up_pkg):
+    """
+    Write PackageHeaderChecksum into the PLDM package header.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+    """
+    pldm_fw_up_pkg.seek(0)
+    package_header_checksum = binascii.crc32(pldm_fw_up_pkg.read())
+    pldm_fw_up_pkg.seek(0, os.SEEK_END)
+    pldm_fw_up_pkg.write(struct.pack("<I", package_header_checksum))
+
+
+def write_pkg_payload_checksum(pldm_fw_up_pkg, image_files):
+    """
+    Write PackagePayloadChecksum into the PLDM package header.
+
+    Per DSP0267: The integrity checksum of the PLDM Package Payload.
+    It is calculated starting at the first byte immediately following this field
+    and includes all bytes of the firmware package payload structure, including
+    any padding of bytes between component images.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            image_files: component images
+    """
+    # Calculate CRC32 over the entire payload (all component images)
+    # using the IEEE 802.3 CRC-32 polynomial
+    package_payload_checksum = 0
+    for image in image_files:
+        with open(image, "rb") as file:
+            # Continue CRC32 calculation across all images
+            package_payload_checksum = binascii.crc32(
+                file.read(), package_payload_checksum
+            )
+    # Ensure the checksum is unsigned 32-bit
+    package_payload_checksum = package_payload_checksum & 0xFFFFFFFF
+    pldm_fw_up_pkg.seek(0, os.SEEK_END)
+    pldm_fw_up_pkg.write(struct.pack("<I", package_payload_checksum))
+
+
+def update_pkg_header_size(pldm_fw_up_pkg, package_header_format_revision):
+    """
+    Update PackageHeader in the PLDM package header. The package header size
+    which is the count of all bytes in the PLDM package header structure is
+    calculated once the package header contents is complete.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+    """
+    pkg_header_checksum_size = 4
+    file_size = pldm_fw_up_pkg.tell() + pkg_header_checksum_size
+    if package_header_format_revision >= 4:
+        pkg_payload_checksum_size = 4
+        file_size += pkg_payload_checksum_size
+    pkg_header_size_offset = 17
+    # Seek past PackageHeaderIdentifier and PackageHeaderFormatRevision
+    pldm_fw_up_pkg.seek(pkg_header_size_offset)
+    pldm_fw_up_pkg.write(struct.pack("<H", file_size))
+    pldm_fw_up_pkg.seek(0, os.SEEK_END)
+
+
+def append_component_images(pldm_fw_up_pkg, image_files):
+    """
+    Append the component images to the firmware update package.
+
+        Parameters:
+            pldm_fw_up_pkg: PLDM FW update package
+            image_files: component images
+    """
+    for image in image_files:
+        with open(image, "rb") as file:
+            for line in file:
+                pldm_fw_up_pkg.write(line)
+
+
+def main():
+    """Create PLDM FW update (DSP0267) package based on a JSON metadata file"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "pldmfwuppkgname", help="Name of the PLDM FW update package"
+    )
+    parser.add_argument("metadatafile", help="Path of metadata JSON file")
+    parser.add_argument(
+        "images",
+        nargs="+",
+        help=(
+            "One or more firmware image paths, in the same order as           "
+            " ComponentImageInformationArea entries"
+        ),
+    )
+
+    args = parser.parse_args()
+    image_files = args.images
+    with open(args.metadatafile) as file:
+        try:
+            metadata = json.load(file)
+        except ValueError:
+            sys.exit("ERROR: Invalid metadata JSON file")
+
+    # Validate the number of component images
+    if len(image_files) != len(metadata["ComponentImageInformationArea"]):
+        sys.exit(
+            "ERROR: number of images passed != number of entries            "
+            " in ComponentImageInformationArea"
+        )
+
+    try:
+        with open(args.pldmfwuppkgname, "w+b") as pldm_fw_up_pkg:
+            package_header_format_revision, component_bitmap_bit_length = (
+                write_pkg_header_info(pldm_fw_up_pkg, metadata)
+            )
+            if (
+                package_header_format_revision
+                not in expected_package_format_versions
+            ):
+                sys.exit(
+                    "ERROR: Unsupported package format version %d"
+                    % package_header_format_revision
+                )
+            write_fw_device_identification_area(
+                pldm_fw_up_pkg,
+                metadata,
+                package_header_format_revision,
+                component_bitmap_bit_length,
+            )
+            if package_header_format_revision >= 2:
+                write_downstream_device_identification_area(
+                    pldm_fw_up_pkg,
+                    metadata,
+                    package_header_format_revision,
+                    component_bitmap_bit_length,
+                )
+            write_component_image_info_area(
+                pldm_fw_up_pkg,
+                metadata,
+                package_header_format_revision,
+                image_files,
+            )
+            update_pkg_header_size(
+                pldm_fw_up_pkg, package_header_format_revision
+            )
+            write_pkg_header_checksum(pldm_fw_up_pkg)
+            if package_header_format_revision >= 4:
+                write_pkg_payload_checksum(pldm_fw_up_pkg, image_files)
+            append_component_images(pldm_fw_up_pkg, image_files)
+            pldm_fw_up_pkg.close()
+    except BaseException:
+        pldm_fw_up_pkg.close()
+        os.remove(args.pldmfwuppkgname)
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This requires a host fw image ready for flashing (without the HPE header which was removed in other script) and packaged as PLDM fw update package with the right compatible and IANA Vendor Id.

Tested: on HPE Proliant G11 D360

Requesting the update

```
curl -k --insecure --user root:0penBmc -H Content-Type:multipart/form-data -X POST -F 'UpdateParameters={"Targets":["/redfish/v1/UpdateService/FirmwareInventory/HostSPIFlash_146"],"@Redfish.OperationApplyTime":"Immediate"};type=application/json' -F 'UpdateFile=@pldm-package-hpe-proliant-g11-d360-host.bin;type=application/octet-stream' https://hpe-dl360-g11-bmc.dut.lab.bs.9e.network:443/redfish/v1/UpdateService/update-multipart
{
  "@odata.id": "/redfish/v1/TaskService/Tasks/1",
  "@odata.type": "#Task.v1_4_3.Task",
  "HidePayload": false,
  "Id": "1",
  "Messages": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The task with Id '1' has started.",
      "MessageArgs": [
        "1"
      ],
      "MessageId": "TaskEvent.1.0.TaskStarted",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ],
  "Name": "Task 1",
  "Payload": {
    "HttpHeaders": [],
    "HttpOperation": "POST",
    "TargetUri": "/redfish/v1/UpdateService/update-multipart"
  },
  "PercentComplete": 0,
  "StartTime": "2026-06-30T14:54:36+00:00",
  "TaskMonitor": "/redfish/v1/TaskService/TaskMonitors/1",
  "TaskState": "Running",
  "TaskStatus": "OK"
}
```

After completing the update, the new host fw version shows up in fw inventory:
```
{
"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
"@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
"Members": [
{
  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/22ba1852"
},
{
  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/HostSPIFlash_9805"
},
{
  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/bios_active"
}
],
"Members@odata.count": 3,
"Name": "Software Inventory Collection"
}
```

One remaining issue is that the Redfish Task for this update seems to timeout or get lost after a while, possible because the fw update code is not reporting progress frequently enough. This remains to be investigated but overall the update seems to be working.

The host boots `HPE ProLiant System BIOS U54 v2.92 05/28/2026` so either the wrong flash chip was written or everything went well.

The flash contents are the same as what we wrote.
```
root@hpe-proliant-g11:~# md5sum /dev/mtd/by-name/host-second
9016af89497120bd4434864bbfbab38d  /dev/mtd/by-name/host-second
md5sum /tmp/bios-stripped.bin
9016af89497120bd4434864bbfbab38d  /tmp/bios-stripped.bin
```

Verify by writing an empty image, the contents are as expected
```
root@hpe-proliant-g11:~# md5sum /dev/mtd/by-name/host-second
58f06dd588d8ffb3beb46ada6309436b  /dev/mtd/by-name/host-second
md5sum empty-img-32M.bin
58f06dd588d8ffb3beb46ada6309436b  empty-img-32M.bin
```

see #84 