### PR TITLE
HPE ProLiant Gen11: Support for BIOS (Next) boot order and IP configuration

### DIFF
--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
@@ -1,0 +1,164 @@
+name: "BIOS: Boot Option Config Bridge"
+description: >-
+  Verify that BiosConfigService parses the CQSBOOT#### boot option
+  records published by the host firmware and exposes them as read-only
+  BIOSConfig attributes. Checks the persisted EV store on the BMC, the
+  BaseBIOSTable published on D-Bus by biosconfig-manager, and the service
+  journal. Requires the host to complete at least one POST cycle so the
+  firmware publishes its boot options over CHIF.
+
+  Note! these attributes are currently not visible via the Redfish
+  /Systems/system/Bios route.
+
+defaults:
+  transport: &bmc_ssh
+    proto: ssh
+    options:
+      host: "[[attributes.BMC]]"
+      user: "root"
+      password: "[[attributes.BMCPassword]]"
+
+stages:
+  - name: Wait for BMC and Power On Host
+    steps:
+      - cmd: ping
+        name: Wait for SSH
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+      - cmd: cmd
+        name: Wait for BMC services
+        transport: *bmc_ssh
+        options:
+          timeout: 2m
+        parameters:
+          executable: sleep
+          args: ["45"]
+      - cmd: shell
+        name: Power on host via Redfish
+        transport: &local
+          proto: local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"On"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
+      - cmd: shell
+        name: Wait for SMBIOS transfer (host POST complete)
+        transport: *bmc_ssh
+        options:
+          timeout: 8m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+      # TODO: Fix static sleep, poll until OSStage or BootProgress work
+      # This is somewhat of a workaround for now to get the system boot into
+      # the OS at least once. Neither OSStage nor BootProgress work because the
+      # post-complete line is not asserting, and the BootProgress interface is
+      # not implemented by any software yet.
+      # Instead, we wait until a full boot happened, and reboot the system again
+      # to get the full EV vars.
+      # Why the EVs are not always being transmitted in the first run is not
+      # clear yet.
+      - cmd: cmd
+        name: Wait for the boot to be finished
+        transport: *bmc_ssh
+        options:
+          timeout: 3m
+        parameters:
+          executable: sleep
+          args: ["90"]
+      - cmd: shell
+        name: Shutdown the system and turn it on again
+        transport: *bmc_ssh
+        options:
+          timeout: 5m
+        parameters:
+          command: >-
+            obmcutil poweroff &&
+            while [ "$(busctl get-property xyz.openbmc_project.Chassis.Buttons /xyz/openbmc_project/state/chassis0 xyz.openbmc_project.State.Chassis CurrentPowerState)" != 's "xyz.openbmc_project.State.Chassis.PowerState.Off"' ]; do sleep 1; done; echo "System powered off" &&
+            obmcutil poweron && echo "System powered on"
+          expect:
+            - regex: "System powered on"
+      - cmd: shell
+        name: Clear stale SMBIOS marker
+        transport: *bmc_ssh
+        parameters:
+          command: "rm -f /var/lib/smbios/smbios2"
+      - cmd: shell
+        name: Wait for second POST (SMBIOS transfer)
+        transport: *bmc_ssh
+        options:
+          timeout: 8m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+      - cmd: cmd
+        name: Wait for all EVs to be published
+        transport: *bmc_ssh
+        options:
+          timeout: 2m
+        parameters:
+          executable: sleep
+          args: ["30"]
+
+  - name: CHIF Service and EV Store
+    on-error: continue
+    steps:
+      - cmd: cmd
+        name: CHIF service is running
+        transport: *bmc_ssh
+        parameters:
+          executable: systemctl
+          args: ["is-active", "xyz.openbmc_project.GxpChif.service"]
+      - cmd: shell
+        name: Boot option EVs (CQSBOOT) persisted by firmware
+        transport: *bmc_ssh
+        parameters:
+          command: "grep -a -o CQSBOOT /var/lib/chif/evs.dat 2>/dev/null | wc -l"
+          expect:
+            - regex: "^[1-9][0-9]*$"
+
+  - name: BIOSConfig Attributes Published
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: BiosConfigService published boot options (journal)
+        transport: *bmc_ssh
+        parameters:
+          command: "journalctl -u xyz.openbmc_project.GxpChif.service --no-pager | grep 'BIOS config: published'"
+          expect:
+            - regex: "published [1-9][0-9]* boot option"
+      - cmd: cmd
+        name: BIOSConfigManager registered on D-Bus
+        transport: *bmc_ssh
+        parameters:
+          executable: busctl
+          args: [list, --no-pager]
+          expect:
+            - regex: "xyz\\.openbmc_project\\.BIOSConfigManager"
+      - cmd: shell
+        name: BaseBIOSTable contains Boot## attributes (D-Bus)
+        transport: *bmc_ssh
+        parameters:
+          command: >-
+            busctl get-property xyz.openbmc_project.BIOSConfigManager
+            /xyz/openbmc_project/bios_config/manager
+            xyz.openbmc_project.BIOSConfig.Manager BaseBIOSTable --no-pager
+          expect:
+            - regex: "Boot[0-9A-Fa-f]{2}"

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
@@ -1,0 +1,273 @@
+name: "Boot: One-Time Override (BIOS Setup)"
+description: >-
+  Sets a one-time BIOS Setup boot override over Redfish, verifies BootService
+  resolves it against the CQSBOOT#### options and writes the CQTBOOTNEXT EV,
+  reboots the host, and confirms the override is consumed and reconciled back
+  in phosphor-settings.
+
+  This is **very slow**! It power-cycles the host and waits for two POST cycles
+  (the UEFI reboots itself again after honouring the one-time boot due to a
+  "policy change".)
+  It must run after the host has POSTed at least once so the firmware has
+  published its boot options (CQSBOOT####) and boot order (CQHBOOTORDER).
+
+defaults:
+  transport: &bmc_ssh
+    proto: ssh
+    options:
+      host: "[[attributes.BMC]]"
+      user: "root"
+      password: "[[attributes.BMCPassword]]"
+
+stages:
+  - name: Wait for BMC and Power On Host
+    steps:
+      - cmd: ping
+        name: Wait for SSH
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+      - cmd: cmd
+        name: Wait for BMC services
+        transport: *bmc_ssh
+        options:
+          timeout: 2m
+        parameters:
+          executable: sleep
+          args: ["45"]
+      - cmd: shell
+        name: Power on host via Redfish
+        transport: &local
+          proto: local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"On"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
+      - cmd: shell
+        name: Wait for first POST (SMBIOS transfer)
+        transport: *bmc_ssh
+        options:
+          timeout: 8m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+      # TODO: Fix static sleep, poll until OSStage or BootProgress work
+      # This is somewhat of a workaround for now to get the system boot into
+      # the OS at least once. Neither OSStage nor BootProgress work because the
+      # post-complete line is not asserting, and the BootProgress interface is
+      # not implemented by any software yet.
+      # Instead, we wait until a full boot happened, and reboot the system again
+      # to get the full EV vars.
+      # Why the EVs are not always being transmitted in the first run is not
+      # clear yet.
+      - cmd: cmd
+        name: Wait for the boot to be finished
+        transport: *bmc_ssh
+        options:
+          timeout: 3m
+        parameters:
+          executable: sleep
+          args: ["90"]
+      - cmd: shell
+        name: Shutdown the system and turn it on again
+        transport: *bmc_ssh
+        options:
+          timeout: 5m
+        parameters:
+          command: >-
+            obmcutil poweroff &&
+            while [ "$(busctl get-property xyz.openbmc_project.Chassis.Buttons /xyz/openbmc_project/state/chassis0 xyz.openbmc_project.State.Chassis CurrentPowerState)" != 's "xyz.openbmc_project.State.Chassis.PowerState.Off"' ]; do sleep 1; done; echo "System powered off" &&
+            obmcutil poweron && echo "System powered on"
+          expect:
+            - regex: "System powered on"
+      - cmd: shell
+        name: Clear stale SMBIOS marker
+        transport: *bmc_ssh
+        parameters:
+          command: "rm -f /var/lib/smbios/smbios2"
+      - cmd: shell
+        name: Wait for second POST (SMBIOS transfer)
+        transport: *bmc_ssh
+        options:
+          timeout: 8m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+      - cmd: cmd
+        name: Wait for all EVs to be published
+        transport: *bmc_ssh
+        options:
+          timeout: 2m
+        parameters:
+          executable: sleep
+          args: ["30"]
+
+  - name: Boot EVs Present
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: Boot options (CQSBOOT) published by firmware
+        transport: *bmc_ssh
+        parameters:
+          command: "grep -a -o CQSBOOT /var/lib/chif/evs.dat 2>/dev/null | wc -l"
+          expect:
+            - regex: "^[1-9][0-9]*$"
+      - cmd: shell
+        name: Persistent boot order (CQHBOOTORDER) published by firmware
+        transport: *bmc_ssh
+        parameters:
+          command: "grep -a -c CQHBOOTORDER /var/lib/chif/evs.dat 2>/dev/null || echo 0"
+          expect:
+            - regex: "^[1-9][0-9]*$"
+
+  - name: Set One-Time BIOS Setup Override via Redfish
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: PATCH BootSourceOverride BiosSetup/Once
+        transport: *local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X PATCH -H 'Content-Type: application/json'
+            -d '{"Boot":{"BootSourceOverrideEnabled":"Once","BootSourceOverrideTarget":"BiosSetup"}}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system
+          expect:
+            - regex: "^(200|204)$"
+      - cmd: shell
+        name: BootService resolved and applied one-time option (journal)
+        transport: *bmc_ssh
+        parameters:
+          command: "journalctl -u xyz.openbmc_project.GxpChif.service --no-pager | grep 'One-time boot: option'"
+          expect:
+            - regex: "One-time boot: option"
+      - cmd: shell
+        name: CQTBOOTNEXT EV written to store
+        transport: *bmc_ssh
+        parameters:
+          command: "grep -a -c CQTBOOTNEXT /var/lib/chif/evs.dat 2>/dev/null || echo 0"
+          expect:
+            - regex: "^[1-9][0-9]*$"
+      - cmd: cmd
+        name: Redfish reports BiosSetup/Once override
+        transport: *local
+        options:
+          timeout: 30s
+        parameters:
+          executable: curl
+          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system"]
+          expect:
+            - regex: '"BootSourceOverrideTarget": *"BiosSetup"'
+            - regex: '"BootSourceOverrideEnabled": *"Once"'
+
+  - name: Reboot Host to test override
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: Clear stale SMBIOS marker
+        transport: *bmc_ssh
+        parameters:
+          command: "rm -f /var/lib/smbios/smbios2"
+      - cmd: shell
+        name: ForceRestart host via Redfish
+        transport: *local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"ForceRestart"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
+      - cmd: shell
+        name: Wait for POST after override (SMBIOS re-transfer)
+        transport: *bmc_ssh
+        options:
+          timeout: 15m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+      - cmd: cmd
+        name: Wait for all EVs to be published
+        transport: *bmc_ssh
+        options:
+          timeout: 2m
+        parameters:
+          executable: sleep
+          args: ["20"]
+      - cmd: cmd
+        name: Dump EV storage
+        transport: *bmc_ssh
+        options:
+          timeout: 2m
+        parameters:
+          executable: hexdump
+          args: ["-C", "/var/lib/chif/evs.dat"]
+
+  - name: Verify that the override got consumed
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: Host consumed one-time boot (journal)
+        transport: *bmc_ssh
+        options:
+          timeout: 3m
+        parameters:
+          command: >-
+            for i in $(seq 1 30); do
+              journalctl -u xyz.openbmc_project.GxpChif.service --no-pager |
+                grep -q 'One-time boot consumed' && { echo consumed; exit 0; }
+              sleep 5;
+            done;
+            echo "not-consumed"; exit 1
+          expect:
+            - regex: "^consumed$"
+      - cmd: shell
+        name: CQTBOOTNEXT cleared from store
+        transport: *bmc_ssh
+        parameters:
+          command: "grep -a -c CQTBOOTNEXT /var/lib/chif/evs.dat 2>/dev/null || echo 0"
+          expect:
+            - regex: "^0$"
+      - cmd: cmd
+        name: Redfish override reconciled back to Continuous
+        transport: *local
+        options:
+          timeout: 30s
+        parameters:
+          executable: curl
+          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system"]
+          expect:
+            - regex: '"BootSourceOverrideEnabled": *"Continuous"'
+
+  - name: Console check
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: "Console shows System Utilities / BIOS setup entry"
+        transport: *bmc_ssh
+        parameters:
+          command: "grep -aiE 'System Utilities|Setup Utility|One-Time Boot' /var/log/obmc-console.log /var/log/obmc-console.log.1 2>/dev/null | tail -n 20 || echo '(console log empty)'"

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/network-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/network-config.yaml
@@ -1,0 +1,115 @@
+name: "Network: CHIF BMC Config Reporting"
+description: >-
+  Verify that the BMC network IP address is being displayed on boot
+  (checking /var/log/obmc-console.log for that.)
+
+defaults:
+  transport: &bmc_ssh
+    proto: ssh
+    options:
+      host: "[[attributes.BMC]]"
+      user: "root"
+      password: "[[attributes.BMCPassword]]"
+
+stages:
+  - name: Wait for BMC
+    steps:
+      - cmd: ping
+        name: Wait for SSH
+        options:
+          timeout: 5m
+        parameters:
+          host: "[[attributes.BMC]]"
+      - cmd: cmd
+        name: Wait for services to settle
+        transport: *bmc_ssh
+        options:
+          timeout: 2m
+        parameters:
+          executable: sleep
+          args: ["45"]
+
+  - name: Network D-Bus State
+    steps:
+      - cmd: cmd
+        name: CHIF service is running
+        transport: *bmc_ssh
+        parameters:
+          executable: systemctl
+          args: ["is-active", "xyz.openbmc_project.GxpChif.service"]
+      - cmd: cmd
+        name: Network service registered on D-Bus
+        transport: *bmc_ssh
+        parameters:
+          executable: busctl
+          args: [list, --no-pager]
+          expect:
+            - regex: "xyz\\.openbmc_project\\.Network"
+      - cmd: cmd
+        name: eth0 interface is UP
+        transport: *bmc_ssh
+        parameters:
+          executable: ip
+          args: ["link", "show", "eth0"]
+          expect:
+            - regex: "UP"
+      - cmd: cmd
+        name: eth0 has an IPv4 address to report
+        transport: *bmc_ssh
+        parameters:
+          executable: ip
+          args: ["-4", "addr", "show", "eth0"]
+          expect:
+            - regex: "inet [0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/"
+      - cmd: shell
+        name: EthernetInterface exposed on D-Bus for CHIF query
+        transport: *bmc_ssh
+        parameters:
+          command: >-
+            busctl introspect xyz.openbmc_project.Network
+            /xyz/openbmc_project/network/eth0
+            xyz.openbmc_project.Network.EthernetInterface --no-pager
+          expect:
+            - regex: "DHCPEnabled"
+
+  - name: Power On Host
+    steps:
+      - cmd: shell
+        name: Power on host via Redfish
+        transport: &local
+          proto: local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"On"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
+      - cmd: shell
+        name: Wait for SMBIOS transfer (host POST complete)
+        transport: *bmc_ssh
+        options:
+          timeout: 8m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+
+  - name: Console check
+    on-error: continue
+    steps:
+      - cmd: shell
+        name: BMC IPv4 shown on host console
+        transport: *bmc_ssh
+        parameters:
+          command: >-
+            IP=$(ip -4 -o addr show eth0 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n1);
+            echo "BMC eth0 IPv4: $IP";
+            grep -aF "$IP" /var/log/obmc-console.log /var/log/obmc-console.log.1 2>/dev/null | tail -n 5 ||
+              echo '(BMC IP not found in console log / log empty)'

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
@@ -41,6 +41,8 @@ install_data(
 src_files = files(
     'src/main.cpp',
     'src/chif_daemon.cpp',
+    'src/boot_service.cpp',
+    'src/bios_config_service.cpp',
     'src/smif_service.cpp',
     'src/health_service.cpp',
     'src/ev_storage.cpp',
@@ -77,6 +79,8 @@ if get_option('tests').enabled()
         'src/smbios_writer.cpp',
         'src/mdr_bridge.cpp',
         'src/chif_daemon.cpp',
+        'src/boot_service.cpp',
+        'src/bios_config_service.cpp',
     )
 
     test_packet = executable(
@@ -123,4 +127,34 @@ if get_option('tests').enabled()
         ],
     )
     test('rom_service', test_rom_service)
+
+    test_boot_service = executable(
+        'test_boot_service',
+        'test/test_boot_service.cpp',
+        test_src_common,
+        dependencies: [
+            gtest_dep,
+            gtest_main_dep,
+            sdbusplus_dep,
+            phosphor_dbus_dep,
+            phosphor_logging_dep,
+            systemd_dep,
+        ],
+    )
+    test('boot_service', test_boot_service)
+
+    test_bios_config_service = executable(
+        'test_bios_config_service',
+        'test/test_bios_config_service.cpp',
+        test_src_common,
+        dependencies: [
+            gtest_dep,
+            gtest_main_dep,
+            sdbusplus_dep,
+            phosphor_dbus_dep,
+            phosphor_logging_dep,
+            systemd_dep,
+        ],
+    )
+    test('bios_config_service', test_bios_config_service)
 endif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/meson.build
@@ -44,6 +44,8 @@ src_files = files(
     'src/boot_service.cpp',
     'src/bios_config_service.cpp',
     'src/smif_service.cpp',
+    'src/smif_network.cpp',
+    'src/net_config.cpp',
     'src/health_service.cpp',
     'src/ev_storage.cpp',
     'src/uefi_fv.cpp',
@@ -51,6 +53,7 @@ src_files = files(
     'src/rom_service.cpp',
     'src/smbios_writer.cpp',
     'src/mdr_bridge.cpp',
+    'src/utils.cpp',
 )
 
 executable(
@@ -73,6 +76,8 @@ if get_option('tests').enabled()
 
     test_src_common = files(
         'src/smif_service.cpp',
+        'src/smif_network.cpp',
+        'src/net_config.cpp',
         'src/health_service.cpp',
         'src/ev_storage.cpp',
         'src/rom_service.cpp',
@@ -81,6 +86,7 @@ if get_option('tests').enabled()
         'src/chif_daemon.cpp',
         'src/boot_service.cpp',
         'src/bios_config_service.cpp',
+        'src/utils.cpp',
     )
 
     test_packet = executable(

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/bios_config_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/bios_config_service.cpp
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "bios_config_service.hpp"
+
+#include "utils.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <utility>
+
+namespace chif
+{
+
+namespace
+{
+constexpr auto biosConfigService = "xyz.openbmc_project.BIOSConfigManager";
+
+uint16_t readLe16(std::span<const uint8_t> data, size_t offset)
+{
+    return static_cast<uint16_t>(data[offset]) |
+           static_cast<uint16_t>(static_cast<uint16_t>(data[offset + 1]) << 8);
+}
+
+} // namespace
+
+BiosConfigService::BiosConfigService(sdbusplus::bus_t& bus,
+                                     EvStorage& evStorage) :
+    bus_(bus), evStorage_(evStorage)
+{
+    // Refresh whenever a boot-option EV changes (or on a bulk clear). Other
+    // EV writes (e.g. CQHBOOTORDER from BootService) are ignored to avoid
+    // needless republishing.
+    evStorage_.addChangeCallback([this](std::string_view name) {
+        if (name.empty() || name.starts_with(bootOptionEvPrefix))
+        {
+            publish();
+        }
+    });
+
+    publish();
+}
+
+std::optional<std::string> BiosConfigService::parseBootOptionName(
+    std::span<const uint8_t> data)
+{
+    if (data.size() < 16)
+    {
+        return std::nullopt;
+    }
+
+    uint16_t bootStrLen = readLe16(data, 14);
+    size_t nameOffset = 16 + bootStrLen + 6 + 2; // past structuredBootStr,
+                                                 // reserved, uefi len field
+    if (nameOffset >= data.size())
+    {
+        return std::nullopt;
+    }
+
+    std::string name;
+    for (size_t i = nameOffset; i + 1 < data.size(); i += 2)
+    {
+        uint16_t ch = readLe16(data, i);
+        if (ch == 0)
+        {
+            break;
+        }
+        // Boot option names are usually ASCII. Remove anything
+        // outside of printable ASCII rather than mangling the UTF-16.
+        name.push_back((ch >= 0x20 && ch < 0x7f) ? static_cast<char>(ch) : '?');
+    }
+
+    if (name.empty())
+    {
+        return std::nullopt;
+    }
+    return name;
+}
+
+std::optional<std::string> BiosConfigService::bootOptionId(
+    const std::string& evName)
+{
+    if (!evName.starts_with(bootOptionEvPrefix))
+    {
+        return std::nullopt;
+    }
+    // The EV name is CQSBOOT#### (4 hex digits), but only the low two digits
+    // identify the option on D-Bus.
+    std::string digits = evName.substr(bootOptionEvPrefix.size());
+    if (digits.size() < 4)
+    {
+        return std::nullopt;
+    }
+    return digits.substr(2, 2);
+}
+
+BiosConfigService::BiosAttribute BiosConfigService::makeStringAttribute(
+    const std::string& value)
+{
+    return BiosAttribute{
+        Manager::AttributeType::String,
+        true,
+        value,
+        "HPE UEFI boot option",
+        "Boot/BootOrder",
+        value,
+        value,
+        {},
+    };
+}
+
+void BiosConfigService::publish()
+{
+    lg2::debug("BIOS config: rebuilding boot options from {COUNT} EV(s)",
+               "COUNT", evStorage_.count());
+
+    BaseBiosTable ours;
+    for (uint32_t i = 0; i < evStorage_.count(); ++i)
+    {
+        auto entry = evStorage_.getByIndex(i);
+        if (!entry)
+        {
+            continue;
+        }
+
+        auto id = bootOptionId(entry->name);
+        if (!id)
+        {
+            lg2::debug("BIOS config: skipping non-boot EV {EV}", "EV",
+                       entry->name);
+            continue;
+        }
+
+        auto name = parseBootOptionName(entry->data);
+        if (!name)
+        {
+            lg2::warning("BIOS config: cannot parse boot option {EV}", "EV",
+                         entry->name);
+            continue;
+        }
+
+        lg2::debug("BIOS config: Boot{ID} = '{NAME}' ({BYTES} bytes)", "ID",
+                   *id, "NAME", *name, "BYTES", entry->data.size());
+        ours.emplace("Boot" + *id, makeStringAttribute(*name));
+    }
+
+    BaseBiosTable table = getBaseTable();
+    for (const auto& key : managedKeys_)
+    {
+        table.erase(key);
+    }
+    managedKeys_.clear();
+    for (auto& [key, value] : ours)
+    {
+        managedKeys_.insert(key);
+        table[key] = std::move(value);
+    }
+
+    if (!setBaseTable(table))
+    {
+        return;
+    }
+
+    lg2::info("BIOS config: published {COUNT} boot option(s)", "COUNT",
+              managedKeys_.size());
+}
+
+BiosConfigService::BaseBiosTable BiosConfigService::getBaseTable()
+{
+    auto value = getProperty<BaseBiosTable>(
+        bus_, biosConfigService, Manager::instance_path, Manager::interface,
+        Manager::property_names::base_bios_table);
+    if (!value)
+    {
+        lg2::warning("BIOS config: cannot read BaseBIOSTable, starting empty");
+        return {};
+    }
+    return *value;
+}
+
+bool BiosConfigService::setBaseTable(const BaseBiosTable& table)
+{
+    if (!setProperty(bus_, biosConfigService, Manager::instance_path,
+                     Manager::interface,
+                     Manager::property_names::base_bios_table, table))
+    {
+        lg2::error("BIOS config: failed to set BaseBIOSTable");
+        return false;
+    }
+    return true;
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/bios_config_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/bios_config_service.hpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include "ev_storage.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <xyz/openbmc_project/BIOSConfig/Manager/common.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace chif
+{
+
+inline constexpr std::string_view bootOptionEvPrefix = "CQSBOOT";
+
+class BiosConfigService
+{
+  public:
+    BiosConfigService(sdbusplus::bus_t& bus, EvStorage& evStorage);
+
+    // Extract the display name from a CQSBOOT#### EV payload. Returns nullopt
+    // when the payload is too short or holds no printable name.
+    static std::optional<std::string> parseBootOptionName(
+        std::span<const uint8_t> data);
+
+    // Return the two-digit option id used on D-Bus (the low two digits of the
+    // CQSBOOT#### suffix, e.g. "01"), or nullopt if the name is not a
+    // boot-option EV.
+    static std::optional<std::string> bootOptionId(const std::string& evName);
+
+  private:
+    using Manager =
+        sdbusplus::common::xyz::openbmc_project::bios_config::Manager;
+    using BaseBiosTable = decltype(Manager::properties_t::base_bios_table);
+    using BiosAttribute = BaseBiosTable::mapped_type;
+
+    // (Re)build boot-option attributes from the EV store and merge them into
+    // the manager's BaseBIOSTable.
+    void publish();
+
+    static BiosAttribute makeStringAttribute(const std::string& value);
+
+    BaseBiosTable getBaseTable();
+    bool setBaseTable(const BaseBiosTable& table);
+
+    sdbusplus::bus_t& bus_;
+    EvStorage& evStorage_;
+    // Attribute keys we published last time, so we can refresh only our own
+    // entries without disturbing attributes owned by other providers.
+    std::set<std::string> managedKeys_;
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/boot_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/boot_service.cpp
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "boot_service.hpp"
+
+#include "bios_config_service.hpp"
+#include "utils.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Object/Enable/common.hpp>
+
+#include <charconv>
+
+namespace chif
+{
+
+namespace
+{
+namespace rules = sdbusplus::bus::match::rules;
+
+using Enable = sdbusplus::common::xyz::openbmc_project::object::Enable;
+
+constexpr auto settingsService = "xyz.openbmc_project.Settings";
+constexpr auto bootPath = "/xyz/openbmc_project/control/host0/boot";
+constexpr auto oneTimeBootPath =
+    "/xyz/openbmc_project/control/host0/boot/one_time";
+
+} // namespace
+
+BootService::BootService(sdbusplus::bus_t& bus, EvStorage& evStorage) :
+    bus_(bus), evStorage_(evStorage)
+{
+    using Source = BootService::Source;
+    using Mode = BootService::Mode;
+
+    matches_.emplace_back(bus_,
+                          rules::propertiesChanged(bootPath, Source::interface),
+                          [this](sdbusplus::message_t&) { syncEffective(); });
+    matches_.emplace_back(bus_,
+                          rules::propertiesChanged(bootPath, Mode::interface),
+                          [this](sdbusplus::message_t&) { syncEffective(); });
+    matches_.emplace_back(
+        bus_, rules::propertiesChanged(oneTimeBootPath, Enable::interface),
+        [this](sdbusplus::message_t&) { syncEffective(); });
+
+    // The host deletes CQTBOOTNEXT once it consumes the one-time boot
+    evStorage_.addChangeCallback([this](std::string_view name) {
+        onEvChanged(name);
+    });
+
+    syncEffective();
+}
+
+std::optional<uint16_t> BootService::optionNumber(std::string_view evName)
+{
+    if (!evName.starts_with(bootOptionEvPrefix))
+    {
+        return std::nullopt;
+    }
+    auto digits = evName.substr(bootOptionEvPrefix.size());
+    if (digits.size() != 4)
+    {
+        return std::nullopt;
+    }
+    uint16_t value = 0;
+    auto* end = digits.data() + digits.size();
+    auto [ptr, ec] = std::from_chars(digits.data(), end, value, 16);
+    if (ec != std::errc{} || ptr != end)
+    {
+        return std::nullopt;
+    }
+    return value;
+}
+
+std::vector<std::string_view> BootService::targetKeywords(Sources source,
+                                                          Modes mode)
+{
+    // BIOS setup is requested through Boot.Mode and takes precedence.
+    if (mode == Modes::Setup)
+    {
+        return {"System Utilities", "Setup"};
+    }
+
+    switch (source)
+    {
+        case Sources::Network:
+            return {"Network Boot", "PXE"};
+        case Sources::HTTP:
+            return {"HTTP Boot", "HTTP"};
+        case Sources::RemovableMedia:
+            return {"USB"};
+        case Sources::ExternalMedia:
+            return {"Virtual Media", "Virtual CD", "Virtual", "CD/DVD", "CD",
+                    "DVD",           "Optical",    "Blu-ray"};
+        case Sources::Disk:
+            return {"Logical Drive", "Bay", "NVMe", "SATA", "SAS",
+                    "SSD",           "HDD", "RAID", "Hard", "Disk"};
+        case Sources::Default:
+            break;
+    }
+    return {};
+}
+
+std::optional<uint16_t> BootService::matchOption(
+    const std::vector<std::pair<uint16_t, std::string>>& options,
+    const std::vector<std::string_view>& keywords)
+{
+    for (auto keyword : keywords)
+    {
+        for (const auto& [number, name] : options)
+        {
+            if (name.contains(keyword))
+            {
+                return number;
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+std::vector<uint8_t> BootService::reorderBootOrder(
+    std::span<const uint8_t> current, uint16_t option)
+{
+    std::vector<uint16_t> order;
+    order.reserve(current.size() / 2);
+    for (size_t i = 0; i + 1 < current.size(); i += 2)
+    {
+        order.push_back(static_cast<uint16_t>(
+            current[i] | (static_cast<uint16_t>(current[i + 1]) << 8)));
+    }
+
+    std::erase(order, option);
+    order.insert(order.begin(), option);
+
+    std::vector<uint8_t> out;
+    out.reserve(order.size() * 2);
+    for (uint16_t v : order)
+    {
+        out.push_back(static_cast<uint8_t>(v & 0xFF));
+        out.push_back(static_cast<uint8_t>(v >> 8));
+    }
+    return out;
+}
+
+std::vector<uint8_t> BootService::encodeOption(uint16_t option)
+{
+    return {static_cast<uint8_t>(option & 0xFF),
+            static_cast<uint8_t>(option >> 8)};
+}
+
+std::optional<uint16_t> BootService::resolveTarget(Sources source, Modes mode)
+{
+    auto keywords = targetKeywords(source, mode);
+    if (keywords.empty())
+    {
+        return std::nullopt;
+    }
+
+    std::vector<std::pair<uint16_t, std::string>> options;
+    for (uint32_t i = 0; i < evStorage_.count(); ++i)
+    {
+        auto entry = evStorage_.getByIndex(i);
+        if (!entry)
+        {
+            continue;
+        }
+        auto number = optionNumber(entry->name);
+        if (!number)
+        {
+            continue;
+        }
+        auto name = BiosConfigService::parseBootOptionName(entry->data);
+        if (!name)
+        {
+            continue;
+        }
+        options.emplace_back(*number, std::move(*name));
+    }
+
+    auto option = matchOption(options, keywords);
+    if (!option)
+    {
+        lg2::warning("Boot override: no boot option matches target "
+                     "(source={SRC} mode={MODE})",
+                     "SRC", Source::convertSourcesToString(source), "MODE",
+                     Mode::convertModesToString(mode));
+    }
+    return option;
+}
+
+bool BootService::applyOneTime(uint16_t option)
+{
+    if (!evStorage_.set(bootNextEvName, encodeOption(option)))
+    {
+        lg2::error("One-time boot: failed to persist {EV}", "EV",
+                   bootNextEvName);
+        return false;
+    }
+    lg2::info("One-time boot: option {OPT}", "OPT", lg2::hex, option);
+    return true;
+}
+
+bool BootService::applyPersistent(uint16_t option)
+{
+    auto entry = evStorage_.getByName(bootOrderEvName);
+    if (!entry || entry->data.size() < 2)
+    {
+        lg2::error("Persistent boot: {EV} missing; cannot reorder "
+                   "(host must boot once to publish it)",
+                   "EV", bootOrderEvName);
+        return false;
+    }
+
+    auto payload = reorderBootOrder(entry->data, option);
+    if (!evStorage_.set(bootOrderEvName, payload))
+    {
+        lg2::error("Persistent boot: Failed to persist {EV}", "EV",
+                   bootOrderEvName);
+        return false;
+    }
+    lg2::info("Persistent boot: option {OPT} moved to front", "OPT", lg2::hex,
+              option);
+    return true;
+}
+
+void BootService::clearOneTime()
+{
+    if (evStorage_.getByName(bootNextEvName))
+    {
+        applyingOverride_ = true;
+        bool ok = evStorage_.del(bootNextEvName);
+        applyingOverride_ = false;
+        if (ok)
+        {
+            lg2::info("One-time boot override cleared");
+        }
+        else
+        {
+            lg2::error("Failed to clear {EV}", "EV", bootNextEvName);
+        }
+    }
+}
+
+void BootService::onEvChanged(std::string_view name)
+{
+    if (applyingOverride_)
+    {
+        return; // our own EV write
+    }
+    if (!name.empty() && name != bootNextEvName)
+    {
+        return; // unrelated EV
+    }
+    if (evStorage_.getByName(bootNextEvName))
+    {
+        return; // not consumed yet
+    }
+    if (!getOneTimeEnabled())
+    {
+        return; // no active one-time override to reconcile
+    }
+
+    lg2::info("One-time boot consumed by host! Clearing override in settings");
+    clearOverrideSettings();
+}
+
+void BootService::clearOverrideSettings()
+{
+    setProperty<Modes>(bus_, settingsService, bootPath, Mode::interface,
+                       Mode::property_names::boot_mode, Modes::Regular);
+    setProperty<Sources>(bus_, settingsService, bootPath, Source::interface,
+                         Source::property_names::boot_source, Sources::Default);
+    setProperty<bool>(bus_, settingsService, oneTimeBootPath, Enable::interface,
+                      Enable::property_names::enabled, false);
+}
+
+void BootService::syncEffective()
+{
+    const bool oneTime = getOneTimeEnabled();
+    const Sources source = getBootSource(bootPath);
+    const Modes mode = getBootMode(bootPath);
+
+    lg2::info("Boot settings sync: oneTime={ONE} source={SRC} mode={MODE}",
+              "ONE", oneTime, "SRC", Source::convertSourcesToString(source),
+              "MODE", Mode::convertModesToString(mode));
+
+    auto option = resolveTarget(source, mode);
+    if (!option)
+    {
+        // drop any pending one-time selection. The persistent order
+        // is left untouched (we cannot reconstruct the ROM's
+        // original order, and it re-publishes it every boot anyway).
+        clearOneTime();
+        return;
+    }
+
+    if (oneTime)
+    {
+        applyOneTime(*option);
+    }
+    else
+    {
+        // A persistent selection supersedes a stale one-time entry.
+        clearOneTime();
+        applyPersistent(*option);
+    }
+}
+
+BootService::Sources BootService::getBootSource(const std::string& path)
+{
+    auto value = getProperty<Sources>(bus_, settingsService, path.c_str(),
+                                      Source::interface,
+                                      Source::property_names::boot_source);
+    if (!value)
+    {
+        lg2::error("Failed to read BootSource at {PATH}", "PATH", path);
+        return Sources::Default;
+    }
+    return *value;
+}
+
+BootService::Modes BootService::getBootMode(const std::string& path)
+{
+    auto value =
+        getProperty<Modes>(bus_, settingsService, path.c_str(), Mode::interface,
+                           Mode::property_names::boot_mode);
+    if (!value)
+    {
+        lg2::error("Failed to read BootMode at {PATH}", "PATH", path);
+        return Modes::Regular;
+    }
+    return *value;
+}
+
+bool BootService::getOneTimeEnabled()
+{
+    auto value =
+        getProperty<bool>(bus_, settingsService, oneTimeBootPath,
+                          Enable::interface, Enable::property_names::enabled);
+    if (!value)
+    {
+        lg2::error("Failed to read one-time Enabled");
+    }
+    return value.value_or(false);
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/boot_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/boot_service.hpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include "ev_storage.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+#include <sdbusplus/message.hpp>
+#include <xyz/openbmc_project/Control/Boot/Mode/common.hpp>
+#include <xyz/openbmc_project/Control/Boot/Source/common.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace chif
+{
+inline constexpr auto bootOrderEvName = "CQHBOOTORDER";
+inline constexpr auto bootNextEvName = "CQTBOOTNEXT";
+
+class BootService
+{
+  public:
+    using Source =
+        sdbusplus::common::xyz::openbmc_project::control::boot::Source;
+    using Sources = Source::Sources;
+    using Mode = sdbusplus::common::xyz::openbmc_project::control::boot::Mode;
+    using Modes = Mode::Modes;
+
+    BootService(sdbusplus::bus_t& bus, EvStorage& evStorage);
+
+    // Parse the 16-bit UEFI option number out of a CQSBOOT#### EV name.
+    // Returns nullopt if the name is not a boot-option EV.
+    static std::optional<uint16_t> optionNumber(std::string_view evName);
+
+    // Priority-ordered display-name keywords to match for a given boot target.
+    // This is kinda hacky mainly because I couldn't figure out if there's a
+    // common identifier that could be used to filter the boot values.
+    static std::vector<std::string_view> targetKeywords(Sources source,
+                                                        Modes mode);
+
+    // Return the option number of the first (option, displayName) pair whose
+    // name contains any keyword, tried in keyword priority order.
+    static std::optional<uint16_t> matchOption(
+        const std::vector<std::pair<uint16_t, std::string>>& options,
+        const std::vector<std::string_view>& keywords);
+
+    // Parse the existing CQHBOOTORDER array and move `option` to the front
+    // (adding it if absent). Returns a byte blob.
+    static std::vector<uint8_t> reorderBootOrder(
+        std::span<const uint8_t> current, uint16_t option);
+
+    // Encode a single option number as a uint16, mainly used for CQTBOOTNEXT.
+    static std::vector<uint8_t> encodeOption(uint16_t option);
+
+  private:
+    void syncEffective();
+
+    // Resolve the active phosphor target to a boot-option number by matching
+    // the CQSBOOT#### display names in the EV store. nullopt = no override.
+    std::optional<uint16_t> resolveTarget(Sources source, Modes mode);
+
+    bool applyOneTime(uint16_t option);
+    bool applyPersistent(uint16_t option);
+    void clearOneTime();
+
+    void onEvChanged(std::string_view name);
+    void clearOverrideSettings();
+
+    Sources getBootSource(const std::string& path);
+    Modes getBootMode(const std::string& path);
+    bool getOneTimeEnabled();
+
+    sdbusplus::bus_t& bus_;
+    EvStorage& evStorage_;
+    std::vector<sdbusplus::bus::match_t> matches_;
+    // Set while BootService itself mutates the EV store, so its own writes are
+    // not misread as a host-side consumption in onEvChanged().
+    bool applyingOverride_ = false;
+};
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.cpp
@@ -5,19 +5,10 @@
 #include <phosphor-logging/lg2.hpp>
 
 #include <cerrno>
-#include <cmath>
 #include <cstring>
-#include <thread>
 
 namespace chif
 {
-
-// Maximum consecutive read errors before backing off.
-// Prevents CPU busy-loop on persistent hardware faults.
-static constexpr int maxConsecutiveErrors = 10;
-static constexpr auto errorBackoffBaseDelay = std::chrono::seconds(1);
-static constexpr auto errorBackoffMaxDelay = std::chrono::seconds(30);
-
 ChifDaemon::ChifDaemon(std::unique_ptr<Channel> channel) :
     channel_(std::move(channel))
 {}
@@ -28,126 +19,125 @@ void ChifDaemon::registerHandler(std::unique_ptr<ServiceHandler> handler)
     handlers_[id] = std::move(handler);
 }
 
-void ChifDaemon::run()
+void ChifDaemon::run(sd_event* event)
 {
-    running_ = true;
-    int consecutiveErrors = 0;
-    int errorRetryCounter = 0;
+    event_ = event;
 
-    lg2::info("CHIF daemon starting");
-
-    while (running_)
+    int fd = channel_->pollFd();
+    if (fd < 0)
     {
-        auto n = channel_->read(recvBuf_);
-        if (n <= 0)
-        {
-            int savedErrno = errno;
-            // EINTR is expected on signal delivery (e.g., SIGTERM).
-            // Other errors may indicate hardware faults — back off to
-            // prevent CPU busy-loop on persistent errors.
-            if (n < 0 && savedErrno != EINTR)
-            {
-                consecutiveErrors++;
-                if (consecutiveErrors >= maxConsecutiveErrors)
-                {
-                    lg2::error(
-                        "CHIF: {COUNT} consecutive read errors "
-                        "(last errno: {ERR}), backing off",
-                        "COUNT", consecutiveErrors, "ERR", savedErrno);
-                    auto delay = std::min(
-                        errorBackoffMaxDelay,
-                        errorBackoffBaseDelay *
-                            static_cast<int>(
-                                std::pow(2, errorRetryCounter)));
-                    std::this_thread::sleep_for(delay);
-                    errorRetryCounter++;
-                }
-            }
-            continue;
-        }
-
-        // Successful read — reset error counters.
-        consecutiveErrors = 0;
-        errorRetryCounter = 0;
-
-        if (static_cast<size_t>(n) < sizeof(ChifPktHeader))
-        {
-            lg2::warning("Short packet received: {SIZE} bytes", "SIZE", n);
-            continue;
-        }
-
-        auto hdr = parseHeader(
-            std::span<const uint8_t>(recvBuf_.data(), static_cast<size_t>(n)));
-
-        // Copy packed fields to locals — packed fields cannot bind to
-        // references, which lg2 requires.
-        uint8_t svcId = hdr.serviceId;
-        uint16_t cmd = hdr.command;
-        uint16_t seq = hdr.sequence;
-
-        lg2::debug("CHIF RX: svc={SVC} cmd={CMD} seq={SEQ} size={SZ}",
-                    "SVC", lg2::hex, svcId, "CMD", lg2::hex, cmd, "SEQ", seq,
-                    "SZ", n);
-
-        auto it = handlers_.find(hdr.serviceId);
-        if (it == handlers_.end())
-        {
-            lg2::warning("CHIF DROP: no handler for svc={SVC} cmd={CMD}",
-                         "SVC", lg2::hex, svcId, "CMD", lg2::hex, cmd);
-            continue;
-        }
-
-        auto reqSpan = std::span<const uint8_t>(recvBuf_.data(),
-                                                static_cast<size_t>(n));
-        auto respSpan = std::span<uint8_t>(respBuf_);
-
-        int respSize = it->second->handle(reqSpan, respSpan);
-        if (respSize > 0)
-        {
-            if (static_cast<size_t>(respSize) < sizeof(ChifPktHeader))
-            {
-                lg2::error(
-                    "Handler returned invalid response size: {SZ}",
-                    "SZ", respSize);
-                continue;
-            }
-
-            auto rspHdr = parseHeader(
-                std::span<const uint8_t>(respBuf_.data(),
-                                         static_cast<size_t>(respSize)));
-            uint8_t rspSvc = rspHdr.serviceId;
-            uint16_t rspCmd = rspHdr.command;
-            uint16_t rspSeq = rspHdr.sequence;
-
-            lg2::debug(
-                "CHIF TX: svc={SVC} cmd={CMD} seq={SEQ} size={SZ}", "SVC",
-                lg2::hex, rspSvc, "CMD", lg2::hex, rspCmd, "SEQ", rspSeq,
-                "SZ", respSize);
-
-            auto written = channel_->write(
-                std::span<const uint8_t>(respBuf_.data(),
-                                         static_cast<size_t>(respSize)));
-            if (written < 0)
-            {
-                int savedErrno = errno;
-                lg2::error(
-                    "CHIF TX failed for cmd={CMD}: errno={ERR}", "CMD",
-                    lg2::hex, cmd, "ERR", savedErrno);
-            }
-        }
-        else
-        {
-            lg2::debug("CHIF: no response for cmd={CMD}", "CMD", lg2::hex,
-                       cmd);
-        }
+        lg2::error("CHIF channel is not pollable; cannot run event loop");
+        return;
     }
 
+    int r = sd_event_add_io(event, &ioSource_, fd, EPOLLIN,
+                            &ChifDaemon::onChannelIo, this);
+    if (r < 0)
+    {
+        lg2::error("Failed to register CHIF io source: {ERR}", "ERR",
+                   strerror(-r));
+        return;
+    }
+
+    lg2::info("CHIF daemon starting");
+    sd_event_loop(event);
     lg2::info("CHIF daemon stopped");
+
+    sd_event_source_unref(ioSource_);
+    ioSource_ = nullptr;
 }
 
 void ChifDaemon::stop()
 {
-    running_ = false;
+    if (event_ != nullptr)
+    {
+        sd_event_exit(event_, 0);
+    }
+}
+
+int ChifDaemon::onChannelIo(sd_event_source* /*source*/, int /*fd*/,
+                            uint32_t /*revents*/, void* userdata)
+{
+    static_cast<ChifDaemon*>(userdata)->processOnce();
+    return 0;
+}
+
+void ChifDaemon::processOnce()
+{
+    auto n = channel_->read(recvBuf_);
+    if (n <= 0)
+    {
+        int savedErrno = errno;
+        // ERINTR/EAGAIN expected on signal delivery or when no data was
+        // received yet.
+        if (n < 0 && savedErrno != EINTR && savedErrno != EAGAIN)
+        {
+            lg2::error("CHIF read failed: {ERR}", "ERR", strerror(savedErrno));
+        }
+        return;
+    }
+
+    if (static_cast<size_t>(n) < sizeof(ChifPktHeader))
+    {
+        lg2::warning("Short packet received: {SIZE} bytes", "SIZE", n);
+        return;
+    }
+
+    auto hdr = parseHeader(
+        std::span<const uint8_t>(recvBuf_.data(), static_cast<size_t>(n)));
+
+    uint8_t svcId = hdr.serviceId;
+    uint16_t cmd = hdr.command;
+    uint16_t seq = hdr.sequence;
+
+    lg2::debug("CHIF RX: svc={SVC} cmd={CMD} seq={SEQ} size={SZ}", "SVC",
+               lg2::hex, svcId, "CMD", lg2::hex, cmd, "SEQ", seq, "SZ", n);
+
+    auto it = handlers_.find(hdr.serviceId);
+    if (it == handlers_.end())
+    {
+        lg2::warning("CHIF DROP: no handler for svc={SVC} cmd={CMD}", "SVC",
+                     lg2::hex, svcId, "CMD", lg2::hex, cmd);
+        return;
+    }
+
+    auto reqSpan =
+        std::span<const uint8_t>(recvBuf_.data(), static_cast<size_t>(n));
+    auto respSpan = std::span<uint8_t>(respBuf_);
+
+    int respSize = it->second->handle(reqSpan, respSpan);
+    if (respSize > 0)
+    {
+        if (static_cast<size_t>(respSize) < sizeof(ChifPktHeader))
+        {
+            lg2::error("Handler returned invalid response size: {SZ}", "SZ",
+                       respSize);
+            return;
+        }
+
+        auto rspHdr = parseHeader(std::span<const uint8_t>(
+            respBuf_.data(), static_cast<size_t>(respSize)));
+        uint8_t rspSvc = rspHdr.serviceId;
+        uint16_t rspCmd = rspHdr.command;
+        uint16_t rspSeq = rspHdr.sequence;
+
+        lg2::debug("CHIF TX: svc={SVC} cmd={CMD} seq={SEQ} size={SZ}", "SVC",
+                   lg2::hex, rspSvc, "CMD", lg2::hex, rspCmd, "SEQ", rspSeq,
+                   "SZ", respSize);
+
+        auto written = channel_->write(std::span<const uint8_t>(
+            respBuf_.data(), static_cast<size_t>(respSize)));
+        if (written < 0)
+        {
+            int savedErrno = errno;
+            lg2::error("CHIF TX failed for cmd={CMD}: errno={ERR}", "CMD",
+                       lg2::hex, cmd, "ERR", savedErrno);
+        }
+    }
+    else
+    {
+        lg2::debug("CHIF: no response for cmd={CMD}", "CMD", lg2::hex, cmd);
+    }
 }
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/chif_daemon.hpp
@@ -4,8 +4,9 @@
 
 #include "packet.hpp"
 
+#include <systemd/sd-event.h>
+
 #include <array>
-#include <atomic>
 #include <memory>
 #include <unordered_map>
 
@@ -21,16 +22,22 @@ class ChifDaemon
     // same service_id.
     void registerHandler(std::unique_ptr<ServiceHandler> handler);
 
-    // Run the main packet loop. Blocks until stop() is called.
-    void run();
+    // Run the main packet loop, using a given sd_event.
+    void run(sd_event* event);
 
-    // Request the daemon to stop (thread-safe).
+    // Exit the event loop.
     void stop();
 
   private:
+    static int onChannelIo(sd_event_source* source, int fd, uint32_t revents,
+                           void* userdata);
+    void processOnce();
+
     std::unique_ptr<Channel> channel_;
     std::unordered_map<uint8_t, std::unique_ptr<ServiceHandler>> handlers_;
-    std::atomic<bool> running_{false};
+
+    sd_event* event_{nullptr};
+    sd_event_source* ioSource_{nullptr};
 
     std::array<uint8_t, maxPacketSize> recvBuf_{};
     std::array<uint8_t, maxPacketSize> respBuf_{};

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/ev_storage.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/ev_storage.cpp
@@ -2,10 +2,10 @@
 // Copyright (C) 2026 9elements GmbH
 #include "ev_storage.hpp"
 
-#include <phosphor-logging/lg2.hpp>
-
 #include <fcntl.h>
 #include <unistd.h>
+
+#include <phosphor-logging/lg2.hpp>
 
 #include <algorithm>
 #include <cstdio>
@@ -21,6 +21,11 @@ static constexpr size_t entryOverhead = maxEvNameLen + sizeof(uint16_t);
 static constexpr size_t headerSize = sizeof(uint32_t) + sizeof(uint32_t);
 
 EvStorage::EvStorage(std::filesystem::path path) : path_(std::move(path)) {}
+
+void EvStorage::addChangeCallback(ChangeCallback callback)
+{
+    changeCallbacks_.push_back(std::move(callback));
+}
 
 int EvStorage::load()
 {
@@ -43,8 +48,7 @@ int EvStorage::load()
     std::ifstream file(path_, std::ios::binary);
     if (!file)
     {
-        lg2::error("EV storage: failed to open {PATH}", "PATH",
-                   path_.string());
+        lg2::error("EV storage: failed to open {PATH}", "PATH", path_.string());
         return -1;
     }
 
@@ -55,8 +59,8 @@ int EvStorage::load()
 
     if (magic != evFileMagic)
     {
-        lg2::error("EV storage: bad magic {MAGIC} in {PATH}", "MAGIC",
-                   lg2::hex, magic, "PATH", path_.string());
+        lg2::error("EV storage: bad magic {MAGIC} in {PATH}", "MAGIC", lg2::hex,
+                   magic, "PATH", path_.string());
         return -1;
     }
 
@@ -76,8 +80,7 @@ int EvStorage::load()
         file.read(reinterpret_cast<char*>(&dataLen), sizeof(dataLen));
 
         if (dataLen > maxEvDataSize ||
-            totalRead + entryOverhead + dataLen > maxEvFileSize ||
-            !file.good())
+            totalRead + entryOverhead + dataLen > maxEvFileSize || !file.good())
         {
             lg2::warning("EV storage: truncated at entry {IDX}", "IDX", i);
             break;
@@ -155,21 +158,20 @@ bool EvStorage::set(const std::string& name, std::span<const uint8_t> data)
             }
         }
         it->data.assign(data.begin(), data.end());
-        return save();
+        return saveAndNotify(name);
     }
 
     // New entry — check space
     size_t needed = entryOverhead + data.size();
     if (serializedSize() + needed > maxEvFileSize)
     {
-        lg2::warning("EV storage: no space for {NAME} ({NEEDED} bytes)",
-                     "NAME", name, "NEEDED", needed);
+        lg2::warning("EV storage: no space for {NAME} ({NEEDED} bytes)", "NAME",
+                     name, "NEEDED", needed);
         return false;
     }
 
-    entries_.push_back(
-        {name, std::vector<uint8_t>(data.begin(), data.end())});
-    return save();
+    entries_.push_back({name, std::vector<uint8_t>(data.begin(), data.end())});
+    return saveAndNotify(name);
 }
 
 bool EvStorage::del(const std::string& name)
@@ -182,13 +184,13 @@ bool EvStorage::del(const std::string& name)
     }
 
     entries_.erase(it);
-    return save();
+    return saveAndNotify(name);
 }
 
 bool EvStorage::deleteAll()
 {
     entries_.clear();
-    return save();
+    return saveAndNotify({});
 }
 
 uint32_t EvStorage::count() const
@@ -210,6 +212,19 @@ size_t EvStorage::serializedSize() const
         total += entryOverhead + entry.data.size();
     }
     return total;
+}
+
+bool EvStorage::saveAndNotify(std::string_view name)
+{
+    if (!save())
+    {
+        return false;
+    }
+    for (const auto& cb : changeCallbacks_)
+    {
+        cb(name);
+    }
+    return true;
 }
 
 bool EvStorage::save()
@@ -259,9 +274,8 @@ bool EvStorage::save()
 
     // Copy from tmpfs to rwfs (cross-device rename is not possible)
     std::error_code ec;
-    std::filesystem::copy_file(tmpPath, path_,
-                               std::filesystem::copy_options::overwrite_existing,
-                               ec);
+    std::filesystem::copy_file(
+        tmpPath, path_, std::filesystem::copy_options::overwrite_existing, ec);
     std::filesystem::remove(tmpPath);
     if (ec)
     {

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/ev_storage.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/ev_storage.hpp
@@ -4,9 +4,11 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <optional>
 #include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace chif
@@ -39,8 +41,10 @@ struct EvEntry
 class EvStorage
 {
   public:
-    explicit EvStorage(
-        std::filesystem::path path = "/var/lib/chif/evs.dat");
+    explicit EvStorage(std::filesystem::path path = "/var/lib/chif/evs.dat");
+
+    using ChangeCallback = std::function<void(std::string_view name)>;
+    void addChangeCallback(ChangeCallback callback);
 
     int load();
 
@@ -61,10 +65,12 @@ class EvStorage
 
   private:
     bool save();
+    bool saveAndNotify(std::string_view name);
     size_t serializedSize() const;
 
     std::filesystem::path path_;
     std::vector<EvEntry> entries_;
+    std::vector<ChangeCallback> changeCallbacks_;
 };
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/health_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/health_service.cpp
@@ -2,9 +2,6 @@
 // Copyright (C) 2026 9elements GmbH
 #include "health_service.hpp"
 
-#include <algorithm>
-#include <cstring>
-
 namespace chif
 {
 
@@ -24,19 +21,7 @@ int HealthService::handle(std::span<const uint8_t> request,
         return -1;
     }
 
-    constexpr auto respSize =
-        static_cast<uint16_t>(sizeof(ChifPktHeader) + sizeof(uint32_t));
-
-    if (response.size() < respSize)
-    {
-        return -1;
-    }
-
-    auto hdr = parseHeader(request);
-
-    std::fill_n(response.data(), respSize, uint8_t{0});
-    initResponse(response, hdr, respSize);
-    return respSize;
+    return emitResponse(parseHeader(request), response, uint32_t{0});
 }
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -7,14 +7,15 @@
 #include "mdr_bridge.hpp"
 #include "platdef_extract.hpp"
 #include "rom_service.hpp"
-#include "smif_service.hpp"
 #include "smbios_writer.hpp"
+#include "smif_service.hpp"
+
+#include <fcntl.h>
+#include <systemd/sd-event.h>
+#include <unistd.h>
 
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
-
-#include <fcntl.h>
-#include <unistd.h>
 
 #include <cerrno>
 #include <csignal>
@@ -26,15 +27,11 @@ namespace
 constexpr auto chifDevice = "/dev/chif24";
 constexpr auto dbusName = "xyz.openbmc_project.GxpChif";
 
-// Global daemon pointer for signal handler
-chif::ChifDaemon* gDaemon = nullptr; // NOLINT
-
-void signalHandler(int /*sig*/)
+int onTerminate(sd_event_source* source, const struct signalfd_siginfo* /*si*/,
+                void* /*userdata*/)
 {
-    if (gDaemon)
-    {
-        gDaemon->stop();
-    }
+    sd_event_exit(sd_event_source_get_event(source), 0);
+    return 0;
 }
 
 // Real device channel wrapping /dev/chif24
@@ -64,6 +61,11 @@ class DeviceChannel : public chif::Channel
         return ::write(fd_, buf.data(), buf.size());
     }
 
+    int pollFd() const override
+    {
+        return fd_;
+    }
+
   private:
     int fd_;
 };
@@ -74,8 +76,7 @@ int main()
 {
     lg2::info("GXP CHIF service starting, version 1.0.0");
 
-    // Open the CHIF device
-    int fd = open(chifDevice, O_RDWR | O_CLOEXEC);
+    int fd = open(chifDevice, O_RDWR | O_CLOEXEC | O_NONBLOCK);
     if (fd < 0)
     {
         lg2::error("Failed to open {DEV}: {ERR}", "DEV", chifDevice, "ERR",
@@ -85,8 +86,15 @@ int main()
 
     auto channel = std::make_unique<DeviceChannel>(fd);
 
-    // Connect to D-Bus and request our well-known name
+    sd_event* event = nullptr;
+    if (int r = sd_event_default(&event); r < 0)
+    {
+        lg2::error("Failed to create event loop: {ERR}", "ERR", strerror(-r));
+        return 1;
+    }
+
     auto bus = sdbusplus::bus::new_default();
+    bus.attach_event(event, SD_EVENT_PRIORITY_NORMAL);
     bus.request_name(dbusName);
 
     // Create service components
@@ -113,18 +121,19 @@ int main()
         &evStorage, std::move(segmentBusMap)));
     daemon.registerHandler(std::make_unique<chif::HealthService>());
 
-    // Install signal handlers for graceful shutdown
-    gDaemon = &daemon;
-    struct sigaction sa{};
-    sa.sa_handler = signalHandler;
-    sigemptyset(&sa.sa_mask);
-    sa.sa_flags = 0;
-    sigaction(SIGTERM, &sa, nullptr);
-    sigaction(SIGINT, &sa, nullptr);
+    sigset_t ss;
+    sigemptyset(&ss);
+    sigaddset(&ss, SIGTERM);
+    sigaddset(&ss, SIGINT);
+    sigprocmask(SIG_BLOCK, &ss, nullptr);
+    sd_event_add_signal(event, nullptr, SIGTERM, onTerminate, nullptr);
+    sd_event_add_signal(event, nullptr, SIGINT, onTerminate, nullptr);
 
     // Run the main event loop (blocks until stopped)
-    daemon.run();
+    daemon.run(event);
 
+    bus.detach_event();
+    sd_event_unref(event);
     lg2::info("GXP CHIF service exiting");
     return 0;
 }

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 9elements GmbH
 
+#include "bios_config_service.hpp"
+#include "boot_service.hpp"
 #include "chif_daemon.hpp"
 #include "ev_storage.hpp"
 #include "health_service.hpp"
@@ -105,6 +107,10 @@ int main()
     {
         lg2::warning("EV storage failed to load, starting with empty store");
     }
+
+    // Boot configuration bridges (D-Bus <-> EV store).
+    chif::BootService bootService(bus, evStorage);
+    chif::BiosConfigService biosConfigService(bus, evStorage);
 
     // Extract PlatDef from host BIOS SPI flash and build I2C segment→bus map
     auto platDefBlob = chif::extractPlatDef();

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -124,7 +124,7 @@ int main()
     daemon.registerHandler(
         std::make_unique<chif::RomService>(smbiosWriter, &mdrBridge));
     daemon.registerHandler(std::make_unique<chif::SmifService>(
-        &evStorage, std::move(segmentBusMap)));
+        &bus, &evStorage, std::move(segmentBusMap)));
     daemon.registerHandler(std::make_unique<chif::HealthService>());
 
     sigset_t ss;

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/mdr_bridge.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/mdr_bridge.cpp
@@ -3,15 +3,17 @@
 #include "mdr_bridge.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Smbios/MDR_V2/common.hpp>
 
 namespace chif
 {
 
 namespace
 {
+using MDRV2 = sdbusplus::common::xyz::openbmc_project::smbios::MDRV2;
+
 constexpr auto mdrService = "xyz.openbmc_project.Smbios.MDR_V2";
 constexpr auto mdrPath = "/xyz/openbmc_project/Smbios/MDR_V2";
-constexpr auto mdrInterface = "xyz.openbmc_project.Smbios.MDR_V2";
 } // namespace
 
 MdrBridge::MdrBridge(sdbusplus::bus_t& bus) : bus_(bus) {}
@@ -20,8 +22,9 @@ bool MdrBridge::synchronize()
 {
     try
     {
-        auto method = bus_.new_method_call(mdrService, mdrPath, mdrInterface,
-                                           "AgentSynchronizeData");
+        auto method =
+            bus_.new_method_call(mdrService, mdrPath, MDRV2::interface,
+                                 MDRV2::method_names::agent_synchronize_data);
 
         bus_.call_noreply(method);
         lg2::info("MDR AgentSynchronizeData called successfully");

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/net_config.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/net_config.cpp
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "net_config.hpp"
+
+#include "utils.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Network/EthernetInterface/common.hpp>
+#include <xyz/openbmc_project/Network/IP/common.hpp>
+#include <xyz/openbmc_project/Network/MACAddress/common.hpp>
+#include <xyz/openbmc_project/Network/SystemConfiguration/common.hpp>
+#include <xyz/openbmc_project/ObjectMapper/common.hpp>
+
+#include <format>
+#include <map>
+#include <optional>
+#include <variant>
+
+namespace chif
+{
+
+namespace
+{
+
+namespace network = sdbusplus::common::xyz::openbmc_project::network;
+using EthernetInterface = network::EthernetInterface;
+using MACAddress = network::MACAddress;
+using IP = network::IP;
+using SystemConfiguration = network::SystemConfiguration;
+using ObjectMapper = sdbusplus::common::xyz::openbmc_project::ObjectMapper;
+
+constexpr auto networkService = "xyz.openbmc_project.Network";
+constexpr auto networkRoot = "/xyz/openbmc_project/network";
+constexpr auto sysConfigPath = "/xyz/openbmc_project/network/config";
+
+AddrOrigin mapOrigin(IP::AddressOrigin o)
+{
+    switch (o)
+    {
+        case IP::AddressOrigin::DHCP:
+            return AddrOrigin::dhcp;
+        case IP::AddressOrigin::SLAAC:
+            return AddrOrigin::slaac;
+        case IP::AddressOrigin::LinkLocal:
+            return AddrOrigin::linkLocal;
+        default:
+            return AddrOrigin::stat;
+    }
+}
+
+std::vector<std::string> getIpPaths(sdbusplus::bus_t& bus,
+                                    const std::string& ifacePath)
+{
+    try
+    {
+        auto m = bus.new_method_call(
+            ObjectMapper::default_service, ObjectMapper::instance_path,
+            ObjectMapper::interface,
+            ObjectMapper::method_names::get_sub_tree_paths);
+        m.append(ifacePath, 0, std::vector<std::string>{IP::interface});
+        auto reply = bus.call(m);
+        std::vector<std::string> paths;
+        reply.read(paths);
+        return paths;
+    }
+    catch (const std::exception&)
+    {
+        return {};
+    }
+}
+
+void collectIpAddresses(sdbusplus::bus_t& bus, const std::string& ifacePath,
+                        NetworkConfig& cfg)
+{
+    using IpVariant = std::variant<std::string, uint8_t, bool, uint32_t>;
+
+    for (const auto& path : getIpPaths(bus, ifacePath))
+    {
+        std::map<std::string, IpVariant> props;
+        try
+        {
+            auto m = bus.new_method_call(networkService, path.c_str(),
+                                         propertiesInterface, "GetAll");
+            m.append(IP::interface);
+            bus.call(m).read(props);
+        }
+        catch (const std::exception&)
+        {
+            continue;
+        }
+
+        auto getStr = [&](const char* key) -> std::string {
+            auto it = props.find(key);
+            if (it == props.end())
+            {
+                return {};
+            }
+            const auto* s = std::get_if<std::string>(&it->second);
+            return s ? *s : std::string{};
+        };
+
+        std::string addrStr = getStr(IP::property_names::address);
+        uint8_t prefix = 0;
+        if (auto it = props.find(IP::property_names::prefix_length);
+            it != props.end() && std::holds_alternative<uint8_t>(it->second))
+        {
+            prefix = std::get<uint8_t>(it->second);
+        }
+
+        IP::Protocol proto{};
+        AddrOrigin origin = AddrOrigin::stat;
+        try
+        {
+            proto =
+                IP::convertProtocolFromString(getStr(IP::property_names::type));
+            origin = mapOrigin(IP::convertAddressOriginFromString(
+                getStr(IP::property_names::origin)));
+        }
+        catch (const std::exception&)
+        {
+            continue;
+        }
+
+        if (proto == IP::Protocol::IPv4)
+        {
+            if (auto v4 = parseV4(addrStr))
+            {
+                // Prefer the first routable (non-link-local) address.
+                if (!cfg.haveV4 || origin != AddrOrigin::linkLocal)
+                {
+                    cfg.haveV4 = true;
+                    cfg.v4addr = *v4;
+                    cfg.v4mask = prefixToMask4(prefix);
+                    cfg.v4Dhcp = (origin == AddrOrigin::dhcp);
+                }
+            }
+        }
+        else if (proto == IP::Protocol::IPv6)
+        {
+            if (auto v6 = parseV6(addrStr))
+            {
+                cfg.v6addrs.push_back({*v6, prefix, origin});
+            }
+        }
+    }
+}
+
+} // namespace
+
+NetworkConfig queryNetworkConfig(sdbusplus::bus_t& bus,
+                                 std::string_view interface)
+{
+    NetworkConfig cfg;
+    const std::string ifacePath = std::format("{}/{}", networkRoot, interface);
+
+    auto dhcp = getProperty<std::string>(
+        bus, networkService, ifacePath.c_str(), EthernetInterface::interface,
+        EthernetInterface::property_names::dhcp_enabled);
+    if (!dhcp)
+    {
+        lg2::warning("Network interface {IF} not found on D-Bus", "IF",
+                     interface);
+        return cfg;
+    }
+    cfg.present = true;
+
+    using DHCPConf = EthernetInterface::DHCPConf;
+    auto conf = EthernetInterface::convertStringToDHCPConf(*dhcp).value_or(
+        DHCPConf::none);
+    cfg.v4Dhcp = conf == DHCPConf::both || conf == DHCPConf::v4 ||
+                 conf == DHCPConf::v4v6stateless;
+    cfg.v6Dhcp = conf == DHCPConf::both || conf == DHCPConf::v6;
+
+    if (auto ra = getProperty<bool>(
+            bus, networkService, ifacePath.c_str(),
+            EthernetInterface::interface,
+            EthernetInterface::property_names::i_pv6_accept_ra))
+    {
+        cfg.v6AcceptRa = *ra;
+    }
+
+    if (auto mac = getProperty<std::string>(
+            bus, networkService, ifacePath.c_str(), MACAddress::interface,
+            MACAddress::property_names::mac_address))
+    {
+        if (auto parsed = parseMac(*mac))
+        {
+            cfg.mac = *parsed;
+        }
+    }
+
+    if (auto host = getProperty<std::string>(
+            bus, networkService, sysConfigPath, SystemConfiguration::interface,
+            SystemConfiguration::property_names::host_name))
+    {
+        cfg.hostName = *host;
+    }
+
+    if (auto domains = getProperty<std::vector<std::string>>(
+            bus, networkService, ifacePath.c_str(),
+            EthernetInterface::interface,
+            EthernetInterface::property_names::domain_name);
+        domains && !domains->empty())
+    {
+        cfg.domainName = domains->front();
+    }
+
+    if (auto gw = getProperty<std::string>(
+            bus, networkService, ifacePath.c_str(),
+            EthernetInterface::interface,
+            EthernetInterface::property_names::default_gateway))
+    {
+        if (auto v4 = parseV4(*gw))
+        {
+            cfg.v4gateway = *v4;
+        }
+    }
+
+    if (auto gw6 = getProperty<std::string>(
+            bus, networkService, ifacePath.c_str(),
+            EthernetInterface::interface,
+            EthernetInterface::property_names::default_gateway6))
+    {
+        if (auto v6 = parseV6(*gw6))
+        {
+            cfg.v6gateway = *v6;
+            cfg.haveV6Gateway = true;
+        }
+    }
+
+    if (auto ns = getProperty<std::vector<std::string>>(
+            bus, networkService, ifacePath.c_str(),
+            EthernetInterface::interface,
+            EthernetInterface::property_names::nameservers))
+    {
+        for (const auto& s : *ns)
+        {
+            if (auto v4 = parseV4(s))
+            {
+                cfg.v4dns.push_back(*v4);
+            }
+            else if (auto v6 = parseV6(s))
+            {
+                cfg.v6dns.push_back(*v6);
+            }
+        }
+    }
+
+    collectIpAddresses(bus, ifacePath, cfg);
+
+    return cfg;
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/net_config.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/net_config.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <sdbusplus/bus.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace chif
+{
+
+enum class AddrOrigin : uint8_t
+{
+    stat = 0,
+    dhcp = 1,
+    slaac = 2,
+    linkLocal = 3,
+};
+
+struct Ipv6Entry
+{
+    std::array<uint8_t, 16> addr{};
+    uint8_t prefix = 0;
+    AddrOrigin origin = AddrOrigin::stat;
+};
+
+struct NetworkConfig
+{
+    bool present = false;
+
+    std::array<uint8_t, 6> mac{};
+    std::string hostName;
+    std::string domainName;
+
+    bool haveV4 = false;
+    bool v4Dhcp = false;
+    uint32_t v4addr = 0;
+    uint32_t v4mask = 0;
+    uint32_t v4gateway = 0;
+    std::vector<uint32_t> v4dns;
+
+    bool v6Dhcp = false;
+    bool v6AcceptRa = false;
+    bool haveV6Gateway = false;
+    std::array<uint8_t, 16> v6gateway{};
+    std::vector<Ipv6Entry> v6addrs;
+    std::vector<std::array<uint8_t, 16>> v6dns;
+};
+
+NetworkConfig queryNetworkConfig(sdbusplus::bus_t& bus,
+                                 std::string_view interface = "eth0");
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/net_packets.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/net_packets.hpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <cstdint>
+
+namespace chif
+{
+
+// Magic value for v3 config layout
+inline constexpr uint32_t netCfgMagic = 0x439cd202;
+inline constexpr uint32_t netCfgVersion = 3;
+inline constexpr uint32_t netSetIpv4Enabled = 0x80;
+inline constexpr uint32_t netSetIpv6Enabled = 0x100;
+inline constexpr uint32_t netStatIpAddr = 0x1;
+inline constexpr uint32_t netStatGateway = 0x2;
+inline constexpr uint32_t netStatDns = 0x4;
+inline constexpr uint32_t netDhcpEnabled = 0x1;
+inline constexpr uint32_t netDhcpStatIpAddr = 0x1;
+
+struct IodRoute
+{
+    uint32_t dest;
+    uint32_t gate;
+    uint32_t mask;
+} __attribute__((packed));
+
+struct IodIntf
+{
+    uint32_t settings;
+    uint32_t status;
+    uint32_t dhcp_options;
+    uint32_t dhcp_status;
+    uint32_t ipaddr;
+    uint32_t ip_mask;
+    uint32_t gateway_ip;
+    uint32_t wins_ip[2];
+    uint32_t dns_ip[3];
+    uint32_t ntp_ip[2];
+    IodRoute route[3];
+    uint16_t vlan_id;
+    uint16_t QoS;
+    char host_name[63];
+    char domain_name[193];
+    uint8_t dhcp_params[64];
+    uint8_t dhcp_clientid_len;
+    uint8_t dhcp_clientid_value[16];
+    uint8_t reserved[75];
+    uint32_t kernel;
+} __attribute__((packed));
+
+static_assert(sizeof(IodIntf) == 512, "IodIntf must be 512 bytes");
+
+struct IodCfg
+{
+    uint32_t magic;
+    uint32_t version;
+    uint32_t checksum;
+    uint32_t sequence;
+    uint32_t settings;
+    uint8_t physel;
+    uint8_t sideband_sel;
+    uint8_t channel;
+    uint8_t package;
+    uint8_t hidden_port;
+    uint8_t reserved[999];
+    IodIntf iface[2];
+} __attribute__((packed));
+
+static_assert(sizeof(IodCfg) == 2048, "IodCfg must be 2048 bytes");
+
+struct Pkt8006
+{
+    uint32_t errorCode;
+    IodCfg cfg;
+} __attribute__((packed));
+
+struct Pkt8063
+{
+    uint32_t errorCode;
+    uint32_t nic_settings;
+    uint32_t nic_status;
+    uint32_t nic_ipaddr;
+    uint32_t nic_ip_mask;
+    uint8_t nic_mac_addr[6];
+    uint32_t nic_gateway_ip;
+    uint32_t nic_wins_ip[2];
+    uint32_t nic_dns_ip[3];
+    uint32_t dhcp_server_ip_address;
+    uint32_t dhcp_options;
+    uint32_t dhcp_status;
+    uint32_t front_nic_ipaddr;
+    uint32_t front_nic_ip_mask;
+    uint32_t front_settings;
+    struct
+    {
+        uint32_t dest;
+        uint32_t gate;
+    } route[3];
+    uint8_t nic_name[50];
+    uint8_t nic_domain_name[128];
+} __attribute__((packed));
+
+inline constexpr uint32_t nicSettingsDefault = 0x3;
+
+struct V6Addr
+{
+    uint8_t addr[16];
+    uint8_t prefix;
+    uint8_t source;
+    uint8_t state;
+    uint8_t reserved;
+} __attribute__((packed));
+
+static_assert(sizeof(V6Addr) == 20, "V6Addr must be 20 bytes");
+
+struct Pkt8120
+{
+    uint32_t errorCode;
+    uint32_t v6options;
+    uint32_t dhcpv6options;
+    V6Addr address[12];
+    uint32_t reserved1[5];
+    V6Addr dns[3];
+    V6Addr gateway;
+    V6Addr dest1;
+    V6Addr gate1;
+    V6Addr dest2;
+    V6Addr gate2;
+    V6Addr dest3;
+    V6Addr gate3;
+    uint8_t post_disp_cfg;
+    uint8_t reserved2[31];
+} __attribute__((packed));
+
+static_assert(sizeof(Pkt8120) == 504, "Pkt8120 must be 504 bytes");
+
+// v6options bits (HPE: "1 IPv6 enabled, 2 IPv4 enabled")
+inline constexpr uint32_t v6OptIpv6Enabled = 0x1;
+inline constexpr uint32_t v6OptIpv4Enabled = 0x2;
+
+inline constexpr uint32_t dhcpv6Stateful = 0x1;
+inline constexpr uint32_t dhcpv6Stateless = 0x2;
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/packet.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/packet.hpp
@@ -118,6 +118,12 @@ class Channel
     virtual ~Channel() = default;
     virtual ssize_t read(std::span<uint8_t> buf) = 0;
     virtual ssize_t write(std::span<const uint8_t> buf) = 0;
+
+    // fd to poll for readability, or -1 if not pollable (e.g. the test mock).
+    virtual int pollFd() const
+    {
+        return -1;
+    }
 };
 
 // Service handler interface — one per service_id.

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/packet.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/packet.hpp
@@ -93,6 +93,23 @@ inline std::span<uint8_t> responsePayload(std::span<uint8_t> resp)
     return resp.subspan(sizeof(ChifPktHeader));
 }
 
+// Serialize a single packed POD payload behind a response header. Returns the
+// total response size, or -1 if the caller's buffer is too small.
+template <typename T>
+int emitResponse(const ChifPktHeader& reqHdr, std::span<uint8_t> resp,
+                 const T& payload)
+{
+    constexpr auto respSize =
+        static_cast<uint16_t>(sizeof(ChifPktHeader) + sizeof(T));
+    if (resp.size() < respSize)
+    {
+        return -1;
+    }
+    initResponse(resp, reqHdr, respSize);
+    std::memcpy(responsePayload(resp).data(), &payload, sizeof(T));
+    return respSize;
+}
+
 // Abstract channel for reading/writing CHIF packets.
 // DeviceChannel wraps /dev/chif24; MockChannel is for testing.
 class Channel

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_network.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_network.cpp
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "net_config.hpp"
+#include "net_packets.hpp"
+#include "smif_service.hpp"
+
+#include <algorithm>
+#include <bit>
+#include <iterator>
+#include <string>
+
+namespace chif
+{
+
+namespace
+{
+
+NetworkConfig query(sdbusplus::bus_t* bus, const std::string& iface)
+{
+    return bus ? queryNetworkConfig(*bus, iface) : NetworkConfig{};
+}
+
+} // namespace
+
+int SmifService::handleIPv4Config(const ChifPktHeader& hdr,
+                                  std::span<uint8_t> response)
+{
+    const NetworkConfig net = query(bus_, netInterface_);
+
+    Pkt8006 msg{};
+    IodCfg& cfg = msg.cfg;
+    cfg.magic = netCfgMagic;
+    cfg.version = netCfgVersion;
+
+    IodIntf& intf = cfg.iface[0];
+    intf.settings = netSetIpv4Enabled;
+    if (!net.v6addrs.empty() || net.v6AcceptRa || net.v6Dhcp)
+    {
+        intf.settings |= netSetIpv6Enabled;
+    }
+
+    if (net.haveV4)
+    {
+        intf.ipaddr = std::byteswap(net.v4addr);
+        intf.ip_mask = std::byteswap(net.v4mask);
+        intf.gateway_ip = std::byteswap(net.v4gateway);
+        intf.status = netStatIpAddr | netStatGateway;
+
+        for (size_t i = 0; i < net.v4dns.size() && i < std::size(intf.dns_ip);
+             ++i)
+        {
+            intf.dns_ip[i] = std::byteswap(net.v4dns[i]);
+        }
+        if (!net.v4dns.empty())
+        {
+            intf.status |= netStatDns;
+        }
+
+        if (net.v4Dhcp)
+        {
+            intf.dhcp_options = netDhcpEnabled;
+            intf.dhcp_status = netDhcpStatIpAddr;
+        }
+    }
+
+    // std::string::copy truncates to the field size.
+    net.hostName.copy(intf.host_name, sizeof(intf.host_name) - 1);
+    net.domainName.copy(intf.domain_name, sizeof(intf.domain_name) - 1);
+
+    return emitResponse(hdr, response, msg);
+}
+
+int SmifService::handleNicConfig(const ChifPktHeader& hdr,
+                                 std::span<uint8_t> response)
+{
+    const NetworkConfig net = query(bus_, netInterface_);
+
+    Pkt8063 msg{};
+    msg.nic_settings = nicSettingsDefault;
+
+    std::ranges::copy(net.mac, msg.nic_mac_addr);
+
+    if (net.haveV4)
+    {
+        msg.nic_ipaddr = std::byteswap(net.v4addr);
+        msg.nic_ip_mask = std::byteswap(net.v4mask);
+        msg.nic_gateway_ip = std::byteswap(net.v4gateway);
+        msg.nic_status = netStatIpAddr | netStatGateway;
+
+        for (size_t i = 0;
+             i < net.v4dns.size() && i < std::size(msg.nic_dns_ip); ++i)
+        {
+            msg.nic_dns_ip[i] = std::byteswap(net.v4dns[i]);
+        }
+
+        if (net.v4Dhcp)
+        {
+            msg.dhcp_options = netDhcpEnabled;
+            msg.dhcp_status = netDhcpStatIpAddr;
+        }
+    }
+
+    net.hostName.copy(reinterpret_cast<char*>(msg.nic_name),
+                      sizeof(msg.nic_name) - 1);
+    net.domainName.copy(reinterpret_cast<char*>(msg.nic_domain_name),
+                        sizeof(msg.nic_domain_name) - 1);
+
+    return emitResponse(hdr, response, msg);
+}
+
+int SmifService::handleIPv6Config(const ChifPktHeader& hdr,
+                                  std::span<uint8_t> response)
+{
+    const NetworkConfig net = query(bus_, netInterface_);
+
+    Pkt8120 msg{};
+
+    if (net.haveV4)
+    {
+        msg.v6options |= v6OptIpv4Enabled;
+    }
+    if (!net.v6addrs.empty() || net.v6AcceptRa || net.v6Dhcp)
+    {
+        msg.v6options |= v6OptIpv6Enabled;
+    }
+    if (net.v6Dhcp)
+    {
+        msg.dhcpv6options |= dhcpv6Stateful;
+    }
+    if (net.v6AcceptRa)
+    {
+        msg.dhcpv6options |= dhcpv6Stateless;
+    }
+
+    for (size_t i = 0; i < net.v6addrs.size() && i < std::size(msg.address);
+         ++i)
+    {
+        const auto& e = net.v6addrs[i];
+        std::ranges::copy(e.addr, msg.address[i].addr);
+        msg.address[i].prefix = e.prefix;
+        msg.address[i].source = static_cast<uint8_t>(e.origin);
+    }
+
+    for (size_t i = 0; i < net.v6dns.size() && i < std::size(msg.dns); ++i)
+    {
+        std::ranges::copy(net.v6dns[i], msg.dns[i].addr);
+    }
+
+    if (net.haveV6Gateway)
+    {
+        std::ranges::copy(net.v6gateway, msg.gateway.addr);
+    }
+
+    return emitResponse(hdr, response, msg);
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -11,10 +11,12 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstring>
 #include <format>
 #include <fstream>
+#include <span>
 #include <string_view>
 
 namespace chif
@@ -101,10 +103,18 @@ int SmifService::buildEvDataResponse(const ChifPktHeader& hdr,
                                      const EvEntry& ev)
 {
     // Layout: [header 8][errorCode 4][name 32][dataLen 2][data N]
-    // HPE pads zero-length EVs to 4 bytes on readback
-    size_t dataSize = ev.data.empty() ? 4 : ev.data.size();
+
+    // The ROM expects a fixed 4-byte descriptor for CQHMEM.
+    static constexpr std::array<uint8_t, 4> cqhmemData = {0x40, 0x60, 0x54,
+                                                          0x00};
+    std::span<const uint8_t> data = ev.data;
+    if (ev.name.starts_with("CQHMEM"))
+    {
+        data = cqhmemData;
+    }
+
     size_t payloadSize = sizeof(uint32_t) + maxEvNameLen + sizeof(uint16_t) +
-                         dataSize;
+                         data.size();
     auto respSize =
         static_cast<uint16_t>(sizeof(ChifPktHeader) + payloadSize);
 
@@ -117,23 +127,19 @@ int SmifService::buildEvDataResponse(const ChifPktHeader& hdr,
     initResponse(response, hdr, respSize);
 
     auto resp = responsePayload(response);
-    // errorCode = 0 (already zeroed)
 
-    // Name at offset 4 (response already zeroed, so null-padding is implicit)
     size_t nameLen = std::min(ev.name.size(), maxEvNameLen - 1);
     std::memcpy(resp.data() + sizeof(uint32_t), ev.name.c_str(), nameLen);
 
-    // dataLen at offset 36 (use padded size for zero-length EVs)
-    auto dataLen = static_cast<uint16_t>(dataSize);
+    auto dataLen = static_cast<uint16_t>(data.size());
     std::memcpy(resp.data() + sizeof(uint32_t) + maxEvNameLen, &dataLen,
                 sizeof(dataLen));
 
-    // data at offset 38 (zero-length EVs get 4 zero bytes from fill_n)
-    if (!ev.data.empty())
+    if (!data.empty())
     {
         std::memcpy(
             resp.data() + sizeof(uint32_t) + maxEvNameLen + sizeof(uint16_t),
-            ev.data.data(), ev.data.size());
+            data.data(), data.size());
     }
 
     return respSize;
@@ -163,8 +169,11 @@ int SmifService::handleGetEvByIndex(const ChifPktHeader& hdr,
     auto entry = evStorage_->getByIndex(index);
     if (!entry)
     {
+        lg2::debug("smif EV: get index {IDX} -> no such EV", "IDX", index);
         return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
     }
+    lg2::debug("smif EV: get index {IDX} -> {NAME} ({BYTES} bytes)", "IDX",
+               index, "NAME", entry->name, "BYTES", entry->data.size());
     return buildEvDataResponse(hdr, response, *entry);
 }
 
@@ -178,10 +187,12 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
     }
 
     uint8_t flags = reqPayload[0];
+    lg2::debug("smif EV: set/delete flags={FLAGS}", "FLAGS", flags);
 
     if (flags & evFlagDeleteAll)
     {
         bool ok = evStorage_->deleteAll();
+        lg2::debug("smif EV: delete-all -> {OK}", "OK", ok);
         return buildSimpleResponse(
             hdr, response, ok ? ev(EvError::success) : ev(EvError::nameTooLong));
     }
@@ -201,6 +212,8 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
             return buildSimpleResponse(hdr, response, ev(EvError::nameTooLong));
         }
         bool ok = evStorage_->del(std::string(nameRegion.data()));
+        lg2::debug("smif EV: delete {NAME} -> {OK}", "NAME", nameRegion.data(),
+                   "OK", ok);
         return buildSimpleResponse(
             hdr, response, ok ? ev(EvError::success) : ev(EvError::deviceError));
     }
@@ -231,6 +244,7 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
         // Set with sz_ev=0 is treated as delete
         if (dataLen == 0)
         {
+            lg2::debug("smif EV: set {NAME} size 0 -> delete", "NAME", nameBuf);
             evStorage_->del(nameBuf);
             return buildSimpleResponse(hdr, response, ev(EvError::success));
         }
@@ -242,6 +256,8 @@ int SmifService::handleSetDeleteEv(const ChifPktHeader& hdr,
 
         auto data = reqPayload.subspan(minSetPayload, dataLen);
         bool ok = evStorage_->set(nameBuf, data);
+        lg2::debug("smif EV: set {NAME} ({BYTES} bytes) -> {OK}", "NAME",
+                   nameBuf, "BYTES", dataLen, "OK", ok);
         return buildSimpleResponse(
             hdr, response, ok ? ev(EvError::success) : ev(EvError::nameTooLong));
     }
@@ -272,43 +288,38 @@ int SmifService::handleGetEvByName(const ChifPktHeader& hdr,
     auto entry = evStorage_->getByName(nameBuf);
     if (!entry)
     {
+        lg2::debug("smif EV: get name {NAME} -> no such EV", "NAME", nameBuf);
         return buildSimpleResponse(hdr, response, ev(EvError::noSuchEv));
     }
+    lg2::debug("smif EV: get name {NAME} -> {BYTES} bytes", "NAME", nameBuf,
+               "BYTES", entry->data.size());
     return buildEvDataResponse(hdr, response, *entry);
 }
 
 int SmifService::handleEvStats(const ChifPktHeader& hdr,
                                std::span<uint8_t> response)
 {
-    // HPE layout: [errorCode u32][rem_sz u32][present_evs u16][max_sz u16]
-    constexpr size_t payloadSize =
-        sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint16_t) +
-        sizeof(uint16_t); // 12 bytes
-    constexpr auto respSize =
-        static_cast<uint16_t>(sizeof(ChifPktHeader) + payloadSize);
-
-    if (response.size() < respSize)
+    struct EvStats
     {
-        return -1;
-    }
+        uint32_t errorCode;
+        uint32_t remSize; // remaining space in the EV file in bytes
+        uint32_t presentEvs; // number of EVs stored
+        uint32_t maxSizeKb; // max EV file size in KiB
+    } __attribute__((packed));
 
-    std::fill_n(response.data(), respSize, uint8_t{0});
-    initResponse(response, hdr, respSize);
+    uint32_t remSize =
+        evStorage_ ? static_cast<uint32_t>(evStorage_->remainingSize()) : 0;
+    uint32_t presentEvs = evStorage_ ? evStorage_->count() : 0;
+    auto maxSizeKb = static_cast<uint32_t>(EvStorage::maxSize() / 1024);
 
-    auto resp = responsePayload(response);
-    // errorCode = 0 (already zeroed)
+    lg2::debug("smif EV: stats present={CNT} rem={REM}B max={MAX}KiB", "CNT",
+               presentEvs, "REM", remSize, "MAX", maxSizeKb);
 
-    uint32_t remaining = evStorage_ ? static_cast<uint32_t>(
-                                          evStorage_->remainingSize())
-                                    : 0;
-    auto cnt = static_cast<uint16_t>(evStorage_ ? evStorage_->count() : 0);
-    auto maxSzKb = static_cast<uint16_t>(EvStorage::maxSize() / 1024);
-
-    std::memcpy(resp.data() + 4, &remaining, sizeof(remaining));
-    std::memcpy(resp.data() + 8, &cnt, sizeof(cnt));
-    std::memcpy(resp.data() + 10, &maxSzKb, sizeof(maxSzKb));
-
-    return respSize;
+    EvStats stats{};
+    stats.remSize = remSize;
+    stats.presentEvs = presentEvs;
+    stats.maxSizeKb = maxSizeKb;
+    return emitResponse(hdr, response, stats);
 }
 
 int SmifService::handleEvState(const ChifPktHeader& hdr,

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -64,9 +64,11 @@ std::string SmifService::deriveShortProductId(const std::string& model)
     return s;
 }
 
-SmifService::SmifService(EvStorage* evStorage,
-                         std::unordered_map<uint8_t, int> segmentBusMap) :
-    evStorage_(evStorage), segmentToBus_(std::move(segmentBusMap))
+SmifService::SmifService(sdbusplus::bus_t* bus, EvStorage* evStorage,
+                         std::unordered_map<uint8_t, int> segmentBusMap,
+                         std::string netInterface) :
+    bus_(bus), evStorage_(evStorage), segmentToBus_(std::move(segmentBusMap)),
+    netInterface_(std::move(netInterface))
 {
     boardSerial_ = readDtString("/proc/device-tree/serial-number");
     if (boardSerial_.empty())
@@ -758,6 +760,14 @@ int SmifService::handle(std::span<const uint8_t> request,
         // ---- Field access (serial number, product ID) ----
         case smifCmdFieldAccess:
             return handleFieldAccess(hdr, reqPayload, response);
+
+        // ---- Network configuration ----
+        case smifCmdIPv4Config:
+            return handleIPv4Config(hdr, response);
+        case smifCmdNicConfig:
+            return handleNicConfig(hdr, response);
+        case smifCmdIPv6Config:
+            return handleIPv6Config(hdr, response);
 
         default:
             return buildSimpleResponse(hdr, response, 0);

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -93,16 +93,7 @@ int SmifService::buildSimpleResponse(const ChifPktHeader& hdr,
                                      std::span<uint8_t> response,
                                      uint32_t errorCode)
 {
-    constexpr auto respSize =
-        static_cast<uint16_t>(sizeof(ChifPktHeader) + sizeof(uint32_t));
-    if (response.size() < respSize)
-    {
-        return -1;
-    }
-    initResponse(response, hdr, respSize);
-    auto resp = responsePayload(response);
-    std::memcpy(resp.data(), &errorCode, sizeof(errorCode));
-    return respSize;
+    return emitResponse(hdr, response, errorCode);
 }
 
 int SmifService::buildEvDataResponse(const ChifPktHeader& hdr,

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -5,6 +5,8 @@
 #include "ev_storage.hpp"
 #include "packet.hpp"
 
+#include <sdbusplus/bus.hpp>
+
 #include <cstdint>
 #include <span>
 #include <string>
@@ -113,8 +115,10 @@ inline constexpr uint16_t smifCmdPlatDefV2End = 0x0207;
 class SmifService : public ServiceHandler
 {
   public:
-    explicit SmifService(EvStorage* evStorage = nullptr,
-                        std::unordered_map<uint8_t, int> segmentBusMap = {});
+    explicit SmifService(sdbusplus::bus_t* bus = nullptr,
+                         EvStorage* evStorage = nullptr,
+                         std::unordered_map<uint8_t, int> segmentBusMap = {},
+                         std::string netInterface = "eth0");
 
     int handle(std::span<const uint8_t> request,
                std::span<uint8_t> response) override;
@@ -158,6 +162,11 @@ class SmifService : public ServiceHandler
                           std::span<const uint8_t> reqPayload,
                           std::span<uint8_t> response);
 
+    // Network configuration handlers
+    int handleIPv4Config(const ChifPktHeader& hdr, std::span<uint8_t> response);
+    int handleNicConfig(const ChifPktHeader& hdr, std::span<uint8_t> response);
+    int handleIPv6Config(const ChifPktHeader& hdr, std::span<uint8_t> response);
+
     static std::string readDtString(const char* path);
     // "HPE ProLiant DL365 Gen11" -> "DL365G11"
     static std::string deriveShortProductId(const std::string& model);
@@ -170,8 +179,10 @@ class SmifService : public ServiceHandler
                                    std::span<uint8_t> response,
                                    const EvEntry& ev);
 
+    sdbusplus::bus_t* bus_;
     EvStorage* evStorage_;
     std::unordered_map<uint8_t, int> segmentToBus_;
+    std::string netInterface_;
     std::string boardSerial_;
     std::string productId_;
 };

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -135,10 +135,8 @@ class SmifService : public ServiceHandler
     int handleGetEvByName(const ChifPktHeader& hdr,
                           std::span<const uint8_t> reqPayload,
                           std::span<uint8_t> response);
-    int handleEvStats(const ChifPktHeader& hdr,
-                      std::span<uint8_t> response);
-    int handleEvState(const ChifPktHeader& hdr,
-                      std::span<uint8_t> response);
+    int handleEvStats(const ChifPktHeader& hdr, std::span<uint8_t> response);
+    int handleEvState(const ChifPktHeader& hdr, std::span<uint8_t> response);
     int handleGetEvAuthStatus(const ChifPktHeader& hdr,
                               std::span<uint8_t> response);
 

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#include "utils.hpp"
+
+#include <arpa/inet.h>
+
+#include <algorithm>
+#include <charconv>
+
+namespace chif
+{
+
+std::optional<uint32_t> parseV4(const std::string& s)
+{
+    uint32_t out = 0;
+    if (!s.empty() && inet_pton(AF_INET, s.c_str(), &out) == 1)
+    {
+        return out;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::array<uint8_t, 16>> parseV6(const std::string& s)
+{
+    std::array<uint8_t, 16> out{};
+    if (!s.empty() && inet_pton(AF_INET6, s.c_str(), out.data()) == 1)
+    {
+        return out;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::array<uint8_t, 6>> parseMac(std::string_view s)
+{
+    std::array<uint8_t, 6> out{};
+    for (uint8_t& byte : out)
+    {
+        if (s.size() < 2)
+        {
+            return std::nullopt;
+        }
+        auto [ptr, ec] = std::from_chars(s.data(), s.data() + 2, byte, 16);
+        if (ec != std::errc{} || ptr != s.data() + 2)
+        {
+            return std::nullopt;
+        }
+        s.remove_prefix(2);
+
+        // Every octet but the last is followed by a ':' separator.
+        if (!s.empty() && s.front() == ':')
+        {
+            s.remove_prefix(1);
+        }
+    }
+    return s.empty() ? std::optional{out} : std::nullopt;
+}
+
+uint32_t prefixToMask4(uint8_t prefix)
+{
+    prefix = std::min<uint8_t>(prefix, 32);
+    return htonl(static_cast<uint32_t>(~uint64_t{0} << (32 - prefix)));
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.hpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+#pragma once
+
+#include <sdbusplus/bus.hpp>
+
+#include <optional>
+#include <variant>
+
+namespace chif
+{
+
+inline constexpr auto propertiesInterface = "org.freedesktop.DBus.Properties";
+
+template <typename T>
+std::optional<T> getProperty(sdbusplus::bus_t& bus, const char* service,
+                             const char* path, const char* interface,
+                             const char* property)
+{
+    try
+    {
+        auto m = bus.new_method_call(service, path, propertiesInterface, "Get");
+        m.append(interface, property);
+        std::variant<T> value;
+        bus.call(m).read(value);
+        return std::get<T>(value);
+    }
+    catch (const std::exception&)
+    {
+        return std::nullopt;
+    }
+}
+
+template <typename T>
+bool setProperty(sdbusplus::bus_t& bus, const char* service, const char* path,
+                 const char* interface, const char* property, const T& value)
+{
+    try
+    {
+        auto m = bus.new_method_call(service, path, propertiesInterface, "Set");
+        m.append(interface, property, std::variant<T>(value));
+        bus.call(m);
+        return true;
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+}
+
+} // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.hpp
@@ -4,7 +4,11 @@
 
 #include <sdbusplus/bus.hpp>
 
+#include <array>
+#include <cstdint>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <variant>
 
 namespace chif
@@ -47,5 +51,10 @@ bool setProperty(sdbusplus::bus_t& bus, const char* service, const char* path,
         return false;
     }
 }
+
+std::optional<uint32_t> parseV4(const std::string& s);
+std::optional<std::array<uint8_t, 16>> parseV6(const std::string& s);
+std::optional<std::array<uint8_t, 6>> parseMac(std::string_view s);
+uint32_t prefixToMask4(uint8_t prefix);
 
 } // namespace chif

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_bios_config_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_bios_config_service.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+#include "../src/bios_config_service.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace chif;
+
+namespace
+{
+
+void appendLe16(std::vector<uint8_t>& out, uint16_t value)
+{
+    out.push_back(static_cast<uint8_t>(value & 0xff));
+    out.push_back(static_cast<uint8_t>((value >> 8) & 0xff));
+}
+
+// Build a CQSBOOT#### EV payload (evBoot) whose UEFI variable holds `name`
+// as a NUL-terminated UTF-16LE string, with `structuredBootStrLen` bytes of
+// filler in the structured-boot-string region.
+std::vector<uint8_t> makeEvBoot(const std::string& name,
+                                uint16_t structuredBootStrLen = 4)
+{
+    std::vector<uint8_t> data;
+    appendLe16(data, 1);                                 // version
+    appendLe16(data, 0);                                 // bootOptionIdLen
+    data.insert(data.end(), 10, 0);                      // bootOptionData[10]
+    appendLe16(data, structuredBootStrLen);              // structuredBootStrLen
+    data.insert(data.end(), structuredBootStrLen, 0xAB); // structuredBootStr
+    data.insert(data.end(), 6, 0);                       // 6 reserved bytes
+    appendLe16(data, static_cast<uint16_t>((name.size() + 1) * 2)); // uefi len
+    for (char c : name)
+    {
+        appendLe16(data, static_cast<uint16_t>(c));
+    }
+    appendLe16(data, 0); // UTF-16 NUL terminator
+    return data;
+}
+
+} // namespace
+
+TEST(BiosConfigParse, ExtractsUtf16DisplayName)
+{
+    auto data = makeEvBoot("UEFI Shell");
+    auto name = BiosConfigService::parseBootOptionName(data);
+    ASSERT_TRUE(name.has_value());
+    EXPECT_EQ(*name, "UEFI Shell");
+}
+
+TEST(BiosConfigParse, HandlesVaryingStructuredBootStrLen)
+{
+    auto data = makeEvBoot("Windows Boot Manager", 32);
+    auto name = BiosConfigService::parseBootOptionName(data);
+    ASSERT_TRUE(name.has_value());
+    EXPECT_EQ(*name, "Windows Boot Manager");
+}
+
+TEST(BiosConfigParse, RejectsTooShortPayload)
+{
+    std::vector<uint8_t> shortData(8, 0);
+    EXPECT_FALSE(BiosConfigService::parseBootOptionName(shortData).has_value());
+}
+
+TEST(BiosConfigParse, RejectsEmptyName)
+{
+    auto data = makeEvBoot("");
+    EXPECT_FALSE(BiosConfigService::parseBootOptionName(data).has_value());
+}
+
+TEST(BiosConfigId, ReturnsSuffixForBootEv)
+{
+    auto id = BiosConfigService::bootOptionId("CQSBOOT0001");
+    ASSERT_TRUE(id.has_value());
+    EXPECT_EQ(*id, "01");
+}
+
+TEST(BiosConfigId, RejectsNonBootEv)
+{
+    EXPECT_FALSE(BiosConfigService::bootOptionId("CQHBOOTORDER").has_value());
+    EXPECT_FALSE(BiosConfigService::bootOptionId("CQSBOOT").has_value());
+    EXPECT_FALSE(BiosConfigService::bootOptionId("SOMETHING").has_value());
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_boot_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/test/test_boot_service.cpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 9elements GmbH
+
+#include "../src/boot_service.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace chif;
+using Sources = BootService::Sources;
+using Modes = BootService::Modes;
+
+TEST(BootServiceOptionNumber, ParsesHexSuffix)
+{
+    EXPECT_EQ(BootService::optionNumber("CQSBOOT0000"),
+              std::optional<uint16_t>(0x0000));
+    EXPECT_EQ(BootService::optionNumber("CQSBOOT0012"),
+              std::optional<uint16_t>(0x0012));
+    EXPECT_EQ(BootService::optionNumber("CQSBOOT000F"),
+              std::optional<uint16_t>(0x000F));
+    EXPECT_EQ(BootService::optionNumber("CQSBOOT00a3"),
+              std::optional<uint16_t>(0x00A3));
+}
+
+TEST(BootServiceOptionNumber, RejectsNonOptionNames)
+{
+    EXPECT_FALSE(BootService::optionNumber("CQHBOOTORDER").has_value());
+    EXPECT_FALSE(BootService::optionNumber("CQTBOOTNEXT").has_value());
+    EXPECT_FALSE(BootService::optionNumber("CQSBOOT01").has_value()); // short
+    EXPECT_FALSE(
+        BootService::optionNumber("CQSBOOT000G").has_value());        // non-hex
+    EXPECT_FALSE(BootService::optionNumber("CQSBOOT00012").has_value()); // long
+}
+
+TEST(BootServiceKeywords, SetupModeWins)
+{
+    auto kw = BootService::targetKeywords(Sources::Network, Modes::Setup);
+    ASSERT_FALSE(kw.empty());
+    EXPECT_EQ(kw.front(), "System Utilities");
+}
+
+TEST(BootServiceKeywords, DefaultSourceYieldsNoOverride)
+{
+    EXPECT_TRUE(
+        BootService::targetKeywords(Sources::Default, Modes::Regular).empty());
+}
+
+TEST(BootServiceMatch, PrefersHigherPriorityKeyword)
+{
+    std::vector<std::pair<uint16_t, std::string>> options = {
+        {0x0009, "PXE Boot"},
+        {0x0006, "Network Boot"},
+        {0x0011, "OCP Slot 15 Port 1 : Broadcom NetXtreme (PXE IPv4)"},
+    };
+    auto kw = BootService::targetKeywords(Sources::Network, Modes::Regular);
+    EXPECT_EQ(BootService::matchOption(options, kw),
+              std::optional<uint16_t>(0x0006));
+}
+
+TEST(BootServiceMatch, ReturnsNulloptWhenNothingMatches)
+{
+    std::vector<std::pair<uint16_t, std::string>> options = {
+        {0x0000, "System Utilities"},
+        {0x0006, "Network Boot"},
+    };
+    auto kw = BootService::targetKeywords(Sources::Disk, Modes::Regular);
+    EXPECT_FALSE(BootService::matchOption(options, kw).has_value());
+}
+
+TEST(BootServiceReorder, MovesExistingOptionToFront)
+{
+    // Order [00,01,02,05,06] with option 06 requested.
+    std::vector<uint8_t> current = {0x00, 0x00, 0x01, 0x00, 0x02,
+                                    0x00, 0x05, 0x00, 0x06, 0x00};
+    auto out = BootService::reorderBootOrder(current, 0x0006);
+    EXPECT_EQ(out, (std::vector<uint8_t>{0x06, 0x00, 0x00, 0x00, 0x01, 0x00,
+                                         0x02, 0x00, 0x05, 0x00}));
+}
+
+TEST(BootServiceReorder, InsertsUnknownOptionAtFront)
+{
+    std::vector<uint8_t> current = {0x00, 0x00, 0x01, 0x00};
+    auto out = BootService::reorderBootOrder(current, 0x0007);
+    EXPECT_EQ(out, (std::vector<uint8_t>{0x07, 0x00, 0x00, 0x00, 0x01, 0x00}));
+}
+
+TEST(BootServiceEncode, EncodesLittleEndianUint16)
+{
+    EXPECT_EQ(BootService::encodeOption(0x0006),
+              (std::vector<uint8_t>{0x06, 0x00}));
+    EXPECT_EQ(BootService::encodeOption(0x0112),
+              (std::vector<uint8_t>{0x12, 0x01}));
+}
+
+static std::vector<std::pair<uint16_t, std::string>> realOptions()
+{
+    return {
+        {0x0005, "Boot Menu"},
+        {0x0000, "System Utilities"},
+        {0x0001, "Embedded UEFI Shell"},
+        {0x0002, "Non-bootable Hotkey"},
+        {0x0003, "Embedded iPXE"},
+        {0x0004, "Diagnose Error"},
+        {0x0006, "Network Boot"},
+        {0x0007, "View BIOS Event Log"},
+        {0x0008, "HTTP Boot"},
+        {0x0009, "PXE Boot"},
+        {0x000A, "Embedded Diagnostics"},
+        {0x000B, "Generic USB Boot"},
+        {0x000C, "Rear USB 1 : PiKVM PiKVM Composite Device"},
+        {0x000D, "OCP Slot 14 : HPE MR408i-o Gen11 - Box 1, Bay 1"},
+        {0x000E, "OCP Slot 14 : HPE MR408i-o Gen11 - Box 1, Bay 2"},
+        {0x0011, "OCP Slot 15 Port 1 : Broadcom NetXtreme Gigabit Ethernet - "
+                 "NIC (HTTP(S) IPv4)"},
+        {0x0012, "OCP Slot 15 Port 1 : Broadcom NetXtreme Gigabit Ethernet - "
+                 "NIC (PXE IPv4)"},
+        {0x000F, "OCP Slot 15 Port 1 : Broadcom NetXtreme Gigabit Ethernet - "
+                 "NIC (PXE IPv6)"},
+        {0x0010, "OCP Slot 15 Port 1 : Broadcom NetXtreme Gigabit Ethernet - "
+                 "NIC (HTTP(S) IPv6)"},
+    };
+}
+
+static std::optional<uint16_t> resolve(Sources source, Modes mode)
+{
+    return BootService::matchOption(realOptions(),
+                                    BootService::targetKeywords(source, mode));
+}
+
+TEST(BootServiceRealDump, ResolvesCommonTargets)
+{
+    // Generic entries win over the per-NIC PXE/HTTP options thanks to keyword
+    // priority ("Network Boot"/"HTTP Boot" before "PXE"/"HTTP").
+    EXPECT_EQ(resolve(Sources::Network, Modes::Regular),
+              std::optional<uint16_t>(0x0006));
+    EXPECT_EQ(resolve(Sources::HTTP, Modes::Regular),
+              std::optional<uint16_t>(0x0008));
+    // "Generic USB Boot" precedes "Rear USB ..." in storage order.
+    EXPECT_EQ(resolve(Sources::RemovableMedia, Modes::Regular),
+              std::optional<uint16_t>(0x000B));
+    // "Bay" distinguishes the storage controller from the NIC "Slot" entries.
+    EXPECT_EQ(resolve(Sources::Disk, Modes::Regular),
+              std::optional<uint16_t>(0x000D));
+    // Setup is requested via Boot.Mode regardless of source.
+    EXPECT_EQ(resolve(Sources::Default, Modes::Setup),
+              std::optional<uint16_t>(0x0000));
+}
+
+TEST(BootServiceRealDump, ExternalMediaIsDeviceSpecificAndUnresolved)
+{
+    EXPECT_FALSE(resolve(Sources::ExternalMedia, Modes::Regular).has_value());
+}
+
+TEST(BootServiceRealDump, DefaultIsNoOverride)
+{
+    EXPECT_FALSE(resolve(Sources::Default, Modes::Regular).has_value());
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service_1.0.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service_1.0.bb
@@ -26,10 +26,18 @@ DEPENDS += " \
     sdbusplus \
     phosphor-dbus-interfaces \
     phosphor-logging \
+    ${@bb.utils.contains('PTEST_ENABLED', '1', 'gtest', '', d)} \
     "
 
 RDEPENDS:${PN} += "smbios-mdr"
 
 FILES:${PN} += "${nonarch_base_libdir}/udev/rules.d"
 
-EXTRA_OEMESON = "-Dtests=disabled"
+EXTRA_OEMESON = " \
+    -Dtests=${@bb.utils.contains('PTEST_ENABLED', '1', 'enabled', 'disabled', d)} \
+"
+
+do_install_ptest() {
+        install -d ${D}${PTEST_PATH}/test
+        cp -rf ${B}/test/*_test ${D}${PTEST_PATH}/test/
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
@@ -39,8 +39,9 @@ RDEPENDS:${PN}-flash = " \
 
 SUMMARY:${PN}-system = "HPE System"
 RDEPENDS:${PN}-system = " \
-        entity-manager \
+        biosconfig-manager \
         dbus-sensors \
+        entity-manager \
         fru-synthesizer \
         gxp-chif-service \
         smbios-mdr \

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-hpe_git.bb
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-hpe_git.bb
@@ -116,4 +116,5 @@ SRC_URI:append = " \
     file://0085-mtd-spi-nor-macronix-allow-mx66l51235f-without-SFDP.patch \
     file://0086-misc-ubm-add-minimal-UBM-backplane-init-driver.patch \
     file://0087-ARM-dts-hpe-gxp-enable-ramoops.patch \
+    file://0088-soc-hpe-gxp-chif-expose-poll-on-char-device.patch \
     "

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable-6.18/0088-soc-hpe-gxp-chif-expose-poll-on-char-device.patch
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable-6.18/0088-soc-hpe-gxp-chif-expose-poll-on-char-device.patch
@@ -1,0 +1,74 @@
+From 791794f2a838c8c719cf5d2c5ef6fbeb12e513b3 Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Tue, 7 Jul 2026 11:02:50 +0200
+Subject: [PATCH] soc: hpe: gxp-chif: expose poll on char device
+
+Allow user-space applications to poll the CHIF char device.
+
+Also fix the IRQ handler to not block pollers when drvdata->waiting[i]
+isn't set. That flag is only set by the blocking read() path, so gating
+the wakeup on it meant a process waiting via poll()/select()/epoll() was
+registered on the wait queue by poll_wait() but never woken, and would
+block indefinitely even though packets had arrived.
+
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ drivers/soc/hpe/gxp-chif.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/soc/hpe/gxp-chif.c b/drivers/soc/hpe/gxp-chif.c
+index 640eae54142d..db67bd8951ea 100644
+--- a/drivers/soc/hpe/gxp-chif.c
++++ b/drivers/soc/hpe/gxp-chif.c
+@@ -18,6 +18,7 @@
+ #include <linux/mod_devicetable.h>
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
++#include <linux/poll.h>
+ #include <linux/regmap.h>
+ #include <linux/sched/signal.h>
+ #include <linux/uaccess.h>
+@@ -241,6 +242,22 @@ static int chif_open(struct inode *inode, struct file *file)
+ 	return 0;
+ }
+ 
++static __poll_t chif_poll(struct file *file, struct poll_table_struct *wait)
++{
++	struct chif_drvdata *drvdata = file->private_data;
++	unsigned int channel = iminor(file_inode(file));
++	__poll_t mask = EPOLLOUT | EPOLLWRNORM; /* chif is always writable */
++
++	if (channel != CHANNEL_SHAREMEM)
++		return EPOLLERR;
++
++	poll_wait(file, &drvdata->wait[channel], wait);
++	if (drvdata->chif24_queue.size > 0)
++		mask |= EPOLLIN | EPOLLRDNORM;
++
++	return mask;
++}
++
+ static ssize_t chif_read(struct file *file, char __user *buf, size_t count,
+ 			 loff_t *f_pos)
+ {
+@@ -399,6 +416,7 @@ static const struct file_operations chif_fops = {
+ 	.read = chif_read,
+ 	.write = chif_write,
+ 	.release = chif_release,
++	.poll = chif_poll,
+ };
+ 
+ static int compare_seq(u32 a, u32 b)
+@@ -510,8 +528,7 @@ static irqreturn_t chif_irq_handle(int irq, void *_drvdata)
+ 			if (active_ccb(drvdata, i) < 0)
+ 				continue;
+ 
+-			if (consume_packet(drvdata, i) > 0 &&
+-			    drvdata->waiting[i])
++			if (consume_packet(drvdata, i) > 0)
+ 				wake_up_interruptible(&drvdata->wait[i]);
+ 		}
+ 	}
+-- 
+2.54.0
+


### PR DESCRIPTION
Planned as a small cleanup, then I found something interesting in the reference code and now I ended up here :smile_cat: 

I really recommend reviewing this commit by commit and not all at once. Otherwise it can become very overwhelming.

This PR consists of multiple commits, but in summary they address:
- Adding poll support on the CHIF char dev
- Fixing a bug that reported wrong EV stat data, causing the BIOS to overwrite the EVs (or only partially write EVs)
- Cleaning up some inconsistencies (using PDI-generated bindings and de-duplicating code via templates)
- Adding BIOS (next) boot order support (next boot works via the UI too; the persistent one works in theory as well, but should preferably be set via Redfish only)
- Adding network config support via the BIOS

Notes:
- IPv6 has basic support, but it's not guaranteed to work.
- BIOS config is very limited (boot options only) for now, due to missing NVRAM access. This should be addressed separately.

Partially addresses #88 