### PR TITLE
FWCI Cleanup for HPE ProLiant DL320 Gen11

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/post.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/post.yaml
@@ -1,5 +1,17 @@
-# Example Post-Stage for a device
 post-stage:
+  # Allowed to fail
+  - cmd: shell
+    name: Power off host via Redfish
+    transport:
+      proto: local
+    parameters:
+      command: >-
+        curl -sk -u root:[[attributes.BMCPassword]]
+        -X POST -H 'Content-Type: application/json'
+        -d '{"ResetType":"ForceOff"}'
+        -o /dev/null -w '%{http_code}'
+        https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset || true
+
   - cmd: dutctl
     name: Power off DUT
     parameters:

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -32,3 +32,20 @@ pre-stage:
       device: "[[attributes.Device]]"
       command: serial
       args: ["expect", "Phosphor OpenBMC"]
+
+  - cmd: ping
+    name: Wait for SSH
+    options:
+      timeout: 5m
+    parameters:
+      host: "[[attributes.BMC]]"
+
+  - cmd: cmd
+    name: Wait for BMC services
+    transport: &local
+      proto: local
+    options:
+      timeout: 2m
+    parameters:
+      executable: sleep
+      args: ["45"]

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
@@ -21,20 +21,6 @@ defaults:
 stages:
   - name: Wait for BMC and Power On Host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for BMC services
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: shell
         name: Power on host via Redfish
         transport: &local

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
@@ -52,7 +52,7 @@ stages:
         name: Wait for SMBIOS transfer (host POST complete)
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||
@@ -99,7 +99,7 @@ stages:
         name: Wait for second POST (SMBIOS transfer)
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
@@ -53,7 +53,7 @@ stages:
         name: Wait for first POST (SMBIOS transfer)
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||
@@ -100,7 +100,7 @@ stages:
         name: Wait for second POST (SMBIOS transfer)
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/chif-proxy.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/chif-proxy.yaml
@@ -15,15 +15,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: CHIF Service Startup
     steps:
       - cmd: cmd

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/dbus-registrations.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/dbus-registrations.yaml
@@ -12,23 +12,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: D-Bus Services Registered
     on-error: continue
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
@@ -42,7 +42,7 @@ stages:
             user: "root"
             password: "[[attributes.BMCPassword]]"
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
@@ -9,22 +9,8 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Power on host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for BMC services
-        transport: *local
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: cmd
         name: Power on host via Redfish
         transport: *local

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-processor.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-processor.yaml
@@ -9,22 +9,8 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Power on host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for BMC services
-        transport: *local
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: shell
         name: Power on host via Redfish
         transport: *local

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-processor.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-processor.yaml
@@ -46,7 +46,7 @@ stages:
             user: "root"
             password: "[[attributes.BMCPassword]]"
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-psu.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-psu.yaml
@@ -10,22 +10,8 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Power On host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *local
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: cmd
         name: Power on host via Redfish
         transport: *local

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-sensors.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-sensors.yaml
@@ -10,27 +10,8 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Power On host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: &bmc_ssh
-          proto: ssh
-          options:
-            host: "[[attributes.BMC]]"
-            user: "root"
-            password: "[[attributes.BMCPassword]]"
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: cmd
         name: Power on host via Redfish
         transport: *local

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-system-identity.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-system-identity.yaml
@@ -48,7 +48,7 @@ stages:
             user: "root"
             password: "[[attributes.BMCPassword]]"
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-system-identity.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-system-identity.yaml
@@ -14,22 +14,8 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Power On host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for BMC services
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: cmd
         name: Power on host via Redfish
         transport: &local

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/kvm-kernel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/kvm-kernel.yaml
@@ -14,23 +14,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: Video Device
     steps:
       - cmd: cmd

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/kvm-services.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/kvm-services.yaml
@@ -15,23 +15,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: Service Status
     steps:
       - cmd: cmd

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/network-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/network-config.yaml
@@ -12,23 +12,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: Network D-Bus State
     steps:
       - cmd: cmd

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/network-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/network-config.yaml
@@ -91,7 +91,7 @@ stages:
         name: Wait for SMBIOS transfer (host POST complete)
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
@@ -52,7 +52,7 @@ stages:
         name: Wait for SMBIOS transfer
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||
@@ -205,7 +205,7 @@ stages:
         name: Wait for SMBIOS transfer
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/power-control.yaml
@@ -15,29 +15,12 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for BMC services
-        transport: &local
-          proto: local
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: Power On Host
     steps:
       - cmd: shell
         name: Send Power On via Redfish
