### PR TITLE
feat: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Documentation at:
+#   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Assign the entire repository (default ownership)
+*	@mynetz @pmaione @sylv-io @walterchris @sinuscosinustan
+
+/.github/workflows/	@sinuscosinustan @AtomicFS
+/.github/actions/	@sinuscosinustan @AtomicFS


### PR DESCRIPTION
This is great feature for automatically ~~suggesting~~ **request** reviewers for PRs. Also defines responsibilities.

I had to kinda guess who would be in the file, so please feel free to correct my assumptions and propose changes.

I would also be comfortable with adding myself as responsible person for some files, but I do not want to just inject myself here. So I will await feedback.
```
/.github/workflows/  @sinuscosinustan @AtomicFS
```