### PR TITLE
HPE ProLiant Gen11: NVRAM/BIOS settings reset support

### DIFF
--- a/.firmwareci/storage/dl320g11_nvram/storage.yaml
+++ b/.firmwareci/storage/dl320g11_nvram/storage.yaml
@@ -1,0 +1,4 @@
+name: dl320g11_nvram
+paths:
+  rom: dl320g11_host_reserved_original.bin
+uri: fwci://dl320g11_nvram

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
@@ -18,13 +18,83 @@ defaults:
       user: "root"
       password: "[[attributes.BMCPassword]]"
 
+post-stage:
+  # Allowed to fail
+  - cmd: shell
+    name: Power off host via Redfish
+    transport:
+      proto: local
+    parameters:
+      command: >-
+        curl -sk -u root:[[attributes.BMCPassword]]
+        -X POST -H 'Content-Type: application/json'
+        -d '{"ResetType":"ForceOff"}'
+        -o /dev/null -w '%{http_code}'
+        https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset || true
+
+  - cmd: copy
+    name: Copy original NVRAM to DUT
+    transport: *bmc_ssh
+    parameters:
+      source: "[[storage.dl320g11_nvram]]"
+      destination: /tmp
+      recursive: true
+
+  - cmd: shell
+    name: Flash original NVRAM to DUT
+    transport: *bmc_ssh
+    parameters:
+      command: "flashcp /tmp/[[storage.dl320g11_nvram.rom]] /dev/mtd/host-reserved"
+
+  - cmd: dutctl
+    name: Power off DUT
+    parameters:
+      agent: "[[attributes.Agent]]"
+      device: "[[attributes.Device]]"
+      command: power
+      args: ["off"]
+
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Reset NVRAM before power on
     steps:
       - cmd: shell
-        name: Power on host via Redfish
+        name: Power off host via Redfish
         transport: &local
           proto: local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"ForceOff"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
+
+      - cmd: shell
+        name: Reset NVRAM
+        transport: *local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios
+          expect:
+            - regex: "^(200|204)$"
+
+      - cmd: cmd
+        name: Wait a bit for NVRAM reset to be completed
+        transport: *bmc_ssh
+        options:
+          timeout: 3m
+        parameters:
+          executable: sleep
+          args: ["20"]
+
+      - cmd: shell
+        name: Power on host via Redfish
+        transport: *local
         parameters:
           command: >-
             curl -sk -u root:[[attributes.BMCPassword]]
@@ -34,11 +104,12 @@ stages:
             https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
           expect:
             - regex: "^(200|204)$"
+
       - cmd: shell
         name: Wait for SMBIOS transfer (host POST complete)
         transport: *bmc_ssh
         options:
-          timeout: 15m
+          timeout: 20m # NVRAM reset can take ages
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||
@@ -47,15 +118,12 @@ stages:
             echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
           expect:
             - regex: "SMBIOS ready"
+
       # TODO: Fix static sleep, poll until OSStage or BootProgress work
       # This is somewhat of a workaround for now to get the system boot into
       # the OS at least once. Neither OSStage nor BootProgress work because the
       # post-complete line is not asserting, and the BootProgress interface is
       # not implemented by any software yet.
-      # Instead, we wait until a full boot happened, and reboot the system again
-      # to get the full EV vars.
-      # Why the EVs are not always being transmitted in the first run is not
-      # clear yet.
       - cmd: cmd
         name: Wait for the boot to be finished
         transport: *bmc_ssh
@@ -64,44 +132,6 @@ stages:
         parameters:
           executable: sleep
           args: ["90"]
-      - cmd: shell
-        name: Shutdown the system and turn it on again
-        transport: *bmc_ssh
-        options:
-          timeout: 5m
-        parameters:
-          command: >-
-            obmcutil poweroff &&
-            while [ "$(busctl get-property xyz.openbmc_project.Chassis.Buttons /xyz/openbmc_project/state/chassis0 xyz.openbmc_project.State.Chassis CurrentPowerState)" != 's "xyz.openbmc_project.State.Chassis.PowerState.Off"' ]; do sleep 1; done; echo "System powered off" &&
-            obmcutil poweron && echo "System powered on"
-          expect:
-            - regex: "System powered on"
-      - cmd: shell
-        name: Clear stale SMBIOS marker
-        transport: *bmc_ssh
-        parameters:
-          command: "rm -f /var/lib/smbios/smbios2"
-      - cmd: shell
-        name: Wait for second POST (SMBIOS transfer)
-        transport: *bmc_ssh
-        options:
-          timeout: 15m
-        parameters:
-          command: >-
-            while [ ! -f /var/lib/smbios/smbios2 ] ||
-                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
-            do sleep 1; done;
-            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
-          expect:
-            - regex: "SMBIOS ready"
-      - cmd: cmd
-        name: Wait for all EVs to be published
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["30"]
 
   - name: CHIF Service and EV Store
     on-error: continue

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
@@ -19,23 +19,80 @@ defaults:
       user: "root"
       password: "[[attributes.BMCPassword]]"
 
+post-stage:
+  # Allowed to fail
+  - cmd: shell
+    name: Power off host via Redfish
+    transport:
+      proto: local
+    parameters:
+      command: >-
+        curl -sk -u root:[[attributes.BMCPassword]]
+        -X POST -H 'Content-Type: application/json'
+        -d '{"ResetType":"ForceOff"}'
+        -o /dev/null -w '%{http_code}'
+        https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset || true
+
+  - cmd: copy
+    name: Copy original NVRAM to DUT
+    transport: *bmc_ssh
+    parameters:
+      source: "[[storage.dl320g11_nvram]]"
+      destination: /tmp
+      recursive: true
+
+  - cmd: shell
+    name: Flash original NVRAM to DUT
+    transport: *bmc_ssh
+    parameters:
+      command: "flashcp /tmp/[[storage.dl320g11_nvram.rom]] /dev/mtd/host-reserved"
+
+  - cmd: dutctl
+    name: Power off DUT
+    parameters:
+      agent: "[[attributes.Agent]]"
+      device: "[[attributes.Device]]"
+      command: power
+      args: ["off"]
+
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Reset NVRAM before power on
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
+      - cmd: shell
+        name: Power off host via Redfish
+        transport: &local
+          proto: local
         parameters:
-          host: "[[attributes.BMC]]"
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"ForceOff"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
+
+      - cmd: shell
+        name: Reset NVRAM
+        transport: *local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios
+          expect:
+            - regex: "^(200|204)$"
+
       - cmd: cmd
-        name: Wait for BMC services
+        name: Wait a bit for NVRAM reset to be completed
         transport: *bmc_ssh
         options:
-          timeout: 2m
+          timeout: 3m
         parameters:
           executable: sleep
-          args: ["45"]
+          args: ["20"]
+
       - cmd: shell
         name: Power on host via Redfish
         transport: &local
@@ -49,11 +106,12 @@ stages:
             https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
           expect:
             - regex: "^(200|204)$"
+
       - cmd: shell
-        name: Wait for first POST (SMBIOS transfer)
+        name: Wait for SMBIOS transfer (host POST complete)
         transport: *bmc_ssh
         options:
-          timeout: 15m
+          timeout: 20m # NVRAM reset can take ages
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||
@@ -62,15 +120,12 @@ stages:
             echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
           expect:
             - regex: "SMBIOS ready"
+
       # TODO: Fix static sleep, poll until OSStage or BootProgress work
       # This is somewhat of a workaround for now to get the system boot into
       # the OS at least once. Neither OSStage nor BootProgress work because the
       # post-complete line is not asserting, and the BootProgress interface is
       # not implemented by any software yet.
-      # Instead, we wait until a full boot happened, and reboot the system again
-      # to get the full EV vars.
-      # Why the EVs are not always being transmitted in the first run is not
-      # clear yet.
       - cmd: cmd
         name: Wait for the boot to be finished
         transport: *bmc_ssh
@@ -79,44 +134,6 @@ stages:
         parameters:
           executable: sleep
           args: ["90"]