-        transport: *local
+        transport: &local
+          proto: local
         parameters:
           command: >-
             curl -sk -u root:[[attributes.BMCPassword]]

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/service-failures.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/service-failures.yaml
@@ -12,23 +12,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: No Unexpected Failures
     steps:
       - cmd: cmd

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/service-health.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/service-health.yaml
@@ -12,23 +12,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: Critical Services Running
     on-error: continue
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/01-service-health.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/01-service-health.yaml
@@ -12,15 +12,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Critical Services Running
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/02-app-global.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/02-app-global.yaml
@@ -15,15 +15,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Get Device ID
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/03-app-watchdog.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/03-app-watchdog.yaml
@@ -10,15 +10,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Get Watchdog Timer
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
@@ -13,15 +13,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: BMC Global Enables
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
@@ -12,15 +12,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Get Chassis Capabilities
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
@@ -10,15 +10,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Sensor Commands
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/07-fru.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/07-fru.yaml
@@ -14,15 +14,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: FRU Inventory Area Info
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/08-sdr.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/08-sdr.yaml
@@ -11,15 +11,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Get SDR Repository Info
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/09-sel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/09-sel.yaml
@@ -12,15 +12,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Get SEL Info
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/10-lan.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/10-lan.yaml
@@ -11,15 +11,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: LAN Configuration - IP and Network
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/11-dcmi.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/11-dcmi.yaml
@@ -11,15 +11,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: DCMI Capability Info
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
@@ -12,15 +12,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Create User
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/13-chassis-power-cycle.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/13-chassis-power-cycle.yaml
@@ -10,15 +10,6 @@ defaults:
     proto: local
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for IPMI LAN
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Pre-condition Checks
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
@@ -16,15 +16,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-
   - name: Reboot Cycle 1
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/fan-control.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/fan-control.yaml
@@ -13,22 +13,8 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Power On host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: cmd
         name: Power on host via Redfish
         transport:

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/inventory-dbus.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/inventory-dbus.yaml
@@ -14,22 +14,8 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC and Power On Host
+  - name: Power On host
     steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for BMC services
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
       - cmd: cmd
         name: Power on host via Redfish
         transport:

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/inventory-dbus.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/inventory-dbus.yaml
@@ -43,7 +43,7 @@ stages:
         name: Wait for SMBIOS transfer
         transport: *bmc_ssh
         options:
-          timeout: 8m
+          timeout: 15m
         parameters:
           command: >-
             while [ ! -f /var/lib/smbios/smbios2 ] ||

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
@@ -13,23 +13,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: Create User Before Reboot
     steps:
       - cmd: cmd

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-console.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-console.yaml
@@ -14,23 +14,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: Console Server
     steps:
       - cmd: cmd

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-data-path.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-data-path.yaml
@@ -14,24 +14,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for BMC services
-        transport: &local
-          proto: local
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["45"]
-
   - name: VUART Kernel Driver
     steps:
       - cmd: cmd
@@ -79,7 +61,8 @@ stages:
     steps:
       - cmd: shell
         name: Send Power On via Redfish
-        transport: *local
+        transport: &local
+          proto: local
         parameters:
           command: >-
             curl -sk -u root:[[attributes.BMCPassword]]

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/vuart-kernel.yaml
@@ -14,59 +14,7 @@ defaults:
       user: "root"
       password: "[[attributes.BMCPassword]]"
 
-pre-stage:
-  - cmd: dutctl
-    name: Power off DUT
-    parameters:
-      agent: "[[attributes.Agent]]"
-      device: "[[attributes.Device]]"
-      command: power
-      args: ["off"]
-
-  - cmd: dutctl
-    name: Emulate Flash
-    parameters:
-      agent: "[[attributes.Agent]]"
-      device: "[[attributes.Device]]"
-      command: emulate-bmc
-      args: ["[[input.firmware]]"]
-
-  - cmd: dutctl
-    name: Power on DUT
-    parameters:
-      agent: "[[attributes.Agent]]"
-      device: "[[attributes.Device]]"
-      command: power
-      args: ["on"]
-
-  - cmd: dutctl
-    name: Wait for boot banner on serial
-    options:
-      timeout: 10m
-    parameters:
-      agent: "[[attributes.Agent]]"
-      device: "[[attributes.Device]]"
-      command: serial
-      args: ["expect", "Phosphor OpenBMC"]
-
 stages:
-  - name: Wait for BMC
-    steps:
-      - cmd: ping
-        name: Wait for SSH
-        options:
-          timeout: 5m
-        parameters:
-          host: "[[attributes.BMC]]"
-      - cmd: cmd
-        name: Wait for services to settle
-        transport: *bmc_ssh
-        options:
-          timeout: 2m
-        parameters:
-          executable: sleep
-          args: ["30"]
-
   - name: Device Node
     steps:
       - cmd: cmd


### PR DESCRIPTION
These commits were cherry-picked from #239 to split the amount of changes a bit more up (and to not mix-up the goal of each PR).

- The SMBIOS timeout must be increased to 15 minutes as the 8 minutes aren't enough after certain tests. 15 minutes should be plenty enough of time.
- Remove duplicate tasks to the pre-stage (DRY)
- Power off the system via Redfish before cutting the power, as the system would recover to the last power state otherwise.