### PR TITLE
firmwareci: bios-config: merge stages with on-error continue set

### DIFF
--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
@@ -134,9 +134,6 @@ stages:
           expect:
             - regex: "^[1-9][0-9]*$"
 
-  - name: BIOSConfig Attributes Published
-    on-error: continue
-    steps:
       - cmd: shell
         name: BiosConfigService published boot options (journal)
         transport: *bmc_ssh

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
@@ -118,7 +118,7 @@ stages:
           executable: sleep
           args: ["30"]
 
-  - name: Boot EVs Present
+  - name: Boot EVs and override test
     on-error: continue
     steps:
       - cmd: shell
@@ -136,9 +136,6 @@ stages:
           expect:
             - regex: "^[1-9][0-9]*$"
 
-  - name: Set One-Time BIOS Setup Override via Redfish
-    on-error: continue
-    steps:
       - cmd: shell
         name: PATCH BootSourceOverride BiosSetup/Once
         transport: *local
@@ -177,9 +174,6 @@ stages:
             - regex: '"BootSourceOverrideTarget": *"BiosSetup"'
             - regex: '"BootSourceOverrideEnabled": *"Once"'
 
-  - name: Reboot Host to test override
-    on-error: continue
-    steps:
       - cmd: shell
         name: Clear stale SMBIOS marker
         transport: *bmc_ssh
@@ -227,9 +221,6 @@ stages:
           executable: hexdump
           args: ["-C", "/var/lib/chif/evs.dat"]
 
-  - name: Verify that the override got consumed
-    on-error: continue
-    steps:
       - cmd: shell
         name: Host consumed one-time boot (journal)
         transport: *bmc_ssh
@@ -263,9 +254,6 @@ stages:
           expect:
             - regex: '"BootSourceOverrideEnabled": *"Continuous"'
 
-  - name: Console check
-    on-error: continue
-    steps:
       - cmd: shell
         name: "Console shows System Utilities / BIOS setup entry"
         transport: *bmc_ssh


### PR DESCRIPTION
FWCI still fails and will not continue to other stages if one fails.

Cite from the FWCI folks to that:
```
"continue" will just work for the same stage of the cmd, but not
across. So if a stage fails the other stages except Cleanup will
always fail

So if you were to merge both stages it would work. There is currently
no mechanism to execute multiple stages even if one fails
```

Fixes: b1939f66 ("firmwareci: add tests for boot order and bios network ip")