### PR TITLE
refactor: use canonical dutctl teststep name

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/post.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/post.yaml
@@ -1,6 +1,6 @@
 # Example Post-Stage for a device
 post-stage:
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Power off DUT
     parameters:
       agent: "[[attributes.Agent]]"

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -1,5 +1,5 @@
 pre-stage:
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Power off DUT
     parameters:
       agent: "[[attributes.Agent]]"
@@ -7,7 +7,7 @@ pre-stage:
       command: power
       args: ["off"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Emulate Flash
     parameters:
       agent: "[[attributes.Agent]]"
@@ -15,7 +15,7 @@ pre-stage:
       command: emulate-bmc
       args: ["[[input.firmware]]"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Power on DUT
     parameters:
       agent: "[[attributes.Agent]]"
@@ -23,7 +23,7 @@ pre-stage:
       command: power
       args: ["on"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Wait for boot banner on serial
     options:
       timeout: 10m

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
@@ -5,7 +5,7 @@ description: >-
   within 25s after that. Baseline: 74s to banner, 19s to SSH (5-run avg).
 
 pre-stage:
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Power off DUT
     parameters:
       agent: "[[attributes.Agent]]"
@@ -13,7 +13,7 @@ pre-stage:
       command: power
       args: ["off"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Emulate Flash
     parameters:
       agent: "[[attributes.Agent]]"
@@ -21,7 +21,7 @@ pre-stage:
       command: emulate-bmc
       args: ["[[input.firmware]]"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Power on DUT
     parameters:
       agent: "[[attributes.Agent]]"
@@ -29,7 +29,7 @@ pre-stage:
       command: power
       args: ["on"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Boot banner within 80s
     options:
       timeout: 80s

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
@@ -1,7 +1,7 @@
 name: "User: Persistence Across Reboot"
 description: >-
   Verify user accounts persist across BMC power cycle. Creates a user,
-  verifies it exists, power cycles the BMC via newdutctl, then verifies
+  verifies it exists, power cycles the BMC via dutctl, then verifies
   the user still exists and can authenticate after reboot.
 
 defaults:
@@ -72,7 +72,7 @@ stages:
 
   - name: BMC Power Cycle
     steps:
-      - cmd: newdutctl
+      - cmd: dutctl
         name: Power off DUT
         parameters:
           agent: "[[attributes.Agent]]"
@@ -85,14 +85,14 @@ stages:
         parameters:
           executable: sleep
           args: ["10"]
-      - cmd: newdutctl
+      - cmd: dutctl
         name: Power on DUT
         parameters:
           agent: "[[attributes.Agent]]"
           device: "[[attributes.Device]]"
           command: power
           args: ["on"]
-      - cmd: newdutctl
+      - cmd: dutctl
         name: Wait for boot banner on serial
         options:
           timeout: 10m

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
@@ -15,7 +15,7 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 pre-stage:
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Power off DUT
     parameters:
       agent: "[[attributes.Agent]]"
@@ -23,7 +23,7 @@ pre-stage:
       command: power
       args: ["off"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Emulate Flash
     parameters:
       agent: "[[attributes.Agent]]"
@@ -31,7 +31,7 @@ pre-stage:
       command: emulate-bmc
       args: ["[[input.firmware]]"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Power on DUT
     parameters:
       agent: "[[attributes.Agent]]"
@@ -39,7 +39,7 @@ pre-stage:
       command: power
       args: ["on"]
 
-  - cmd: newdutctl
+  - cmd: dutctl
     name: Wait for boot banner on serial
     options:
       timeout: 10m


### PR DESCRIPTION
Switch the teststep cmd from the deprecated "newdutctl" alias to its canonical name "dutctl". Server accepts both; params unchanged.