-      - cmd: shell
-        name: Shutdown the system and turn it on again
-        transport: *bmc_ssh
-        options:
-          timeout: 5m
-        parameters:
-          command: >-
-            obmcutil poweroff &&
-            while [ "$(busctl get-property xyz.openbmc_project.Chassis.Buttons /xyz/openbmc_project/state/chassis0 xyz.openbmc_project.State.Chassis CurrentPowerState)" != 's "xyz.openbmc_project.State.Chassis.PowerState.Off"' ]; do sleep 1; done; echo "System powered off" &&
-            obmcutil poweron && echo "System powered on"
-          expect:
-            - regex: "System powered on"
-      - cmd: shell
-        name: Clear stale SMBIOS marker
-        transport: *bmc_ssh
-        parameters:
-          command: "rm -f /var/lib/smbios/smbios2"
-      - cmd: shell
-        name: Wait for second POST (SMBIOS transfer)
-        transport: *bmc_ssh
-        options:
-          timeout: 15m
-        parameters:
-          command: >-
-            while [ ! -f /var/lib/smbios/smbios2 ] ||
-                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
-            do sleep 1; done;
-            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
-          expect:
-            - regex: "SMBIOS ready"
-      - cmd: cmd
-        name: Wait for all EVs to be published
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["30"]
 
   - name: Boot EVs and override test
     on-error: continue

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/packagegroups/packagegroup-hpe-apps.bb
@@ -44,6 +44,7 @@ RDEPENDS:${PN}-system = " \
         entity-manager \
         fru-synthesizer \
         gxp-chif-service \
+        platform-init \
         smbios-mdr \
         udev-gxp-i2c-passthrough \
         "

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb/0001-OpenBmc-org-BiosReset.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb/0001-OpenBmc-org-BiosReset.patch
@@ -1,0 +1,55 @@
+From 314043cc4d0da60aa8934c155a0514b19ebfd22a Mon Sep 17 00:00:00 2001
+From: Oliver Brewka <oliver.brewka@9elements.com>
+Date: Thu, 12 Mar 2026 02:34:29 +0100
+Subject: [PATCH] OpenBmc org BiosReset
+
+Currently the BiosReset action is only supported on openpower platforms,
+as the implementation calls into an org.openpower owned dbus service.
+
+As part of this patch series [1], a new cmos-reset service is added to
+platform-init that also should be requested via said Redfish action,
+independent of the platform.
+
+To unify, call into a xyz.openbmc_project owned service. Accordingly,
+adpapt the busname in openpower-pnor-code-mgmt [2].
+
+Tested: In order to test the openpower case, built a romulus image
+based on this patch and the patch in openpower-pnor-code-mgmt.
+Made a POST request and checked the journal that the request triggered
+the service.
+Limitation of this testing is that the dbus call errors out as expected
+with "Failed to reset bios: No route to host".
+I don't have access to an openpower platform, but if real hw testing is
+needed I could ask around on discord if someone could run the code on
+their machine.
+
+All testing for the patch series in platform-init has already been
+tested through Redfish.
+
+[1] https://gerrit.openbmc.org/c/openbmc/platform-init/+/88369
+[2] https://gerrit.openbmc.org/c/openbmc/openpower-pnor-code-mgmt/+/88228
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/bmcweb/+/88227]
+Change-Id: I5a52f138848063814e08b152756b8d5d8c31e267
+Signed-off-by: Oliver Brewka <oliver.brewka@9elements.com>
+---
+ redfish-core/lib/bios.hpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/redfish-core/lib/bios.hpp b/redfish-core/lib/bios.hpp
+index ddbd77cc7..281de9be7 100644
+--- a/redfish-core/lib/bios.hpp
++++ b/redfish-core/lib/bios.hpp
+@@ -115,7 +115,8 @@ inline void handleBiosResetPost(
+                 return;
+             }
+         },
+-        "org.open_power.Software.Host.Updater", "/xyz/openbmc_project/software",
++        "xyz.openbmc_project.Software.Host.Updater0",
++        "/xyz/openbmc_project/software",
+         "xyz.openbmc_project.Common.FactoryReset", "Reset");
+ }
+ 
+-- 
+2.54.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -1,5 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+        file://0001-OpenBmc-org-BiosReset.patch \
+        "
+
 PACKAGECONFIG:append = " redfish-allow-deprecated-power-thermal"
 
 EXTRA_OEMESON:append = " \
-    -Dhttp-body-limit=64 \
-"
+        -Dhttp-body-limit=64 \
+        "

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0001-build-allow-compiling-selected-platforms-only.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0001-build-allow-compiling-selected-platforms-only.patch
@@ -1,0 +1,202 @@
+From cb55b0e61d890fbc6e4f0ecf15d9d3acc3033cb8 Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Mon, 20 Jul 2026 22:59:37 +0200
+Subject: [PATCH] build: allow compiling selected platforms only
+
+platform-init links the init code for all platforms into the binary,
+meaning it adds code for every board regardless of which one it targets.
+
+On space-constrained systems this may not fit. A BMC with a 32MB SPI
+(e.g. the HPE ProLiant Gen11 platforms) can barely fit all apps to run
+the OpenBMC stack. Adding init code for platforms that will never run on
+the target wastes valuable storage space.
+
+Make the set of compiled-in platforms a build-time choice. A new
+'platforms' meson array selects which platforms are compiled and
+available. By default, all platforms will be selected to keep
+backwards-compatibility. The init_functions array will be auto-generated
+by meson via platform.hpp.in. If no platform is selected
+(i.e. overwriting the default to be empty), or if platform-name is not
+part of the selected platforms, an error will be thrown.
+
+Building only nvidia-gb200 instead of all platforms can shrink the
+compressed binary (stripped and splitted in squashfs.xz) by ~16 KiB:
+
+    all platforms:    155648 bytes
+    nvidia-gb200:     139264 bytes
+    saving:            16384 bytes
+
+Upstream-Status: Pending
+Change-Id: I67f15741e1d5521ba55aa3b3c04d5af5b0b1641e
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ meson.build     | 54 ++++++++++++++++++++++++++++++++++++++++++-------
+ meson.options   | 13 ++++++++++++
+ platform.cpp    | 15 +++-----------
+ platform.hpp.in | 15 ++++++++++++++
+ 4 files changed, 78 insertions(+), 19 deletions(-)
+ create mode 100644 platform.hpp.in
+
+diff --git a/meson.build b/meson.build
+index f402c48..f0ba3e7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -19,14 +19,45 @@ cli11_dep = dependency(
+ )
+ i2c_dep = meson.get_compiler('cpp').find_library('i2c')
+ 
+-platform_srcs = files(
+-    'intel/acrp.cpp',
+-    'intel/jcrp.cpp',
+-    'nvidia/gb200.cpp',
+-    'nvidia/nvl32.cpp',
+-)
+ util_srcs = files('gpio.cpp', 'i2c.cpp', 'utilities.cpp')
+ 
++platform_name = get_option('platform-name')
++platforms = get_option('platforms')
++if platforms.length() == 0
++    error('at least one platform must be selected!')
++endif
++
++if platform_name not in platforms
++    error('selected platform name not selected in platforms')
++endif
++
++platforms_map = {
++    'intel-acrp': {'src': files('intel/acrp.cpp'), 'fn': 'intel::init_acrp'},
++    'intel-jcrp': {'src': files('intel/jcrp.cpp'), 'fn': 'intel::init_jcrp'},
++    'nvidia-gb200': {
++        'src': files('nvidia/gb200.cpp'),
++        'fn': 'nvidia::init_gb200_base',
++    },
++    'nvidia-gb200-with-p2020': {
++        'src': files('nvidia/gb200.cpp'),
++        'fn': 'nvidia::init_gb200_with_p2020',
++    },
++    'nvidia-nvl32': {
++        'src': files('nvidia/nvl32.cpp'),
++        'fn': 'nvidia::init_nvl32',
++    },
++}
++
++platform_srcs = []
++platform_entries = []
++foreach platform : platforms
++    src = platforms_map[platform]
++    if src['src'] not in platform_srcs
++        platform_srcs += src['src']
++    endif
++    platform_entries += 'PLATFORM("@0@", @1@)'.format(platform, src['fn'])
++endforeach
++
+ exe = executable(
+     'platform',
+     ['platform.cpp'] + platform_srcs + util_srcs,
+@@ -43,6 +74,15 @@ configure_file(
+     install_dir: systemd_system_unit_dir,
+     install: true,
+     configuration: configuration_data(
+-        {'PLATFORM_NAME': get_option('platform-name')},
++        {'PLATFORM_NAME': platform_name},
+     ),
+ )
++
++conf = configuration_data()
++conf.set('PLATFORMS', ',\n    '.join(platform_entries))
++
++configure_file(
++    input: 'platform.hpp.in',
++    output: 'platform.hpp',
++    configuration: conf,
++)
+diff --git a/meson.options b/meson.options
+index 9004923..6e5f74d 100644
+--- a/meson.options
++++ b/meson.options
+@@ -1,3 +1,16 @@
++option(
++    'platforms',
++    type: 'array',
++    choices: [
++        'intel-acrp',
++        'intel-jcrp',
++        'nvidia-gb200',
++        'nvidia-gb200-with-p2020',
++        'nvidia-nvl32',
++    ],
++    description: 'List of platforms to be included',
++)
++
+ option(
+     'platform-name',
+     type: 'string',
+diff --git a/platform.cpp b/platform.cpp
+index a90e209..4ca3729 100644
+--- a/platform.cpp
++++ b/platform.cpp
+@@ -1,10 +1,10 @@
+ // SPDX-License-Identifier: Apache-2.0
+ // SPDX-FileCopyrightText: Copyright OpenBMC Authors
+ 
++#include "platform.hpp"
++
+ #include "gpio.hpp"
+ #include "i2c.hpp"
+-#include "intel.hpp"
+-#include "nvidia.hpp"
+ #include "utilities.hpp"
+ 
+ #include <fcntl.h>
+@@ -14,18 +14,9 @@
+ #include <gpiod.hpp>
+ 
+ #include <algorithm>
+-#include <array>
+-#include <iostream>
+ #include <string_view>
+ #include <utility>
+ 
+-constexpr std::array<std::pair<std::string_view, int (*)()>, 5> init_functions{
+-    {{"intel-acrp", intel::init_acrp},
+-     {"intel-jcrp", intel::init_jcrp},
+-     {"nvidia-gb200", nvidia::init_gb200_base},
+-     {"nvidia-gb200-with-p2020", nvidia::init_gb200_with_p2020},
+-     {"nvidia-nvl32", nvidia::init_nvl32}}};
+-
+ int main(int argc, char** argv)
+ {
+     CLI::App app("Platform init CLI");
+@@ -48,7 +39,7 @@ int main(int argc, char** argv)
+         [&platform_name](const std::pair<std::string_view, int (*)()> val) {
+             return val.first == platform_name;
+         });
+-    if (it == init_functions.end())
++    if (it == std::ranges::end(init_functions))
+     {
+         std::cerr << init_sub->help() << "\n";
+         return EXIT_FAILURE;
+diff --git a/platform.hpp.in b/platform.hpp.in
+new file mode 100644
+index 0000000..05a1e04
+--- /dev/null
++++ b/platform.hpp.in
+@@ -0,0 +1,15 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: Copyright OpenBMC Authors
++
++#pragma once
++
++#include "intel.hpp"
++#include "nvidia.hpp"
++
++#include <string_view>
++
++#define PLATFORM(name, func) {name, func}
++
++inline constexpr std::pair<std::string_view, int (*)()> init_functions[] = {
++    @PLATFORMS@
++};
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0002-Use-CLI11-callback-function-for-init-sub.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0002-Use-CLI11-callback-function-for-init-sub.patch
@@ -1,0 +1,91 @@
+From 712244df77a86ed2bf81fc62d3710c36284ec4c9 Mon Sep 17 00:00:00 2001
+From: Oliver Brewka <oliver.brewka@9elements.com>
+Date: Sun, 14 Jun 2026 15:14:11 +0200
+Subject: [PATCH 1/6] Use CLI11 callback function for init sub
+
+Follow-up patch adds a new sub command. Using CLI11 callback function to
+have uniform code for sub command handling.
+
+Tested: Build a meta-catalina image.
+Upon boot, check the output of `systemctl status platform_init`.
+Confirmed the dummy init function for meta-catalina executed.
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/platform-init/+/91318/1]
+Change-Id: I71261b28ee60279c589b50a7ae5943cf3b1b9960
+Signed-off-by: Oliver Brewka <oliver.brewka@9elements.com>
+[Tan: modified to be compatible with own changes]
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ platform.cpp | 40 +++++++++++++++++++++++++++++++---------
+ 1 file changed, 31 insertions(+), 9 deletions(-)
+
+diff --git a/platform.cpp b/platform.cpp
+index 4ca3729..9ef0ee9 100644
+--- a/platform.cpp
++++ b/platform.cpp
+@@ -17,6 +17,29 @@
+ #include <string_view>
+ #include <utility>
+ 
++void init_sub_callback(std::string& platform_name, bool& success)
++{
++    const auto* it = std::ranges::find_if(
++        init_functions,
++        [&platform_name](const std::pair<std::string_view, int (*)()> val) {
++            return val.first == platform_name;
++        });
++    if (it == std::ranges::end(init_functions))
++    {
++        std::cerr << "no init function";
++        return;
++    }
++
++    int rc = it->second();
++    if (rc != EXIT_SUCCESS)
++    {
++        std::cerr << "init function failed\n";
++        return;
++    }
++
++    success = true;
++}
++
+ int main(int argc, char** argv)
+ {
+     CLI::App app("Platform init CLI");
+@@ -26,24 +49,23 @@ int main(int argc, char** argv)
+     CLI::App* init_sub =
+         app.add_subcommand("init", "Initialize the platform and daemonize");
+     std::string platform_name;
++    bool success = false;
+     init_sub
+         ->add_option("platform_name", platform_name,
+                      "Name of the platform to init")
+         ->required();
+-    app.require_subcommand();
+ 
++    init_sub->callback([&platform_name, &success]() {
++        init_sub_callback(platform_name, success);
++    });
++
++    app.require_subcommand();
+     CLI11_PARSE(app, argc, argv)
+ 
+-    const auto* it = std::ranges::find_if(
+-        init_functions,
+-        [&platform_name](const std::pair<std::string_view, int (*)()> val) {
+-            return val.first == platform_name;
+-        });
+-    if (it == std::ranges::end(init_functions))
++    if (!success)
+     {
+-        std::cerr << init_sub->help() << "\n";
+         return EXIT_FAILURE;
+     }
+ 
+-    return it->second();
++    return EXIT_SUCCESS;
+ }
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0003-Add-phosphor-logging-and-PDI-deps.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0003-Add-phosphor-logging-and-PDI-deps.patch
@@ -1,0 +1,61 @@
+From 5a190e960675d35eb60d775a12ecede3810e14c3 Mon Sep 17 00:00:00 2001
+From: Oliver Brewka <oliver.brewka@9elements.com>
+Date: Wed, 22 Jul 2026 15:57:48 +0200
+Subject: [PATCH 2/6] Add phosphor-logging and PDI deps
+
+Follow-up patches depend on phosphor-logging and
+phosphor-dbus-interfaces. This patch adds the wrap files and declares
+those packages as new meson dependencies.
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/platform-init/+/91320/2]
+Change-Id: I6b21ed838b1c6cea62c9fc283010b5687d7bf755
+Signed-off-by: Oliver Brewka <oliver.brewka@9elements.com>
+---
+ meson.build                               | 3 ++-
+ subprojects/phosphor-dbus-interfaces.wrap | 6 ++++++
+ subprojects/phosphor-logging.wrap         | 6 ++++++
+ 3 files changed, 14 insertions(+), 1 deletion(-)
+ create mode 100644 subprojects/phosphor-dbus-interfaces.wrap
+ create mode 100644 subprojects/phosphor-logging.wrap
+
+diff --git a/meson.build b/meson.build
+index f0ba3e7..68108a2 100644
+--- a/meson.build
++++ b/meson.build
+@@ -10,7 +10,8 @@ gpiodcxx_dep = dependency('libgpiodcxx', default_options: ['bindings=cxx'])
+ systemd_dep = dependency('systemd')
+ libsystemd_dep = dependency('libsystemd')
+ sdbusplus = dependency('sdbusplus', include_type: 'system')
+-
++phosphor_dbus_interfaces_dep = dependency('phosphor-dbus-interfaces')
++phosphor_logging_dep = dependency('phosphor-logging')
+ 
+ cli11_dep = dependency(
+     'CLI11',
+diff --git a/subprojects/phosphor-dbus-interfaces.wrap b/subprojects/phosphor-dbus-interfaces.wrap
+new file mode 100644
+index 0000000..346aa0c
+--- /dev/null
++++ b/subprojects/phosphor-dbus-interfaces.wrap
+@@ -0,0 +1,6 @@
++[wrap-git]
++url = https://github.com/openbmc/phosphor-dbus-interfaces.git
++revision = HEAD
++
++[provide]
++phosphor-dbus-interfaces = phosphor_dbus_interfaces_dep
+diff --git a/subprojects/phosphor-logging.wrap b/subprojects/phosphor-logging.wrap
+new file mode 100644
+index 0000000..71eee8b
+--- /dev/null
++++ b/subprojects/phosphor-logging.wrap
+@@ -0,0 +1,6 @@
++[wrap-git]
++url = https://github.com/openbmc/phosphor-logging.git
++revision = HEAD
++
++[provide]
++phosphor-logging = phosphor_logging_dep
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0004-cmos-reset-Add-cmos-reset-service.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0004-cmos-reset-Add-cmos-reset-service.patch
@@ -1,0 +1,404 @@
+From c9587458e328f5da931eb4e91e988bfda3a0f23b Mon Sep 17 00:00:00 2001
+From: Oliver Brewka <oliver.brewka@9elements.com>
+Date: Mon, 16 Mar 2026 06:22:02 +0100
+Subject: [PATCH 3/6] cmos-reset: Add cmos reset service
+
+In order to support a cmos reset / clear, add a dbus service that
+exposes the Reset method from xyz.openbmc_project.Common.FactoryReset.
+
+Each platform should define its specific cmos reset function which gets
+passed to the service.
+For that matter, the platform-init repository is a suitable place to add
+this service to, since it already provides a platform specific project
+and code structure as well as utility wrappers around i2c and gpio for
+easy implementation.
+
+Follow-up patches complete the following flow of actions:
+
+1. Check host state
+2. power off, if running
+3. set ActivationBlocksTransition interface
+4. run platform cmos reset function
+5. remove ActivationBlocksTransition interface
+6. restore initial host power state
+7. send success event log
+
+If any step fails, send a failure event log and return early.
+
+The service has been designed with Redfish in mind. A user should be
+able to trigger the reset through Bios.ResetBios action, for a) a lack
+of a better action and b) a cmos reset typically is performed to reset
+the bios.
+
+Currently on the bmcweb side this action calls into
+`org.openpower.Software.Host.Updater /xyz/openbmc_project/software
+xyz.openbmc_project.Common.FactoryReset Reset`. As part of this series,
+the busName shall be changed to
+xyz.openbmc_project.Software.Host.Updater0 [2] in an attempt to unify.
+
+Upgrading the code to be compatible with multi-host platforms in the
+future might require to change the instance path to include the specific
+host segment.
+
+The service can be started with the added cmos-reset-service sub
+command.
+
+Required recipe update [3].
+
+Tested: Code compiles.
+Build an image that configures to use the service. Run the image and
+check if the service is started correctly. Trigger the Reset method both
+manually and through Redfish and check journal output for the correct
+debug prints.
+
+[1] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/88227
+[2] https://gerrit.openbmc.org/c/openbmc/openpower-pnor-code-mgmt/+/88228
+[3] https://gerrit.openbmc.org/c/openbmc/openbmc/+/88527/4
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/platform-init/+/88370/13]
+Change-Id: Ia385ab1ccf48b441ffcd449385350c0dec21aae5
+Signed-off-by: Oliver Brewka <oliver.brewka@9elements.com>
+[Tan: removed Catalina code, adapted to be compatible with Meson dynamic
+      rendering]
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ cmos-reset/cmos_reset.cpp                     | 62 +++++++++++++++++++
+ cmos-reset/cmos_reset.hpp                     | 42 +++++++++++++
+ ..._project.Software.Host.Updater0.service.in | 12 ++++
+ meson.build                                   | 33 +++++++++-
+ meson.options                                 |  7 +++
+ platform.cpp                                  | 41 ++++++++++++
+ platform.hpp.in                               |  8 +++
+ 7 files changed, 202 insertions(+), 3 deletions(-)
+ create mode 100644 cmos-reset/cmos_reset.cpp
+ create mode 100644 cmos-reset/cmos_reset.hpp
+ create mode 100644 cmos-reset/xyz.openbmc_project.Software.Host.Updater0.service.in
+
+diff --git a/cmos-reset/cmos_reset.cpp b/cmos-reset/cmos_reset.cpp
+new file mode 100644
+index 0000000..c8b72e2
+--- /dev/null
++++ b/cmos-reset/cmos_reset.cpp
+@@ -0,0 +1,62 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: Copyright OpenBMC Authors
++
++#include "cmos_reset.hpp"
++
++#include <phosphor-logging/lg2.hpp>
++
++PHOSPHOR_LOG2_USING;
++
++namespace cmos
++{
++
++sdbusplus::async::task<> CmosReset::startReset()
++{
++    info("CMOS reset requested");
++
++    bool success = co_await doReset();
++
++    if (!success)
++    {
++        error("CMOS reset failed");
++        co_return;
++    }
++
++    info("CMOS reset successful");
++}
++
++sdbusplus::async::task<bool> CmosReset::doReset()
++{
++    if (!resetMethod)
++    {
++        error("No reset function provided for this platform");
++        co_return false;
++    }
++
++    bool success = co_await resetMethod(ctx);
++    if (!success)
++    {
++        error("CMOS reset failed");
++        co_return false;
++    }
++
++    co_return true;
++}
++
++int init_service(CmosResetMethod resetMethod)
++{
++    sdbusplus::async::context ctx;
++    sdbusplus::server::manager_t manager(ctx, softwarePath);
++
++    CmosReset service(ctx, softwarePath, resetMethod);
++
++    ctx.spawn([](sdbusplus::async::context& ctx) -> sdbusplus::async::task<> {
++        ctx.request_name(busName);
++        co_return;
++    }(ctx));
++
++    ctx.run();
++
++    return EXIT_SUCCESS;
++}
++} // namespace cmos
+diff --git a/cmos-reset/cmos_reset.hpp b/cmos-reset/cmos_reset.hpp
+new file mode 100644
+index 0000000..73eb39c
+--- /dev/null
++++ b/cmos-reset/cmos_reset.hpp
+@@ -0,0 +1,42 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: Copyright OpenBMC Authors
++
++#include <sdbusplus/bus.hpp>
++#include <xyz/openbmc_project/Common/FactoryReset/aserver.hpp>
++
++namespace cmos
++{
++
++constexpr const char* softwarePath = "/xyz/openbmc_project/software";
++constexpr const char* busName = "xyz.openbmc_project.Software.Host.Updater0";
++
++using CmosResetMethod =
++    std::function<sdbusplus::async::task<bool>(sdbusplus::async::context& ctx)>;
++
++class CmosReset :
++    public sdbusplus::aserver::xyz::openbmc_project::common::FactoryReset<
++        CmosReset>
++{
++  public:
++    CmosReset(sdbusplus::async::context& ctx, const char* objPath,
++              CmosResetMethod resetMethod = nullptr) :
++        sdbusplus::aserver::xyz::openbmc_project::common::FactoryReset<
++            CmosReset>(ctx, objPath),
++        ctx(ctx), resetMethod(resetMethod)
++    {}
++
++    auto method_call(reset_t)
++    {
++        ctx.spawn(startReset());
++    };
++
++    sdbusplus::async::task<> startReset();
++    sdbusplus::async::task<bool> doReset();
++
++  private:
++    sdbusplus::async::context& ctx;
++    CmosResetMethod resetMethod;
++};
++
++int init_service(CmosResetMethod resetMethod);
++} // namespace cmos
+diff --git a/cmos-reset/xyz.openbmc_project.Software.Host.Updater0.service.in b/cmos-reset/xyz.openbmc_project.Software.Host.Updater0.service.in
+new file mode 100644
+index 0000000..c45ce3a
+--- /dev/null
++++ b/cmos-reset/xyz.openbmc_project.Software.Host.Updater0.service.in
+@@ -0,0 +1,12 @@
++[Unit]
++Description=platform cmos reset service
++Before=xyz.openbmc_project.FruDevice.service
++
++[Service]
++ExecStart=/usr/libexec/platform cmos-reset-service @PLATFORM_NAME@
++Restart=always
++Type=dbus
++BusName=xyz.openbmc_project.Software.Host.Updater0
++
++[Install]
++WantedBy=multi-user.target
+diff --git a/meson.build b/meson.build
+index 68108a2..1310b05 100644
+--- a/meson.build
++++ b/meson.build
+@@ -20,6 +20,7 @@ cli11_dep = dependency(
+ )
+ i2c_dep = meson.get_compiler('cpp').find_library('i2c')
+ 
++cmos_reset_srcs = files('cmos-reset/cmos_reset.cpp')
+ util_srcs = files('gpio.cpp', 'i2c.cpp', 'utilities.cpp')
+ 
+ platform_name = get_option('platform-name')
+@@ -51,19 +52,34 @@ platforms_map = {
+ 
+ platform_srcs = []
+ platform_entries = []
++cmos_reset_entries = []
+ foreach platform : platforms
+     src = platforms_map[platform]
+     if src['src'] not in platform_srcs
+         platform_srcs += src['src']
+     endif
+     platform_entries += 'PLATFORM("@0@", @1@)'.format(platform, src['fn'])
++    if 'cmos_reset_fn' in src
++        cmos_reset_entries += 'PLATFORM("@0@", @1@)'.format(
++            platform,
++            src['cmos_reset_fn'],
++        )
++    endif
+ endforeach
+ 
+ exe = executable(
+     'platform',
+-    ['platform.cpp'] + platform_srcs + util_srcs,
+-    dependencies: [gpiodcxx_dep, libsystemd_dep, cli11_dep, i2c_dep, sdbusplus],
+-    include_directories: ['.', 'nvidia', 'intel'],
++    ['platform.cpp'] + platform_srcs + cmos_reset_srcs + util_srcs,
++    dependencies: [
++        gpiodcxx_dep,
++        libsystemd_dep,
++        cli11_dep,
++        i2c_dep,
++        sdbusplus,
++        phosphor_logging_dep,
++        phosphor_dbus_interfaces_dep,
++    ],
++    include_directories: ['.', 'cmos-reset', 'intel', 'nvidia'],
+     install: true,
+     install_dir: get_option('libexecdir'),
+ )
+@@ -81,9 +97,20 @@ configure_file(
+ 
+ conf = configuration_data()
+ conf.set('PLATFORMS', ',\n    '.join(platform_entries))
++conf.set('CMOS_RESET_PLATFORMS', ',\n    '.join(cmos_reset_entries))
+ 
+ configure_file(
+     input: 'platform.hpp.in',
+     output: 'platform.hpp',
+     configuration: conf,
+ )
++
++configure_file(
++    input: 'cmos-reset/xyz.openbmc_project.Software.Host.Updater0.service.in',
++    output: 'xyz.openbmc_project.Software.Host.Updater0.service',
++    install_dir: systemd_system_unit_dir,
++    install: true,
++    configuration: configuration_data(
++        {'PLATFORM_NAME': platform_name},
++    ),
++)
+diff --git a/meson.options b/meson.options
+index 6e5f74d..961234e 100644
+--- a/meson.options
++++ b/meson.options
+@@ -17,3 +17,10 @@ option(
+     value: 'nvidia-gb200',
+     description: 'Platform to init (Temporary)',
+ )
++
++option(
++    'cmos-reset',
++    type: 'feature',
++    value: 'disabled',
++    description: 'Enable CMOS reset service',
++)
+diff --git a/platform.cpp b/platform.cpp
+index 9ef0ee9..ea556bc 100644
+--- a/platform.cpp
++++ b/platform.cpp
+@@ -3,6 +3,7 @@
+ 
+ #include "platform.hpp"
+ 
++#include "cmos_reset.hpp"
+ #include "gpio.hpp"
+ #include "i2c.hpp"
+ #include "utilities.hpp"
+@@ -12,6 +13,7 @@
+ 
+ #include <CLI/CLI.hpp>
+ #include <gpiod.hpp>
++#include <sdbusplus/async.hpp>
+ 
+ #include <algorithm>
+ #include <string_view>
+@@ -40,6 +42,32 @@ void init_sub_callback(std::string& platform_name, bool& success)
+     success = true;
+ }
+ 
++void cmos_reset_sub_callback(std::string& platform_name, bool& success)
++{
++    const auto* it = std::ranges::find_if(
++        cmos_reset_functions,
++        [&platform_name](
++            const std::pair<std::string_view, sdbusplus::async::task<bool> (*)(
++                                                  sdbusplus::async::context&)>
++                val) { return val.first == platform_name; });
++
++    if (it == std::ranges::end(cmos_reset_functions))
++    {
++        std::cerr << "no reset function";
++        return;
++    }
++
++    int rc = cmos::init_service(it->second);
++
++    if (rc != EXIT_SUCCESS)
++    {
++        std::cerr << "failed to initialize cmos-reset service\n";
++        return;
++    }
++
++    success = true;
++}
++
+ int main(int argc, char** argv)
+ {
+     CLI::App app("Platform init CLI");
+@@ -48,8 +76,12 @@ int main(int argc, char** argv)
+ 
+     CLI::App* init_sub =
+         app.add_subcommand("init", "Initialize the platform and daemonize");
++    CLI::App* cmos_reset_sub = app.add_subcommand(
++        "cmos-reset-service", "Start the cmos-reset service");
++
+     std::string platform_name;
+     bool success = false;
++
+     init_sub
+         ->add_option("platform_name", platform_name,
+                      "Name of the platform to init")
+@@ -59,6 +91,15 @@ int main(int argc, char** argv)
+         init_sub_callback(platform_name, success);
+     });
+ 
++    cmos_reset_sub
++        ->add_option("platform_name", platform_name,
++                     "Name of the platform to start the service on")
++        ->required();
++
++    cmos_reset_sub->callback([&platform_name, &success]() {
++        cmos_reset_sub_callback(platform_name, success);
++    });
++
+     app.require_subcommand();
+     CLI11_PARSE(app, argc, argv)
+ 
+diff --git a/platform.hpp.in b/platform.hpp.in
+index 05a1e04..8963825 100644
+--- a/platform.hpp.in
++++ b/platform.hpp.in
+@@ -6,6 +6,8 @@
+ #include "intel.hpp"
+ #include "nvidia.hpp"
+ 
++#include <sdbusplus/async.hpp>
++
+ #include <string_view>
+ 
+ #define PLATFORM(name, func) {name, func}
+@@ -13,3 +15,9 @@
+ inline constexpr std::pair<std::string_view, int (*)()> init_functions[] = {
+     @PLATFORMS@
+ };
++
++inline constexpr std::pair<std::string_view, sdbusplus::async::task<bool> (*)(
++                                                 sdbusplus::async::context&)>
++    cmos_reset_functions[] = {
++    @CMOS_RESET_PLATFORMS@
++};
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0005-cmos-reset-Add-event-logs.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0005-cmos-reset-Add-event-logs.patch
@@ -1,0 +1,153 @@
+From b2cfaf273e7b051a2e6849abff8ceb48fa1d4661 Mon Sep 17 00:00:00 2001
+From: Oliver Brewka <oliver.brewka@9elements.com>
+Date: Sun, 5 Apr 2026 22:11:26 +0200
+Subject: [PATCH 4/6] cmos-reset: Add event logs
+
+The Redfish request for a Bios.ResetBios action only initiates the
+reset and passes control to the service. A user should be able to check
+whether the reset was successful or not afterwards through Redfish
+EventLog log service.
+
+For that matter, a Common.FactoryReset.ResetFailure error and a
+Common.FactoryReset.ResetSuccess event have been added to PDI [1] to log
+either a failed or a successful reset.
+
+Tested: Build the image.
+Pass in a valid platform reset function to check the
+successful reset notification.
+
+Verify the according log entry has been created under
+xyz.openbmc_project.Logging.
+
+Output for successful reset upon request through Redfish:
+
+```
+$ curl -v -k  POST
+'https://'"${BMC}"':'"${BMC_WEBPORT}"'/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios' \
+        -H 'X-Auth-Token: '"$BMCWEB_SESSION_TOKEN_YV4"'' \
+        -H "Content-Type: application/json" -d "{${BODY}}"
+
+$ journalctl -u xyz.openbmc_project.Software.Host.Updater0
+...
+OPENBMC_MESSAGE_ID={"xyz.openbmc_project.Common.FactoryReset.ResetSuccess":{"RESET_CAUSE", "Manual CMOS reset", "SOURCE":"/xyz/openbmc_project/software","_SOURCE":{"COLUMN":77,"FILE":"../../../../../../../../../../openbmc/platform-init/cmos-reset/cmos_reset.cpp","FUNCTION":"sdbusplus::async::task<void> cmos::CmosReset::startReset()","LINE":35,"PID":397}}}
+...
+
+$ busctl introspect xyz.openbmc_project.Logging
+/xyz/openbmc_project/logging/entry/2
+
+...
+xyz.openbmc_project.Logging.Entry           interface -         -                                                                                                                                                                                                                                                -
+.GetEntry                                   method    -         h                                                                                                                                                                                                                                                -
+.AdditionalData                             property  a{ss}     6 "RESET_CAUSE" "Manual CMOS reset" "SOURCE" "/xyz/openbmc_project/software" "_CODE_FILE" "../../../../../../../../../../openbmc/platform-init/cmos-reset/cmos_reset.cpp" "_CODE_FUNC" "sdbusplus::async::task<void> cmos::CmosReset::startReset()" "_CODE_LINE" "29" "_PID" "382" emits-change writable
+.EventId                                    property  s         ""                                                                                                                                                                                                                                               emits-change writable
+.Id                                         property  u         2                                                                                                                                                                                                                                                emits-change writable
+.Message                                    property  s         "xyz.openbmc_project.Common.FactoryReset.ResetSuccess"                                                                                                                                                                                           emits-change writable
+.Resolution                                 property  s         ""                                                                                                                                                                                                                                               emits-change writable
+.Resolved                                   property  b         true                                                                                                                                                                                                                                             emits-change writable
+.ServiceProviderNotify                      property  s         "xyz.openbmc_project.Logging.Entry.Notify.NotSupported"                                                                                                                                                                                          emits-change writable
+.Severity                                   property  s         "xyz.openbmc_project.Logging.Entry.Level.Informational"                                                                                                                                                                                          emits-change writable
+.Timestamp                                  property  t         1775688249078                                                                                                                                                                                                                                    emits-change writable
+.UpdateTimestamp                            property  t         1775688249108                                                                                                                                                                                                                                    emits-change writable
+xyz.openbmc_project.Object.Delete           interface -         -                                                                                                                                                                                                                                                -
+.Delete                                     method    -         -                                                                                                                                                                                                                                                -
+xyz.openbmc_project.Software.Version        interface -         -                                                                                                                                                                                                                                                -
+.Purpose                                    property  s         "xyz.openbmc_project.Software.Version.VersionPurpose.BMC"                                                                                                                                                                                        emits-change writable
+.Version                                    property  s         "3.0.0-dev-2041-gac0738a32c-dirty"                                                                                                                                                                                                               emits-change writable
+```
+
+Output dbus log entry for failed reset by passing a nullptr to
+init_service:
+
+```
+$ busctl introspect xyz.openbmc_project.Logging
+/xyz/openbmc_project/logging/entry/4
+
+...
+xyz.openbmc_project.Logging.Entry           interface -         -                                                                                                                                                                                                                                                -
+.GetEntry                                   method    -         h                                                                                                                                                                                                                                                -
+.AdditionalData                             property  a{ss}     6 "RESET_CAUSE" "Manual CMOS reset" "SOURCE" "/xyz/openbmc_project/software" "_CODE_FILE" "../../../../../../../../../../openbmc/platform-init/cmos-reset/cmos_reset.cpp" "_CODE_FUNC" "sdbusplus::async::task<void> cmos::CmosReset::startReset()" "_CODE_LINE" "22" "_PID" "395" emits-change writable
+.EventId                                    property  s         ""                                                                                                                                                                                                                                               emits-change writable
+.Id                                         property  u         4                                                                                                                                                                                                                                                emits-change writable
+.Message                                    property  s         "xyz.openbmc_project.Common.FactoryReset.ResetFailure"                                                                                                                                                                                           emits-change writable
+.Resolution                                 property  s         ""                                                                                                                                                                                                                                               emits-change writable
+.Resolved                                   property  b         false                                                                                                                                                                                                                                            emits-change writable
+.ServiceProviderNotify                      property  s         "xyz.openbmc_project.Logging.Entry.Notify.NotSupported"                                                                                                                                                                                          emits-change writable
+.Severity                                   property  s         "xyz.openbmc_project.Logging.Entry.Level.Error"                                                                                                                                                                                                  emits-change writable
+.Timestamp                                  property  t         1775745905610                                                                                                                                                                                                                                    emits-change writable
+.UpdateTimestamp                            property  t         1775745905610                                                                                                                                                                                                                                    emits-change writable
+xyz.openbmc_project.Object.Delete           interface -         -                                                                                                                                                                                                                                                -
+.Delete                                     method    -         -                                                                                                                                                                                                                                                -
+xyz.openbmc_project.Software.Version        interface -         -                                                                                                                                                                                                                                                -
+.Purpose                                    property  s         "xyz.openbmc_project.Software.Version.VersionPurpose.BMC"                                                                                                                                                                                        emits-change writable
+.Version                                    property  s         "3.0.0-dev-2041-gac0738a32c-dirty"                                                                                                                                                                                                               emits-change writable
+
+```
+
+[1] https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/89047
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/platform-init/+/89046/12]
+Change-Id: I4e6cd9492accfc3791e9921bf42624e427c84ba5
+Signed-off-by: Oliver Brewka <oliver.brewka@9elements.com>
+---
+ cmos-reset/cmos_reset.cpp | 9 +++++++++
+ cmos-reset/cmos_reset.hpp | 6 ++++++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/cmos-reset/cmos_reset.cpp b/cmos-reset/cmos_reset.cpp
+index c8b72e2..8dee77a 100644
+--- a/cmos-reset/cmos_reset.cpp
++++ b/cmos-reset/cmos_reset.cpp
+@@ -3,6 +3,7 @@
+ 
+ #include "cmos_reset.hpp"
+ 
++#include <phosphor-logging/commit.hpp>
+ #include <phosphor-logging/lg2.hpp>
+ 
+ PHOSPHOR_LOG2_USING;
+@@ -19,10 +20,18 @@ sdbusplus::async::task<> CmosReset::startReset()
+     if (!success)
+     {
+         error("CMOS reset failed");
++        co_await lg2::commit(
++            ctx, ResetFailure("RESET_CAUSE", "Manual CMOS reset", "SOURCE",
++                              sdbusplus::object_path(softwarePath)));
+         co_return;
+     }
+ 
+     info("CMOS reset successful");
++    const auto logPath = co_await lg2::commit(
++        ctx, ResetSuccess("RESET_CAUSE", "Manual CMOS reset", "SOURCE",
++                          sdbusplus::object_path(softwarePath)));
++
++    co_await lg2::resolve(ctx, logPath);
+ }
+ 
+ sdbusplus::async::task<bool> CmosReset::doReset()
+diff --git a/cmos-reset/cmos_reset.hpp b/cmos-reset/cmos_reset.hpp
+index 73eb39c..23afc3b 100644
+--- a/cmos-reset/cmos_reset.hpp
++++ b/cmos-reset/cmos_reset.hpp
+@@ -3,6 +3,7 @@
+ 
+ #include <sdbusplus/bus.hpp>
+ #include <xyz/openbmc_project/Common/FactoryReset/aserver.hpp>
++#include <xyz/openbmc_project/Common/FactoryReset/event.hpp>
+ 
+ namespace cmos
+ {
+@@ -13,6 +14,11 @@ constexpr const char* busName = "xyz.openbmc_project.Software.Host.Updater0";
+ using CmosResetMethod =
+     std::function<sdbusplus::async::task<bool>(sdbusplus::async::context& ctx)>;
+ 
++using ResetFailure =
++    sdbusplus::error::xyz::openbmc_project::common::FactoryReset::ResetFailure;
++using ResetSuccess =
++    sdbusplus::event::xyz::openbmc_project::common::FactoryReset::ResetSuccess;
++
+ class CmosReset :
+     public sdbusplus::aserver::xyz::openbmc_project::common::FactoryReset<
+         CmosReset>
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0006-cmos-reset-Add-power-control-capabilities.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0006-cmos-reset-Add-power-control-capabilities.patch
@@ -1,0 +1,282 @@
+From 8dc15541ee9684ad62bb71eaecf03ef36d7f716c Mon Sep 17 00:00:00 2001
+From: Oliver Brewka <oliver.brewka@9elements.com>
+Date: Tue, 17 Mar 2026 16:43:46 +0100
+Subject: [PATCH 5/6] cmos-reset: Add power control capabilities
+
+Ideally the host is powered off before any reset.
+Add functionality, to check if the host is running and to do state
+transitions accordingly.
+
+A sane default behavior is to restore the previously captured host state
+as is done in phosphor-bmc-code-mgmt repository.
+
+In addition to have more control over the transition timeouts, the
+'host-state-transition-timeout' option has been added with a default
+value of 60 seconds.
+
+The majority of the core power logic comes from phosphor-bmc-code-mgmt
+with slight adjustments made. The dbus match got removed, as well as
+some checks of CurrentHostState, which are now done inside the doReset()
+function.
+
+Tested:
+The logic has been tested on a tyan s8047 board.
+Triggered a cmos reset through redfish in both, the 'Off' and the
+'Running' state of the host.
+Validated that the service printed the correct logs as well as checked
+x86-power-control that it registered the correct state transitions.
+Made sure, that when the host initially was 'Running', that state got
+restored  after the reset.
+
+Output for a cmos reset, when host was initially running:
+
+```
+May 10 13:59:32 s8047 cmos-reset[318]: CMOS reset requested
+May 10 13:59:32 s8047 cmos-reset[318]: Host is running, transitioning to off
+May 10 13:59:33 s8047 cmos-reset[318]: Resetting cmos
+May 10 13:59:38 s8047 cmos-reset[318]: CMOS reset done
+May 10 13:59:39 s8047 cmos-reset[318]: CMOS reset successful
+May 10 13:59:39 s8047 cmos-reset[318]: Restoring previous host state
+May 10 13:59:39 s8047 cmos-reset[318]: Host state restored
+May 10 13:59:39 s8047 cmos-reset[318]: OPENBMC_MESSAGE_ID={"xyz.openbmc_project.Common.FactoryReset.ResetSuccess":{"RESET_CAUSE", "Manual CMOS reset", "SOURCE":"/xyz/openbmc_project/software","_SOURCE":{"COLUMN":77,"FILE":"../../../../../../../../../../openbmc/platform-init/cmos-reset/cmos_reset.cpp","FUNCTION":"sdbusplus::async::task<void> cmos::CmosReset::startReset()","LINE":36,"PID":318}}}
+
+```
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/platform-init/+/88371/16]
+Change-Id: Ifbcd00d0443ba5292acf9e9a3380deeb16098f9d
+Signed-off-by: Oliver Brewka <oliver.brewka@9elements.com>
+---
+ cmos-reset/cmos_reset.cpp | 41 ++++++++++++++++++++++++++++++++
+ cmos-reset/host_power.cpp | 50 +++++++++++++++++++++++++++++++++++++++
+ cmos-reset/host_power.hpp | 45 +++++++++++++++++++++++++++++++++++
+ meson.build               |  9 ++++++-
+ meson.options             |  7 ++++++
+ 5 files changed, 151 insertions(+), 1 deletion(-)
+ create mode 100644 cmos-reset/host_power.cpp
+ create mode 100644 cmos-reset/host_power.hpp
+
+diff --git a/cmos-reset/cmos_reset.cpp b/cmos-reset/cmos_reset.cpp
+index 8dee77a..8050ff9 100644
+--- a/cmos-reset/cmos_reset.cpp
++++ b/cmos-reset/cmos_reset.cpp
+@@ -3,6 +3,8 @@
+ 
+ #include "cmos_reset.hpp"
+ 
++#include "host_power.hpp"
++
+ #include <phosphor-logging/commit.hpp>
+ #include <phosphor-logging/lg2.hpp>
+ 
+@@ -11,6 +13,8 @@ PHOSPHOR_LOG2_USING;
+ namespace cmos
+ {
+ 
++using namespace host_power;
++
+ sdbusplus::async::task<> CmosReset::startReset()
+ {
+     info("CMOS reset requested");
+@@ -42,6 +46,30 @@ sdbusplus::async::task<bool> CmosReset::doReset()
+         co_return false;
+     }
+ 
++    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch)
++    auto powerstate = co_await HostPower::getState(ctx);
++
++    if (powerstate != stateOn && powerstate != stateOff)
++    {
++        error("Invalid host state {STATE}", "STATE", powerstate);
++        co_return false;
++    }
++
++    bool restorePowerState = false;
++    if (powerstate == stateOn)
++    {
++        info("Host is running, transitioning to off");
++        bool success = co_await HostPower::setState(ctx, stateOff);
++
++        if (!success)
++        {
++            error("Error host power off");
++            co_return false;
++        }
++
++        restorePowerState = true;
++    }
++
+     bool success = co_await resetMethod(ctx);
+     if (!success)
+     {
+@@ -49,6 +77,19 @@ sdbusplus::async::task<bool> CmosReset::doReset()
+         co_return false;
+     }
+ 
++    if (restorePowerState)
++    {
++        lg2::info("Restoring previous host state");
++        bool success = co_await HostPower::setState(ctx, stateOn);
++
++        if (!success)
++        {
++            error("Error restoring power state");
++            co_return false;
++        }
++        lg2::info("Host state restored successfully");
++    }
++
+     co_return true;
+ }
+ 
+diff --git a/cmos-reset/host_power.cpp b/cmos-reset/host_power.cpp
+new file mode 100644
+index 0000000..a621401
+--- /dev/null
++++ b/cmos-reset/host_power.cpp
+@@ -0,0 +1,50 @@
++#include "host_power.hpp"
++
++#include <phosphor-logging/lg2.hpp>
++
++PHOSPHOR_LOG2_USING;
++
++namespace host_power
++{
++
++sdbusplus::async::task<bool> HostPower::setState(sdbusplus::async::context& ctx,
++                                                 HostState state)
++{
++    auto client = sdbusplus::client::xyz::openbmc_project::state::Host(ctx)
++                      .service(hostStateService)
++                      .path(host0ObjectPath);
++
++    co_await client.requested_host_transition(
++        (state == stateOn) ? transitionOn : transitionOff);
++
++    debug("Requested host transition to {STATE}", "STATE", state);
++
++    for (size_t i = 0; i < HOST_STATE_TRANSITION_TIMEOUT; i++)
++    {
++        co_await sdbusplus::async::sleep_for(ctx, std::chrono::seconds(1));
++
++        if ((co_await client.current_host_state()) == state)
++        {
++            debug("Successfully achieved state {STATE}", "STATE", state);
++            co_return true;
++        }
++    }
++
++    error("Failed to achieve state {STATE} before the timeout of {TIMEOUT}s",
++          "STATE", state, "TIMEOUT", HOST_STATE_TRANSITION_TIMEOUT);
++
++    co_return false;
++}
++
++sdbusplus::async::task<HostState> HostPower::getState(
++    sdbusplus::async::context& ctx)
++{
++    auto client = sdbusplus::client::xyz::openbmc_project::state::Host(ctx)
++                      .service(hostStateService)
++                      .path(host0ObjectPath);
++
++    auto res = co_await client.current_host_state();
++
++    co_return res;
++}
++} // namespace host_power
+diff --git a/cmos-reset/host_power.hpp b/cmos-reset/host_power.hpp
+new file mode 100644
+index 0000000..5d84149
+--- /dev/null
++++ b/cmos-reset/host_power.hpp
+@@ -0,0 +1,45 @@
++#pragma once
++
++#include "config.h"
++
++#include <sdbusplus/async.hpp>
++#include <sdbusplus/async/context.hpp>
++#include <xyz/openbmc_project/State/Host/client.hpp>
++
++namespace host_power
++{
++
++const auto stateOn =
++    sdbusplus::client::xyz::openbmc_project::state::Host<>::HostState::Running;
++const auto stateOff =
++    sdbusplus::client::xyz::openbmc_project::state::Host<>::HostState::Off;
++const auto transitionOn =
++    sdbusplus::client::xyz::openbmc_project::state::Host<>::Transition::On;
++const auto transitionOff =
++    sdbusplus::client::xyz::openbmc_project::state::Host<>::Transition::Off;
++
++using HostState =
++    sdbusplus::client::xyz::openbmc_project::state::Host<>::HostState;
++
++using StateIntf =
++    sdbusplus::client::xyz::openbmc_project::state::Host<void, void>;
++
++const auto host0ObjectPath = sdbusplus::client::xyz::openbmc_project::state::
++                                 Host<>::namespace_path::value +
++                             std::string("/host0");
++
++constexpr const char* hostStateService = "xyz.openbmc_project.State.Host0";
++
++class HostPower
++{
++  public:
++    // @param state   desired powerstate
++    // @returns       true on success
++    static sdbusplus::async::task<bool> setState(sdbusplus::async::context& ctx,
++                                                 HostState state);
++
++    // @returns       host powerstate
++    static sdbusplus::async::task<HostState> getState(
++        sdbusplus::async::context& ctx);
++};
++}; // namespace host_power
+diff --git a/meson.build b/meson.build
+index 1310b05..0c46879 100644
+--- a/meson.build
++++ b/meson.build
+@@ -20,7 +20,7 @@ cli11_dep = dependency(
+ )
+ i2c_dep = meson.get_compiler('cpp').find_library('i2c')
+ 
+-cmos_reset_srcs = files('cmos-reset/cmos_reset.cpp')
++cmos_reset_srcs = files('cmos-reset/cmos_reset.cpp', 'cmos-reset/host_power.cpp')
+ util_srcs = files('gpio.cpp', 'i2c.cpp', 'utilities.cpp')
+ 
+ platform_name = get_option('platform-name')
+@@ -105,6 +105,13 @@ configure_file(
+     configuration: conf,
+ )
+ 
++conf = configuration_data()
++conf.set(
++    'HOST_STATE_TRANSITION_TIMEOUT',
++    get_option('host-state-transition-timeout'),
++)
++configure_file(output: 'config.h', configuration: conf)
++
+ configure_file(
+     input: 'cmos-reset/xyz.openbmc_project.Software.Host.Updater0.service.in',
+     output: 'xyz.openbmc_project.Software.Host.Updater0.service',
+diff --git a/meson.options b/meson.options
+index 961234e..c0626b3 100644
+--- a/meson.options
++++ b/meson.options
+@@ -24,3 +24,10 @@ option(
+     value: 'disabled',
+     description: 'Enable CMOS reset service',
+ )
++
++option(
++    'host-state-transition-timeout',
++    type: 'integer',
++    value: 60,
++    description: 'Timeout for host state transition.',
++)
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0007-cmos-reset-Add-ActivationBlocksTransition.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0007-cmos-reset-Add-ActivationBlocksTransition.patch
@@ -1,0 +1,65 @@
+From 3221b323ba27d4008860142923611566b299c32a Mon Sep 17 00:00:00 2001
+From: Oliver Brewka <oliver.brewka@9elements.com>
+Date: Tue, 17 Mar 2026 18:16:09 +0100
+Subject: [PATCH 6/6] cmos-reset: Add ActivationBlocksTransition
+
+Analogous to a software update, add
+`xyz.openbmc_project.Software.ActionvationBlocksTransition` to the
+service before any reset. Remove the interface afterwards.
+
+Tested: Build an image and run it in qemu with a sleep of 25 seconds to
+increase the capture time for the interface added event.
+
+Observe the interface gets added before the reset, and verify it gets
+removed after the reset.
+
+Upstream-Status: Submitted [Gerrit, https://gerrit.openbmc.org/c/openbmc/platform-init/+/88395/15]
+Change-Id: I3e37f349c90d24ec18d3176a7c4fb628a6f2a947
+Signed-off-by: Oliver Brewka <oliver.brewka@9elements.com>
+---
+ cmos-reset/cmos_reset.cpp | 15 +++++++++++----
+ cmos-reset/cmos_reset.hpp |  1 +
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/cmos-reset/cmos_reset.cpp b/cmos-reset/cmos_reset.cpp
+index 8050ff9..af8eccc 100644
+--- a/cmos-reset/cmos_reset.cpp
++++ b/cmos-reset/cmos_reset.cpp
+@@ -70,11 +70,18 @@ sdbusplus::async::task<bool> CmosReset::doReset()
+         restorePowerState = true;
+     }
+ 
+-    bool success = co_await resetMethod(ctx);
+-    if (!success)
+     {
+-        error("CMOS reset failed");
+-        co_return false;
++        auto abt = sdbusplus::aserver::xyz::openbmc_project::software::
++            ActivationBlocksTransition<CmosReset, void>(ctx, softwarePath);
++
++        abt.emit_added();
++
++        bool success = co_await resetMethod(ctx);
++        if (!success)
++        {
++            error("CMOS reset failed");
++            co_return false;
++        }
+     }
+ 
+     if (restorePowerState)
+diff --git a/cmos-reset/cmos_reset.hpp b/cmos-reset/cmos_reset.hpp
+index 23afc3b..b21c7e7 100644
+--- a/cmos-reset/cmos_reset.hpp
++++ b/cmos-reset/cmos_reset.hpp
+@@ -4,6 +4,7 @@
+ #include <sdbusplus/bus.hpp>
+ #include <xyz/openbmc_project/Common/FactoryReset/aserver.hpp>
+ #include <xyz/openbmc_project/Common/FactoryReset/event.hpp>
++#include <xyz/openbmc_project/Software/ActivationBlocksTransition/aserver.hpp>
+ 
+ namespace cmos
+ {
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0008-Add-HPE-GXP.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init/0008-Add-HPE-GXP.patch
@@ -1,0 +1,218 @@
+From c45ac635413d63384ddb47fad88c08e1bc506334 Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Thu, 23 Jul 2026 17:45:50 +0200
+Subject: [PATCH] Add HPE GXP
+
+Add the minimum requirement for HPE GXP Platform Init and full support
+for CMOS reset.
+
+Tested: Code compiles and CMOS reset works
+
+Upstream-Status: Pending
+Change-Id: I59dfb0491102468af8cbad22c80f544f366d0c57
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ hpe/gxp.cpp     | 116 ++++++++++++++++++++++++++++++++++++++++++++++++
+ hpe/hpe.hpp     |  15 +++++++
+ meson.build     |   7 ++-
+ meson.options   |   1 +
+ platform.hpp.in |   1 +
+ 5 files changed, 139 insertions(+), 1 deletion(-)
+ create mode 100644 hpe/gxp.cpp
+ create mode 100644 hpe/hpe.hpp
+
+diff --git a/hpe/gxp.cpp b/hpe/gxp.cpp
+new file mode 100644
+index 0000000..af9bcf9
+--- /dev/null
++++ b/hpe/gxp.cpp
+@@ -0,0 +1,116 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: Copyright OpenBMC Authors
++
++#include "hpe.hpp"
++#include "utilities.hpp"
++
++#include <systemd/sd-daemon.h>
++
++#include <sdbusplus/asio/connection.hpp>
++
++#include <chrono>
++#include <filesystem>
++#include <format>
++#include <fstream>
++#include <iostream>
++#include <string_view>
++
++namespace hpe
++{
++
++constexpr const auto nvramPath = "/dev/mtd/host-reserved";
++constexpr const auto chifEvsPath = "/var/lib/chif/evs.dat";
++constexpr const auto chifSvc = "xyz.openbmc_project.GxpChif.service";
++
++constexpr const auto systemdService = "org.freedesktop.systemd1";
++constexpr const auto systemdObjPath = "/org/freedesktop/systemd1";
++constexpr const auto systemdManagerInterface =
++    "org.freedesktop.systemd1.Manager";
++
++bool restartUnit(sdbusplus::bus_t& bus, const std::string& unit)
++{
++    lg2::info("Restarting {UNIT}", "UNIT", unit);
++
++    auto method = bus.new_method_call(systemdService, systemdObjPath,
++                                      systemdManagerInterface, "RestartUnit");
++
++    method.append(unit);
++    method.append("replace");
++
++    try
++    {
++        bus.call_noreply(method);
++    }
++    catch (const sdbusplus::exception_t& e)
++    {
++        lg2::error("Failed to restart unit {UNIT}, exception: {ERR}", "UNIT",
++                   unit, "ERR", e);
++        return false;
++    }
++
++    return true;
++}
++
++int logged_system(std::string_view cmd)
++{
++    lg2::info("calling {CMD}", "CMD", cmd);
++    int rc = std::system(cmd.data());
++    return rc;
++}
++
++sdbusplus::async::task<bool> gxp_cmos_reset(
++    [[maybe_unused]] sdbusplus::async::context& ctx)
++{
++    auto bus = sdbusplus::bus::new_default_system();
++
++    lg2::info("CMOS reset triggered");
++    wait_for_path_to_exist(nvramPath, std::chrono::seconds(10));
++
++    int rc = logged_system(std::format("flash_eraseall {}", nvramPath));
++
++    if (rc < 0)
++    {
++        lg2::error("NVRAM erase failed with {ERR}", "ERR", rc);
++        co_return false;
++    }
++
++    try
++    {
++        if (std::filesystem::remove(chifEvsPath))
++        {
++            lg2::info("EV storage cleared");
++        }
++        else
++        {
++            lg2::warning("EV storage not found. Maybe removed?");
++        }
++    }
++    catch (const std::filesystem::filesystem_error& err)
++    {
++        lg2::error("Error clearing EV storage: {ERR}", "ERR", err.what());
++        co_return false;
++    }
++
++    if (!restartUnit(bus, chifSvc))
++    {
++        co_return false;
++    }
++
++    co_return true;
++}
++
++int init_gxp_base()
++{
++    lg2::info("GXP platform init");
++
++    int notify_rc = sd_notify(0, "READY=1\nSTATUS=GXP init complete");
++
++    if (notify_rc < 0)
++    {
++        lg2::error("sd_notify READY=1 failed: {RC}", "RC", notify_rc);
++        return EXIT_FAILURE;
++    }
++
++    return EXIT_SUCCESS;
++}
++} // namespace hpe
+diff --git a/hpe/hpe.hpp b/hpe/hpe.hpp
+new file mode 100644
+index 0000000..28fd716
+--- /dev/null
++++ b/hpe/hpe.hpp
+@@ -0,0 +1,15 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: Copyright OpenBMC Authors
++
++#pragma once
++
++#include <phosphor-logging/lg2.hpp>
++#include <sdbusplus/async.hpp>
++
++namespace hpe
++{
++
++int init_gxp_base();
++sdbusplus::async::task<bool> gxp_cmos_reset(sdbusplus::async::context&);
++
++} // namespace hpe
+diff --git a/meson.build b/meson.build
+index 0c46879..9945dfb 100644
+--- a/meson.build
++++ b/meson.build
+@@ -34,6 +34,11 @@ if platform_name not in platforms
+ endif
+ 
+ platforms_map = {
++    'hpe-gxp': {
++        'src': files('hpe/gxp.cpp'),
++        'fn': 'hpe::init_gxp_base',
++        'cmos_reset_fn': 'hpe::gxp_cmos_reset',
++    },
+     'intel-acrp': {'src': files('intel/acrp.cpp'), 'fn': 'intel::init_acrp'},
+     'intel-jcrp': {'src': files('intel/jcrp.cpp'), 'fn': 'intel::init_jcrp'},
+     'nvidia-gb200': {
+@@ -79,7 +84,7 @@ exe = executable(
+         phosphor_logging_dep,
+         phosphor_dbus_interfaces_dep,
+     ],
+-    include_directories: ['.', 'cmos-reset', 'intel', 'nvidia'],
++    include_directories: ['.', 'cmos-reset', 'hpe', 'intel', 'nvidia'],
+     install: true,
+     install_dir: get_option('libexecdir'),
+ )
+diff --git a/meson.options b/meson.options
+index c0626b3..e673c62 100644
+--- a/meson.options
++++ b/meson.options
+@@ -4,6 +4,7 @@ option(
+     choices: [
+         'intel-acrp',
+         'intel-jcrp',
++        'hpe-gxp',
+         'nvidia-gb200',
+         'nvidia-gb200-with-p2020',
+         'nvidia-nvl32',
+diff --git a/platform.hpp.in b/platform.hpp.in
+index 8963825..81cd448 100644
+--- a/platform.hpp.in
++++ b/platform.hpp.in
+@@ -3,6 +3,7 @@
+ 
+ #pragma once
+ 
++#include "hpe.hpp"
+ #include "intel.hpp"
+ #include "nvidia.hpp"
+ 
+-- 
+2.53.0
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init_%.bbappend
@@ -2,4 +2,21 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = " \
         file://0001-build-allow-compiling-selected-platforms-only.patch \
+        file://0002-Use-CLI11-callback-function-for-init-sub.patch \
+        file://0003-Add-phosphor-logging-and-PDI-deps.patch \
+        file://0004-cmos-reset-Add-cmos-reset-service.patch \
+        file://0005-cmos-reset-Add-event-logs.patch \
+        file://0006-cmos-reset-Add-power-control-capabilities.patch \
+        file://0007-cmos-reset-Add-ActivationBlocksTransition.patch \
         "
+
+EXTRA_OEMESON:append = " \
+        -Dcmos-reset=enabled \
+        "
+
+DEPENDS:append = " \
+        phosphor-dbus-interfaces \
+        phosphor-logging \
+        "
+
+SYSTEMD_SERVICE:${PN}:append = " xyz.openbmc_project.Software.Host.Updater0.service "

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+        file://0001-build-allow-compiling-selected-platforms-only.patch \
+        "

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/platform/platform-init_%.bbappend
@@ -8,9 +8,12 @@ SRC_URI:append = " \
         file://0005-cmos-reset-Add-event-logs.patch \
         file://0006-cmos-reset-Add-power-control-capabilities.patch \
         file://0007-cmos-reset-Add-ActivationBlocksTransition.patch \
+        file://0008-Add-HPE-GXP.patch \
         "
 
 EXTRA_OEMESON:append = " \
+        -Dplatforms=hpe-gxp \
+        -Dplatform-name=hpe-gxp \
         -Dcmos-reset=enabled \
         "
 

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-hpe_git.bb
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-hpe_git.bb
@@ -117,4 +117,5 @@ SRC_URI:append = " \
     file://0086-misc-ubm-add-minimal-UBM-backplane-init-driver.patch \
     file://0087-ARM-dts-hpe-gxp-enable-ramoops.patch \
     file://0088-soc-hpe-gxp-chif-expose-poll-on-char-device.patch \
+    file://0089-ARM-dts-hpe-gxp-add-nvram-partitions.patch \
     "

--- a/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable-6.18/0089-ARM-dts-hpe-gxp-add-nvram-partitions.patch
+++ b/meta-canopy/meta-hpe/meta-gxp/recipes-kernel/linux/linux-stable-6.18/0089-ARM-dts-hpe-gxp-add-nvram-partitions.patch
@@ -1,0 +1,47 @@
+From 2187a85db03cdebeb20fc935df5fef1751db2500 Mon Sep 17 00:00:00 2001
+From: Tan Siewert <tan.siewert@9elements.com>
+Date: Fri, 24 Jul 2026 01:33:41 +0200
+Subject: [PATCH] ARM: dts: hpe: gxp: add nvram partitions
+
+Add the memory-mapped host NVRAM partitions. The register and offsets
+were extracted from the vendor device-tree that is available in the HPE
+tarball.
+
+Signed-off-by: Tan Siewert <tan.siewert@9elements.com>
+---
+ arch/arm/boot/dts/hpe/hpe-gxp.dts | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/arch/arm/boot/dts/hpe/hpe-gxp.dts b/arch/arm/boot/dts/hpe/hpe-gxp.dts
+index 0646d3bf6e63..501cecfc1859 100644
+--- a/arch/arm/boot/dts/hpe/hpe-gxp.dts
++++ b/arch/arm/boot/dts/hpe/hpe-gxp.dts
+@@ -572,6 +572,25 @@ coretemp: coretemp@c0000130 {
+ 			reg = <0xc0000130 0x8>;
+ 		};
+ 
++		sram: sram@d0000000 {
++			compatible = "mtd-ram";
++			reg = <0xd0000000 0x80000>;
++			bank-width = <1>;
++			erase-size = <1>;
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "host-reserved";
++				reg = <0x0 0x10000>;
++			};
++
++			partition@10000 {
++				label = "nvram";
++				reg = <0x10000 0x70000>;
++			};
++		};
++
+ 		fan-keys {
+ 		compatible = "gpio-keys-polled";
+ 		poll-interval = <1000>;
+-- 
+2.54.0
+


### PR DESCRIPTION
This PR consists of multiple commits, but in summary they address:

- Backporting the pending `cmos-reset` topic to `platform-init` and `bmcweb`, so that we can actually reset the BIOS NVRAM.
- Bringing up `platform-init` on the HPE GXP platforms with NVRAM reset support (erases `/dev/mtd/host-reserved`, which holds both the NVRAM and the BIOS EVs, and also clears the EV storage in `/var/lib/chif/evs.dat`)
- Adding the memory-mapped host NVRAM partition (`host-reserved`) to the GXP device tree (needed before any of the NVRAM reset stuff works)
- FWCI: Reset the NVRAM before the first boot for a clean state on certain tests (doing it for every test would increase the CI time too much)

