### PR TITLE
firmwareci: fix unresolved input template

### DIFF
--- a/.firmwareci/duts/dut-canopy-qemu/pre.yaml
+++ b/.firmwareci/duts/dut-canopy-qemu/pre.yaml
@@ -9,7 +9,7 @@ pre-stage:
         "-nographic",
         "-net", "nic",
         "-net", "user,hostfwd=:127.0.0.1:2222-:22,hostfwd=:127.0.0.1:2443-:443,hostfwd=udp:127.0.0.1:2623-:623,hostname=qemu",
-        "-drive", "file=[[input.Binary]],if=mtd,format=raw",
+        "-drive", "file=[[input.firmware]],if=mtd,format=raw",
 
         # Bus 3 — temperature and power sensors
         "-device", "tmp105,address=0x48,id=tmp105_cpu0,bus=aspeed.i2c.bus.3",

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -13,7 +13,7 @@ pre-stage:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: emulate-bmc
-      args: ["[[input.Binary]]"]
+      args: ["[[input.firmware]]"]
 
   - cmd: newdutctl
     name: Power on DUT

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
@@ -19,7 +19,7 @@ pre-stage:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: emulate-bmc
-      args: ["[[input.Binary]]"]
+      args: ["[[input.firmware]]"]
 
   - cmd: newdutctl
     name: Power on DUT

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
@@ -29,7 +29,7 @@ pre-stage:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
       command: emulate-bmc
-      args: ["[[input.Binary]]"]
+      args: ["[[input.firmware]]"]
 
   - cmd: newdutctl
     name: Power on DUT

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# Documentation at:
-#   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Assign the entire repository (default ownership)
-*	@mynetz @pmaione @sylv-io @walterchris @sinuscosinustan
-
-/.github/workflows/	@sinuscosinustan @AtomicFS
-/.github/actions/	@sinuscosinustan @AtomicFS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
             {
               "board": "hpe-proliant-g11",
               "fwci_workflow_name": "hpe-dl320-g11-ci",
-              "fwci_binary_name": "Binary=obmc-phosphor-image-hpe-proliant-g11.GXP2loader-t282-t288-sgn00.static.mtd"
+              "fwci_binary_name": "firmware=obmc-phosphor-image-hpe-proliant-g11.GXP2loader-t282-t288-sgn00.static.mtd"
             }
           ]')
           echo "include=$include" >> "$GITHUB_OUTPUT"
@@ -102,5 +102,5 @@ jobs:
         with:
           TOKEN: ${{ secrets.FWCI_TOKEN }}
           WORKFLOW_NAME: ${{ matrix.fwci_workflow_name || format('{0}-ci', matrix.board) }}
-          BINARIES: ${{ matrix.fwci_binary_name || format('Binary=obmc-phosphor-image-{0}.static.mtd', matrix.board) }}
+          BINARIES: ${{ matrix.fwci_binary_name || format('firmware=obmc-phosphor-image-{0}.static.mtd', matrix.board) }}
           GITHUB_INSTALLATION_ID: ${{ secrets.FWCI_GITHUB_INSTALLATION_ID }}


### PR DESCRIPTION
The Canopy QEMU tests failed with the following error message in FWCI:
```
failed to prepare job: failed to validate templating: pre-stage template validation failed for DUT Canopy-QEMU: unresolved input template: [[input.firmware]]
```

As recommended by the FWCI folks, use `firmware` as input instead of `Binary`.

Fixes: d4833e96 ("ci: refactor build workflows")