### PR TITLE
HPE ProLiant Gen11: Fix PlatDef Multi-bundle parsing

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/xyz.openbmc_project.GxpChif.service
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/service_files/xyz.openbmc_project.GxpChif.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=GXP CHIF Service
-After=dbus.service dev-chif24.device
+After=dbus.service dev-chif24.device xyz.openbmc_project.EntityManager.service
+Wants=xyz.openbmc_project.EntityManager.service
 Requires=dbus.service
 BindsTo=dev-chif24.device
 

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/main.cpp
@@ -18,16 +18,37 @@
 
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
 
 #include <cerrno>
 #include <csignal>
 #include <cstring>
 #include <memory>
+#include <unordered_map>
+#include <utility>
 
 namespace
 {
 constexpr auto chifDevice = "/dev/chif24";
 constexpr auto dbusName = "xyz.openbmc_project.GxpChif";
+constexpr auto inventoryPathPrefix = "/xyz/openbmc_project/inventory/";
+
+std::unordered_map<uint8_t, int> loadSegmentBusMap(sdbusplus::bus_t& bus)
+{
+    auto platformId = chif::readPlatformId(bus);
+    if (!platformId)
+    {
+        return {};
+    }
+
+    auto platDefBlob = chif::extractPlatDef(platformId);
+    if (platDefBlob.empty())
+    {
+        return {};
+    }
+
+    return chif::buildSegmentBusMap(chif::parseI2cSegments(platDefBlob));
+}
 
 int onTerminate(sd_event_source* source, const struct signalfd_siginfo* /*si*/,
                 void* /*userdata*/)
@@ -112,20 +133,34 @@ int main()
     chif::BootService bootService(bus, evStorage);
     chif::BiosConfigService biosConfigService(bus, evStorage);
 
-    // Extract PlatDef from host BIOS SPI flash and build I2C segment→bus map
-    auto platDefBlob = chif::extractPlatDef();
-    auto segmentBusMap =
-        platDefBlob.empty()
-            ? std::unordered_map<uint8_t, int>{}
-            : chif::buildSegmentBusMap(chif::parseI2cSegments(platDefBlob));
-
     // Build daemon and register handlers
     chif::ChifDaemon daemon(std::move(channel));
     daemon.registerHandler(
         std::make_unique<chif::RomService>(smbiosWriter, &mdrBridge));
-    daemon.registerHandler(std::make_unique<chif::SmifService>(
-        &bus, &evStorage, std::move(segmentBusMap)));
+    auto segmentBusMap = loadSegmentBusMap(bus);
+    bool segmentMapLoaded = !segmentBusMap.empty();
+    auto smifService = std::make_unique<chif::SmifService>(
+        &bus, &evStorage, std::move(segmentBusMap));
+    auto* smif = smifService.get();
+    daemon.registerHandler(std::move(smifService));
     daemon.registerHandler(std::make_unique<chif::HealthService>());
+
+    sdbusplus::bus::match_t inventoryMatch(
+        bus,
+        sdbusplus::bus::match::rules::interfacesAdded() +
+            sdbusplus::bus::match::rules::argNpath(0, inventoryPathPrefix),
+        [&bus, smif, &segmentMapLoaded](sdbusplus::message_t&) {
+            if (segmentMapLoaded)
+            {
+                return;
+            }
+            auto map = loadSegmentBusMap(bus);
+            if (!map.empty())
+            {
+                smif->setSegmentBusMap(std::move(map));
+                segmentMapLoaded = true;
+            }
+        });
 
     sigset_t ss;
     sigemptyset(&ss);

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
@@ -9,29 +9,42 @@
 #include "platdef_extract.hpp"
 
 #include "uefi_fv.hpp"
-
-#include <phosphor-logging/lg2.hpp>
+#include "utils.hpp"
 
 #include <zlib.h>
 
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Board/Motherboard/common.hpp>
+
+#include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
+#include <optional>
+#include <ranges>
+#include <span>
 #include <string>
 #include <string_view>
 
 namespace chif
 {
 
+static constexpr std::string_view bundleSignature = "$PlatdefBundle1$";
+
+using Motherboard = sdbusplus::common::xyz::openbmc_project::inventory::item::
+    board::Motherboard;
+
+static constexpr auto inventoryPath = "/xyz/openbmc_project/inventory";
+static constexpr auto productIdProperty = "ProductId";
+
 // PlatDef bundle and record structures (from HPE openbmc-chif-svc platdef.h)
 #pragma pack(push, 1)
 
-// From HPE upstream platdef.h
-#define PLATDEF_BUNDLE_SIGNATURE "$PlatdefBundle1$"
-
 struct PlatDefBundleHeader
 {
-    char signature[16]; // PLATDEF_BUNDLE_SIGNATURE
+    char signature[16]; // bundleSignature
     uint32_t totalSize;
     uint16_t flags;
     uint8_t headerLength;
@@ -128,8 +141,7 @@ static_assert(sizeof(PlatDefTableData) == 112,
               "PlatDefTableData must be 112 bytes");
 static_assert(sizeof(PlatDefI2CSegment) == 32,
               "PlatDefI2CSegment must be 32 bytes");
-static_assert(sizeof(PlatDefI2CMux) == 16,
-              "PlatDefI2CMux must be 16 bytes");
+static_assert(sizeof(PlatDefI2CMux) == 16, "PlatDefI2CMux must be 16 bytes");
 static_assert(sizeof(PlatDefI2CEngineFixed) == 48,
               "PlatDefI2CEngineFixed must be 48 bytes");
 
@@ -171,40 +183,98 @@ static std::string findMtdByLabel(const std::string& label)
     return {};
 }
 
-// Decompress the PlatDef blob from the raw APML file.
-// Layout: [PlatDefBundleHeader][PlatDefTableData][zlib compressed records...]
-// Returns: [PlatDefTableData header][decompressed records]
-static std::vector<uint8_t> decompressPlatDef(const std::vector<uint8_t>& raw)
+// Locate the PlatDefTableData block that applies to the running platform.
+//
+// A single-platform APML file is just [PlatDefTableData][records...]. A bundled
+// one is a sequence of [PlatDefBundleHeader][PlatDefTableData][records...]
+// blocks, each header listing the platform IDs (CPLD board IDs) it covers and
+// terminated by an end marker, i.e. anything that is not a valid header.
+//
+// Returns the table data of the matching block, or an empty span.
+std::span<const uint8_t> selectPlatDefBundle(std::span<const uint8_t> raw,
+                                             std::optional<uint16_t> platformId)
 {
-    // The APML file starts with a PlatDefBundleHeader followed by
-    // a PlatDefTableData record. HPE skips the bundle header to reach
-    // the table data.
-    if (raw.size() < sizeof(PlatDefBundleHeader))
+    auto isBundle = [](std::span<const uint8_t> blob) {
+        return blob.size() >= sizeof(PlatDefBundleHeader) &&
+               std::memcmp(blob.data(), bundleSignature.data(),
+                           bundleSignature.size()) == 0;
+    };
+
+    if (!isBundle(raw))
     {
-        lg2::error("PlatDef: blob too small for bundle header");
-        return {};
+        return raw;
     }
 
-    if (std::memcmp(raw.data(), PLATDEF_BUNDLE_SIGNATURE,
-                    sizeof(PLATDEF_BUNDLE_SIGNATURE) - 1) != 0)
+    for (size_t offset = 0; isBundle(raw.subspan(offset));)
     {
-        lg2::error("PlatDef: invalid bundle signature");
-        return {};
+        const auto* bundle =
+            reinterpret_cast<const PlatDefBundleHeader*>(raw.data() + offset);
+
+        size_t headerBytes = static_cast<size_t>(bundle->headerLength) * 16;
+        size_t totalSize = bundle->totalSize;
+        size_t bundleSize =
+            sizeof(PlatDefBundleHeader) + bundle->count * sizeof(uint16_t);
+
+        if ((headerBytes < bundleSize) || (totalSize <= headerBytes) ||
+            (offset + totalSize > raw.size()))
+        {
+            lg2::error("PlatDef: malformed bundle header at {OFF} "
+                       "(headerLength={HLEN}, count={CNT}, totalSize={TSZ})",
+                       "OFF", lg2::hex, offset, "HLEN", bundle->headerLength,
+                       "CNT", bundle->count, "TSZ", totalSize);
+            return {};
+        }
+
+        std::span<const uint16_t> ids(
+            reinterpret_cast<const uint16_t*>(
+                raw.data() + offset + sizeof(PlatDefBundleHeader)),
+            bundle->count);
+
+        // Without a platform ID the only safe choice is a bundle that is the
+        // sole one in the blob, i.e. built for a single platform.
+        bool match =
+            platformId
+                ? std::ranges::find(ids, *platformId) != ids.end()
+                : offset == 0 && !isBundle(raw.subspan(offset + totalSize));
+
+        if (match)
+        {
+            lg2::info("PlatDef: using bundle at {OFF}, first {PID}", "OFF",
+                      lg2::hex, offset, "PID", lg2::hex,
+                      ids.empty() ? 0 : ids.front());
+            return raw.subspan(offset + headerBytes, totalSize - headerBytes);
+        }
+
+        offset += totalSize;
     }
 
-    size_t offset = sizeof(PlatDefBundleHeader);
+    if (platformId)
+    {
+        lg2::error("PlatDef: no bundle covers platform {PID}", "PID", lg2::hex,
+                   *platformId);
+    }
+    else
+    {
+        lg2::error("PlatDef: multi-platform bundle but no platform ID known");
+    }
+    return {};
+}
 
-    if (offset + sizeof(PlatDefTableData) > raw.size())
+// Decompress a PlatDef table data block.
+// Layout: [PlatDefTableData][zlib compressed records...]
+// Returns: [PlatDefTableData header][decompressed records]
+static std::vector<uint8_t> decompressPlatDef(std::span<const uint8_t> raw)
+{
+    if (raw.size() < sizeof(PlatDefTableData))
     {
         lg2::error("PlatDef: blob too small for table data header");
         return {};
     }
 
     PlatDefTableData tableHdr{};
-    std::memcpy(&tableHdr, raw.data() + offset, sizeof(tableHdr));
+    std::memcpy(&tableHdr, raw.data(), sizeof(tableHdr));
 
-    std::string_view desc(tableHdr.description,
-                          sizeof(tableHdr.description));
+    std::string_view desc(tableHdr.description, sizeof(tableHdr.description));
     if (auto nul = desc.find('\0'); nul != std::string_view::npos)
     {
         desc = desc.substr(0, nul);
@@ -221,11 +291,11 @@ static std::vector<uint8_t> decompressPlatDef(const std::vector<uint8_t>& raw)
     if (!(tableHdr.flags & tableDataFlagZLib))
     {
         lg2::info("PlatDef: not compressed, returning raw records");
-        return std::vector<uint8_t>(raw.begin() + offset, raw.end());
+        return std::vector<uint8_t>(raw.begin(), raw.end());
     }
 
     // Compressed: zlib data starts after the PlatDefTableData header
-    size_t compOffset = offset + sizeof(PlatDefTableData);
+    size_t compOffset = sizeof(PlatDefTableData);
     if (tableHdr.compressedSize < sizeof(PlatDefTableData))
     {
         lg2::error("PlatDef: invalid compressedSize {SZ}",
@@ -276,7 +346,50 @@ static constexpr EfiGuid apmlFileGuid = {
     0xC5F6001C, 0x39B4, 0x43DD,
     {0x9B, 0x9B, 0x68, 0x32, 0xF1, 0xBB, 0x4B, 0xE9}};
 
-std::vector<uint8_t> extractPlatDef()
+std::optional<uint16_t> readPlatformId(sdbusplus::bus_t& bus)
+{
+    auto subtree = getSubtree(bus, inventoryPath, 0, {Motherboard::interface});
+    if (subtree.empty())
+    {
+        lg2::warning("PlatDef: no motherboard inventory object below {PATH}",
+                     "PATH", inventoryPath);
+        return std::nullopt;
+    }
+
+    for (const auto& [path, services] : subtree)
+    {
+        for (const auto& service : std::views::keys(services))
+        {
+            auto value = getProperty<uint64_t>(
+                bus, service.c_str(), path.c_str(), Motherboard::interface,
+                productIdProperty);
+            if (!value)
+            {
+                continue;
+            }
+
+            if (*value > std::numeric_limits<uint16_t>::max())
+            {
+                lg2::warning("PlatDef: {PROP} {VAL} on {PATH} is not a "
+                             "12-bit platform ID",
+                             "PROP", productIdProperty, "VAL", *value, "PATH",
+                             path);
+                continue;
+            }
+
+            auto id = static_cast<uint16_t>(*value);
+            lg2::info("PlatDef: platform ID {PID} from {PATH}", "PID", lg2::hex,
+                      id, "PATH", path);
+            return id;
+        }
+    }
+
+    lg2::warning("PlatDef: {PROP} not readable on any motherboard object",
+                 "PROP", productIdProperty);
+    return std::nullopt;
+}
+
+std::vector<uint8_t> extractPlatDef(std::optional<uint16_t> platformId)
 {
     std::string mtdPath = findMtdByLabel("host-prime");
     if (mtdPath.empty())
@@ -310,7 +423,13 @@ std::vector<uint8_t> extractPlatDef()
         return {};
     }
 
-    return decompressPlatDef(raw);
+    auto tableData = selectPlatDefBundle(raw, platformId);
+    if (tableData.empty())
+    {
+        return {};
+    }
+
+    return decompressPlatDef(tableData);
 }
 
 // ---------------------------------------------------------------------------

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.cpp
@@ -36,7 +36,7 @@ struct PlatDefBundleHeader
     uint16_t flags;
     uint8_t headerLength;
     uint8_t count;
-    uint8_t reserved[8];
+    // Platform IDs are handled separately.
 };
 
 struct PlatDefRecordHeader
@@ -120,8 +120,8 @@ struct PlatDefI2CEngineFixed
 
 #pragma pack(pop)
 
-static_assert(sizeof(PlatDefBundleHeader) == 32,
-              "PlatDefBundleHeader must be 32 bytes");
+static_assert(sizeof(PlatDefBundleHeader) == 24,
+              "PlatDefBundleHeader must be 24 bytes");
 static_assert(sizeof(PlatDefRecordHeader) == 32,
               "PlatDefRecordHeader must be 32 bytes (Gen11 layout)");
 static_assert(sizeof(PlatDefTableData) == 112,

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/platdef_extract.hpp
@@ -2,17 +2,33 @@
 // Copyright (C) 2026 9elements GmbH
 #pragma once
 
+#include <sdbusplus/bus.hpp>
+
 #include <cstdint>
+#include <optional>
+#include <span>
 #include <unordered_map>
 #include <vector>
 
 namespace chif
 {
 
+// Read the platform (CPLD board) ID from the ProductId property of the
+// motherboard inventory object. Returns nullopt if inventory is unavailable.
+std::optional<uint16_t> readPlatformId(sdbusplus::bus_t& bus);
+
 // Extract and decompress the APML PlatDef blob from the host BIOS SPI flash.
 // Searches the "host-prime" MTD partition for the APML firmware volume,
 // extracts and decompresses the records. Returns empty vector if not found.
-std::vector<uint8_t> extractPlatDef();
+[[nodiscard]] std::vector<uint8_t> extractPlatDef(
+    std::optional<uint16_t> platformId);
+
+// Locate the still-compressed PlatDefTableData block inside a raw APML blob.
+// An unbundled blob is returned as-is; a bundled one is walked for the block
+// covering platformId. Returns an empty span if no block matches or a bundle
+// header is malformed.
+[[nodiscard]] std::span<const uint8_t> selectPlatDefBundle(
+    std::span<const uint8_t> raw, std::optional<uint16_t> platformId);
 
 // I2C segment mapping: BIOS segment ID → CPLD register + channel value.
 // Populated from RecordType_I2CEngine (type 14) records in the PlatDef blob.

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.cpp
@@ -2,13 +2,13 @@
 // Copyright (C) 2026 9elements GmbH
 #include "smif_service.hpp"
 
-#include <phosphor-logging/lg2.hpp>
-
 #include <fcntl.h>
 #include <linux/i2c-dev.h>
 #include <linux/i2c.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+#include <phosphor-logging/lg2.hpp>
 
 #include <algorithm>
 #include <array>
@@ -85,8 +85,16 @@ SmifService::SmifService(sdbusplus::bus_t* bus, EvStorage* evStorage,
         lg2::warning("No model in device-tree, using fallback");
     }
 
-    lg2::info("Platform serial: {SN}, product ID: {PID}", "SN",
-              boardSerial_, "PID", productId_);
+    lg2::info("Platform serial: {SN}, product ID: {PID}", "SN", boardSerial_,
+              "PID", productId_);
+}
+
+void SmifService::setSegmentBusMap(
+    std::unordered_map<uint8_t, int> segmentBusMap)
+{
+    segmentToBus_ = std::move(segmentBusMap);
+    lg2::info("I2C proxy: {CNT} segment mappings installed", "CNT",
+              segmentToBus_.size());
 }
 
 // ---------------------------------------------------------------------------

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/smif_service.hpp
@@ -128,6 +128,8 @@ class SmifService : public ServiceHandler
         return smifServiceId;
     }
 
+    void setSegmentBusMap(std::unordered_map<uint8_t, int> segmentBusMap);
+
   private:
     // EV command handlers
     int handleGetEvByIndex(const ChifPktHeader& hdr,

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.cpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.cpp
@@ -4,11 +4,35 @@
 
 #include <arpa/inet.h>
 
+#include <xyz/openbmc_project/ObjectMapper/common.hpp>
+
 #include <algorithm>
 #include <charconv>
 
+using ObjectMapper = sdbusplus::common::xyz::openbmc_project::ObjectMapper;
+
 namespace chif
 {
+
+GetSubTreeResponse getSubtree(sdbusplus::bus_t& bus,
+                              const std::string& searchPath, int depth,
+                              const std::vector<std::string>& interfaces)
+{
+    try
+    {
+        auto m = bus.new_method_call(
+            ObjectMapper::default_service, ObjectMapper::instance_path,
+            ObjectMapper::interface, ObjectMapper::method_names::get_sub_tree);
+        m.append(searchPath, depth, interfaces);
+        GetSubTreeResponse response;
+        bus.call(m).read(response);
+        return response;
+    }
+    catch (const std::exception&)
+    {
+        return {};
+    }
+}
 
 std::optional<uint32_t> parseV4(const std::string& s)
 {

--- a/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.hpp
+++ b/meta-canopy/meta-hpe/meta-common/recipes-hpe/gxp-chif-service/gxp-chif-service/src/utils.hpp
@@ -6,15 +6,26 @@
 
 #include <array>
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
+#include <vector>
 
 namespace chif
 {
 
 inline constexpr auto propertiesInterface = "org.freedesktop.DBus.Properties";
+
+using MapperServiceMap = std::map<std::string, std::vector<std::string>>;
+using GetSubTreeResponse =
+    std::vector<std::pair<std::string, MapperServiceMap>>;
+
+GetSubTreeResponse getSubtree(sdbusplus::bus_t& bus,
+                              const std::string& searchPath, int depth,
+                              const std::vector<std::string>& interfaces);
 
 template <typename T>
 std::optional<T> getProperty(sdbusplus::bus_t& bus, const char* service,


### PR DESCRIPTION
This PR consists of multiple commits.

The APML blob on the host SPI can contain several PlatDef bundles, one per platform, and we unconditionally took the first one. On multi-platform images that meant parsing another platform's PlatDef and ending up with a wrong I2C segment map (a DL320 Gen11 may have used the ML110 Gen11 bundle, depending on the order on the SPI).

We now walk the bundle chain and match the platform ID against the `ProductId` of the inventory object.