### PR TITLE
meta-canopy: scripts: fix automatic version detection

### DIFF
--- a/meta-canopy/scripts/gen-hpe-bios-pldm
+++ b/meta-canopy/scripts/gen-hpe-bios-pldm
@@ -153,7 +153,7 @@ if [[ -n "$VERSION_OVERRIDE" ]]; then
 else
 	ROM_VER_X="$(rom_info_get "$INPUT" ROM_MAJOR_VER)"
 	ROM_VER_Y="$(rom_info_get "$INPUT" ROM_MINOR_VER)"
-	[ -n "$ROM_VER_X" || -n "$ROM_VER_Y" ]] || \
+	[[ -n "$ROM_VER_X" || -n "$ROM_VER_Y" ]] || \
 		die "Could not find [ROM_INFO]/ROM_VER_* in '$INPUT'. Use -v to specify version."
 	VERSION="$ROM_VER_X.$ROM_VER_Y"
 	echo "  Version:    $VERSION (auto-detected from ROM_INFO)"


### PR DESCRIPTION
just a small fix to make the automatic host firmware detection work in the PLDM generation script