### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      time: '00:00'
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
more lightweight version of #211

Only use dependabot to keep the GitHub actions up-to-date, do not touch the git submodules.