### PR TITLE
Fix IPMI FirmwareCI workflow and add trigger to run it on main/tags

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -23,6 +23,16 @@ pre-stage:
       command: power
       args: ["on"]
 
+  - cmd: cmd
+    name: Setup Tools
+    transport: &local
+      proto: local
+    options:
+      timeout: 2m
+    parameters:
+      executable: cat
+      args: ["[[storage.dl320_tools]]/dummy.txt"]
+
   - cmd: dutctl
     name: Wait for boot banner on serial
     options:

--- a/.firmwareci/storage/dl320_tools/storage.yaml
+++ b/.firmwareci/storage/dl320_tools/storage.yaml
@@ -1,0 +1,5 @@
+name: dl320_tools
+commands:
+  - "apt-get update -qq"
+  - "apt-get install -y --no-install-recommends ipmitool jq"
+uri: fwci://dl320_tools

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
@@ -65,7 +65,7 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x37
           expect:
-            - regex: '^[0-9a-f]{2}( [0-9a-f]{2}){15}$'
+            - regex: '^\s*[0-9a-f]{2}( [0-9a-f]{2}){15}\s*$'
       - cmd: shell
         name: Get Channel Auth Capabilities (0x06 0x38) - ch14 admin
         transport: *local

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/04-app-messaging.yaml
@@ -4,9 +4,7 @@ description: >-
   Enables (2Fh), BT Interface Capabilities (36h), Get System GUID (37h),
   Get Channel Auth Capabilities (38h), Get Session Info (3Dh), Get Channel
   Access (41h), Get Channel Info (42h), Get User Access (44h), Get User Name
-  (46h), Get Channel Cipher Suites (54h), Get System Interface Capabilities
-  (57h), and Get System Info Parameters (59h). Commands that may not be
-  supported on all builds carry on-error: continue.
+  (46h), Get Channel Cipher Suites (54h), and Get System Info Parameters (59h).
 
 defaults:
   transport: &local
@@ -33,23 +31,60 @@ stages:
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x36
+      # 57h is only implemented by the 'arm' ipmid OEM provider, which reports
+      # SSIF capabilities. This platform's host interface is KCS (ipmi_kcs1,
+      # channel 15) and OBMC_ORG_IPMI_OEM_PROVIDERS is empty, so the handler is
+      # never registered and ipmid rejects the command with 0xC1.
       - cmd: shell
-        name: Get System Interface Capabilities (0x06 0x57)
+        name: Get System Interface Capabilities (0x06 0x57) rejected with 0xC1
         transport: *local
         options:
           timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x57 0x00 2>&1 || true
+          expect:
+            - regex: 'rsp=0xc1|Invalid command'
+
+  - name: Wait for SMBIOS System GUID source
+    steps:
+      - cmd: shell
+        name: Power host on so BIOS pushes SMBIOS (no-op if already on)
+        transport: *local
+        options:
+          timeout: "1m"
           on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x06 0x57 0x00
+            chassis power on
+      - cmd: shell
+        name: Wait until smbios-mdr publishes a non-zero System UUID
+        transport: &bmc_ssh
+          proto: ssh
+          options:
+            host: "[[attributes.BMC]]"
+            user: "root"
+            password: "[[attributes.BMCPassword]]"
+        options:
+          timeout: "8m"
+        parameters:
+          command: >-
+            until busctl get-property xyz.openbmc_project.Smbios.MDR_V2
+            /xyz/openbmc_project/inventory/system/chassis/motherboard/bios
+            xyz.openbmc_project.Common.UUID UUID 2>/dev/null
+            | grep -qiE '[1-9a-f]'; do sleep 10; done;
+            echo "System GUID source ready"
+          expect:
+            - regex: 'System GUID source ready'
 
   - name: System Identity and Authentication
     steps:
@@ -58,7 +93,6 @@ stages:
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
@@ -66,6 +100,7 @@ stages:
             raw 0x06 0x37
           expect:
             - regex: '^\s*[0-9a-f]{2}( [0-9a-f]{2}){15}\s*$'
+            - regex: '[1-9a-f]'
       - cmd: shell
         name: Get Channel Auth Capabilities (0x06 0x38) - ch14 admin
         transport: *local
@@ -94,16 +129,17 @@ stages:
   - name: Channel and User Information
     steps:
       - cmd: shell
-        name: Get Channel Access (0x06 0x41) - ch1
+        name: Get Channel Access (0x06 0x41) - ch1 present volatile
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x06 0x41 0x01 0x00
+            raw 0x06 0x41 0x01 0x80
+          expect:
+            - regex: '^\s*[0-9a-f]{2} [0-9a-f]{2}\s*$'
       - cmd: shell
         name: Get Channel Info (0x06 0x42) - ch1
         transport: *local
@@ -153,12 +189,13 @@ stages:
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x06 0x59 0x00 0x00 0x00
+            raw 0x06 0x59 0x00 0x00 0x00 0x00
+          expect:
+            - regex: '^\s*11 00\s*$'
 
   - name: Messaging via ipmitool Aliases
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
@@ -4,8 +4,7 @@ description: >-
   Capabilities (00h), Get Chassis Status (01h), Chassis Identify (04h),
   Set Chassis Capabilities (05h), Set Power Restore Policy (06h), Get System
   Restart Cause (07h), Get/Set System Boot Options (09h/08h), Set Front Panel
-  Button Enables (0Ah), and Get POH Counter (0Fh). Power cycle is in
-  12-chassis-power-cycle.yaml.
+  Button Enables (0Ah), and Get POH Counter (0Fh).
 
 defaults:
   transport: &local
@@ -64,16 +63,17 @@ stages:
   - name: Get System Restart Cause
     steps:
       - cmd: shell
-        name: Get System Restart Cause (0x00 0x07)
+        name: Get System Restart Cause (0x00 0x07) currently fails with 0xFF
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x00 0x07
+            raw 0x00 0x07 2>&1 || true
+          expect:
+            - regex: 'rsp=0xff|Unspecified error'
 
   - name: Get POH Counter
     steps:
@@ -82,14 +82,14 @@ stages:
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x00 0x0f
           expect:
-            - regex: '^\s*[0-9a-f]{2} '
+            # 0x3c minutes per count (60), then the uint32 counter, LSB first.
+            - regex: '^\s*3c( [0-9a-f]{2}){4}\s*$'
 
   - name: Get System Boot Options
     steps:
@@ -147,16 +147,17 @@ stages:
   - name: Set Front Panel Button Enables
     steps:
       - cmd: shell
-        name: Set Front Panel Enables - All enabled (0x00 0x0a)
+        name: Set Front Panel Enables (0x00 0x0a) rejected with 0xFF
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x00 0x0a 0x00
+            raw 0x00 0x0a 0x00 2>&1 || true
+          expect:
+            - regex: 'rsp=0xff|Unspecified error'
 
   - name: Chassis via ipmitool Aliases
     steps:
@@ -173,24 +174,22 @@ stages:
           expect:
             - regex: 'System Power\s*:'
       - cmd: shell
-        name: chassis restart_cause (alias)
+        name: chassis restart_cause (alias) fails with 0xFF
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            chassis restart_cause
+            chassis restart_cause 2>&1 || true
           expect:
-            - regex: 'Restart Cause'
+            - regex: 'Get Chassis Restart Cause failed: Unspecified error'
       - cmd: shell
         name: chassis poh (alias)
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/05-chassis.yaml
@@ -89,7 +89,7 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x00 0x0f
           expect:
-            - regex: '^[0-9a-f]{2} '
+            - regex: '^\s*[0-9a-f]{2} '
 
   - name: Get System Boot Options
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
@@ -46,4 +46,4 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x04 0x2f 0x01
           expect:
-            - regex: '^[0-9a-f]{2}'
+            - regex: '^\s*[0-9a-f]{2}'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/06-sensor-event.yaml
@@ -1,49 +1,140 @@
 name: "IPMI: Sensor Commands (NetFn 0x04)"
 description: >-
-  Verify Sensor NetFn commands (Table G-1, §35). Sensor commands target sensor
-  number 0x01 (SDR-assigned): Get Sensor Reading (2Dh), Get Sensor Threshold
-  (27h), and Get Sensor Type (2Fh). All carry on-error: continue as sensor
-  numbers are dynamically assigned.
+  Verify Sensor NetFn commands (Table G-1, §35): Get Sensor Reading (2Dh), Get
+  Sensor Threshold (27h), and Get Sensor Type (2Fh).
+  .
+  A set of sensors is BMC-served and present with the host powered
+  off: both PSUs
+  (IINPUT/IOUTPUT/PINPUT/POUTPUT/TEMP1/VINPUT/VOUTPUT/FAN1 per PSU)
+  and the GXP SoC temperature. Those are checked first, before the
+  host is powered on. The host is then powered on, since CPU and DIMM
+  sensors only enter the SDR after the host is up.
+  .
+  Sensor numbers are assigned dynamically by dbus-sdr, so the per-sensor
+  commands resolve one from the SDR at run time rather than hardcoding it.
+  GXP_Temp is used as the anchor because it is present either way.
 
 defaults:
   transport: &local
     proto: local
 
 stages:
+  - name: Baseline Sensors (host power not required)
+    steps:
+      - cmd: shell
+        name: Poll until the SDR is populated
+        transport: *local
+        options:
+          timeout: "5m"
+        parameters:
+          command: >-
+            while true; do
+            N=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 sdr elist 2>/dev/null | wc -l);
+            [ "$N" -gt 0 ] && echo "$N sensor records" && exit 0;
+            sleep 5;
+            done
+      - cmd: shell
+        name: PSU1, PSU2 and GXP temperature are present with the host off
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            sdr elist
+          expect:
+            - regex: 'PSU1'
+            - regex: 'PSU2'
+            - regex: 'GXP_Temp'
+
   - name: Sensor Commands
     steps:
       - cmd: shell
-        name: Get Sensor Reading (0x04 0x2d) - sensor number 1
+        name: Get Sensor Reading (0x04 0x2d) - gxp temp sensor
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x04 0x2d 0x01
-      - cmd: shell
-        name: Get Sensor Threshold (0x04 0x27) - sensor number 1
-        transport: *local
-        options:
-          timeout: "30s"
-          on-error: continue
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x04 0x27 0x01
-      - cmd: shell
-        name: Get Sensor Type (0x04 0x2f) - sensor number 1
-        transport: *local
-        options:
-          timeout: "30s"
-          on-error: continue
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x04 0x2f 0x01
+            L=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 sdr elist 2>/dev/null);
+            N=$(echo "$L" | grep -i gxp | head -1 | awk -F'|' '{gsub(/[^0-9a-fA-F]/,"",$2); print "0x"$2}');
+            [ -z "$N" ] && N=$(echo "$L" | head -1 | awk -F'|' '{gsub(/[^0-9a-fA-F]/,"",$2); print "0x"$2}');
+            echo "sensor number: $N";
+            ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x04 0x2d $N
           expect:
             - regex: '^\s*[0-9a-f]{2}'
+      - cmd: shell
+        name: Get Sensor Threshold (0x04 0x27) - gxp temp sensor
+        transport: *local
+        options:
+          timeout: "30s"
+          on-error: continue
+        parameters:
+          command: >-
+            L=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 sdr elist 2>/dev/null);
+            N=$(echo "$L" | grep -i gxp | head -1 | awk -F'|' '{gsub(/[^0-9a-fA-F]/,"",$2); print "0x"$2}');
+            [ -z "$N" ] && N=$(echo "$L" | head -1 | awk -F'|' '{gsub(/[^0-9a-fA-F]/,"",$2); print "0x"$2}');
+            echo "sensor number: $N";
+            ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x04 0x27 $N
+      # Get sensor type does not function properly with dynamic-sensors
+      - cmd: shell
+        name: Get Sensor Type (0x04 0x2f) - gxp temp sensor
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            L=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 sdr elist 2>/dev/null);
+            N=$(echo "$L" | grep -i gxp | head -1 | awk -F'|' '{gsub(/[^0-9a-fA-F]/,"",$2); print "0x"$2}');
+            [ -z "$N" ] && N=$(echo "$L" | head -1 | awk -F'|' '{gsub(/[^0-9a-fA-F]/,"",$2); print "0x"$2}');
+            echo "sensor number: $N";
+            ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x04 0x2f $N 2>&1 || true
+          expect:
+            - regex: 'rsp=0xcb|Requested sensor, data, or record not found'
+
+  - name: Power On Host
+    steps:
+      - cmd: shell
+        name: Chassis power on (no-op if already on)
+        transport: *local
+        options:
+          timeout: "1m"
+          on-error: continue
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            chassis power on
+      - cmd: shell
+        name: Poll chassis status until host is on
+        transport: *local
+        options:
+          timeout: "8m"
+        parameters:
+          command: >-
+            while true; do
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x00 0x01 2>/dev/null | awk '{print $1}');
+            [ -n "$S" ] && [ $(( 0x$S & 1 )) -eq 1 ] && echo "host on (0x$S)" && exit 0;
+            sleep 5;
+            done
+
+  - name: Sensors With Host On
+    steps:
+      - cmd: shell
+        name: Baseline sensors still present after power on
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            N=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 sdr elist | wc -l);
+            echo "sensor records: $N";
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            sdr elist
+          expect:
+            - regex: 'PSU1'
+            - regex: 'PSU2'
+            - regex: 'GXP_Temp'
+            - regex: 'Pwm'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/08-sdr.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/08-sdr.yaml
@@ -3,8 +3,7 @@ description: >-
   Verify SDR Repository commands (Table G-1, §33): Get SDR Repository Info
   (20h), Get SDR Repository Allocation Info (21h), Reserve SDR Repository
   (22h), Get SDR (23h, first record header), and Get SDR Repository Time
-  (28h). Allocation Info and Repository Time carry on-error: continue as they
-  are not universally implemented.
+  (28h).
 
 defaults:
   transport: &local
@@ -71,12 +70,13 @@ stages:
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0a 0x28
+            raw 0x0a 0x28 2>&1 || true
+          expect:
+            - regex: 'rsp=0xc1|Invalid command'
 
   - name: SDR Repository via ipmitool Aliases
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/09-sel.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/09-sel.yaml
@@ -3,9 +3,7 @@ description: >-
   Verify System Event Log commands (Table G-1, §31): Get SEL Info (40h), Get
   SEL Allocation Info (41h), Reserve SEL (42h), Get SEL Entry (43h), Add SEL
   Entry (44h), Partial Add SEL Entry (45h), Delete SEL Entry (46h), Clear SEL
-  (47h), Get/Set SEL Time (48h/49h), and Get SEL Time UTC Offset (5Ch). Set
-  SEL Time, Delete, Partial Add, Allocation Info, and UTC Offset carry
-  on-error: continue. Clear SEL runs last using a fresh reservation.
+  (47h), Get/Set SEL Time (48h/49h), and Get SEL Time UTC Offset (5Ch).
 
 defaults:
   transport: &local
@@ -41,7 +39,7 @@ stages:
   - name: Add SEL Entry
     steps:
       - cmd: shell
-        name: Add SEL Entry (0x0a 0x44) - test system event record
+        name: Add SEL Entry (0x0a 0x44)
         transport: *local
         options:
           timeout: "30s"
@@ -52,11 +50,13 @@ stages:
             raw 0x0a 0x44
             0xff 0xff 0x02 0x00 0x00 0x00 0x00
             0x20 0x00 0x04 0x01 0x01 0x00 0x00 0x00 0x00
+          expect:
+            - regex: '^\s*ff ff\s*$'
 
   - name: Get SEL Entry
     steps:
       - cmd: shell
-        name: Get SEL Entry (0x0a 0x43) - last record
+        name: Get SEL Entry (0x0a 0x43)
         transport: *local
         options:
           timeout: "30s"
@@ -64,18 +64,21 @@ stages:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0a 0x43 0x00 0x00 0xff 0xff 0x00 0xff
+            raw 0x0a 0x43 0x00 0x00 0xff 0xff 0x00 0xff 2>&1 || true
+          expect:
+            - regex: 'rsp=0xcb|Requested sensor, data, or record not found'
       - cmd: shell
         name: Partial Add SEL Entry (0x0a 0x45)
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0a 0x45 0x00 0x00 0xff 0xff 0x00 0xff
+            raw 0x0a 0x45 0x00 0x00 0xff 0xff 0x00 0xff 2>&1 || true
+          expect:
+            - regex: 'rsp=0xc1|Invalid command'
 
   - name: SEL Time
     steps:
@@ -90,27 +93,29 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x0a 0x48
       - cmd: shell
-        name: Set SEL Time (0x0a 0x49)
+        name: Set SEL Time (0x0a 0x49) - currently 0xD5, NTP is enabled
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0a 0x49 0x00 0x00 0x00 0x00
+            raw 0x0a 0x49 0x00 0x00 0x00 0x00 2>&1 || true
+          expect:
+            - regex: 'rsp=0xd5|Command not supported in present state'
       - cmd: shell
         name: Get SEL Time UTC Offset (0x0a 0x5c)
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0a 0x5c
+            raw 0x0a 0x5c 2>&1 || true
+          expect:
+            - regex: 'rsp=0xc1|Invalid command'
 
   - name: SEL Management
     steps:
@@ -119,37 +124,40 @@ stages:
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0a 0x41
+            raw 0x0a 0x41 2>&1 || true
+          expect:
+            - regex: 'rsp=0xc1|Invalid command'
       - cmd: shell
         name: Delete SEL Entry (0x0a 0x46)
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0a 0x46 0x00 0x00 0x01 0x00
+            raw 0x0a 0x46 0x00 0x00 0x01 0x00 2>&1 || true
+          expect:
+            - regex: 'rsp=0xc1|Invalid command'
 
   - name: Clear SEL
     steps:
       - cmd: shell
-        name: Clear SEL (0x0a 0x47) - reserve then clear in one step
+        name: Clear SEL (0x0a 0x47)
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             RES=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x0a 0x42);
             ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x0a 0x47
-            $(echo "$RES" | awk '{print "0x"$1, "0x"$2}') 0x43 0x4c 0x52 0xaa
+            $(echo "$RES" | awk '{print "0x"$1, "0x"$2}') 0x43 0x4c 0x52 0xaa 2>&1 || true
+          expect:
+            - regex: 'rsp=0xff|Unspecified error'
 
   - name: SEL via ipmitool Aliases
     steps:
@@ -176,9 +184,9 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             sel time get
           expect:
-            - regex: '[0-9]{4}'
+            - regex: '[0-9]{2}/[0-9]{2}/[0-9]{2,4} [0-9]{2}:[0-9]{2}:[0-9]{2}'
       - cmd: shell
-        name: sel list after clear (alias - expects empty)
+        name: sel list (alias)
         transport: *local
         options:
           timeout: "30s"
@@ -186,6 +194,6 @@ stages:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            sel list
+            sel list 2>&1
           expect:
             - regex: '(SEL has no entries|\|)'

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/10-lan.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/10-lan.yaml
@@ -2,9 +2,8 @@ name: "IPMI: LAN Configuration Commands (NetFn 0x0c)"
 description: >-
   Verify Get LAN Configuration Parameter (0x0c 0x02) for key network
   parameters on channel 1: IP address (param3), subnet mask (param6), MAC
-  address (param5), VLAN ID (param20), and cipher suite list (param17).
-  Cipher suite list carries on-error: continue as it may not be implemented
-  on all firmware builds.
+  address (param5), VLAN ID (param20), and RMCP+ messaging cipher suite
+  entries (param23).
 
 defaults:
   transport: &local
@@ -57,16 +56,17 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x0c 0x02 0x01 0x14 0x00 0x00
       - cmd: shell
-        name: Get LAN Config Cipher Suite List (0x0c 0x02) - ch1 param17
+        name: Get LAN Config Cipher Suite Entries (0x0c 0x02) - ch1 param23
         transport: *local
         options:
           timeout: "30s"
-          on-error: continue
         parameters:
           command: >-
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x0c 0x02 0x01 0x11 0x00 0x00
+            raw 0x0c 0x02 0x01 0x17 0x00 0x00
+          expect:
+            - regex: '^\s*11( [0-9a-f]{2})+'
 
   - name: LAN Configuration via ipmitool Alias
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/11-dcmi.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/11-dcmi.yaml
@@ -38,7 +38,7 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x2c 0x07 0xdc 0x01 0x40 0x01 0x01
           expect:
-            - regex: '^[0-9a-f]'
+            - regex: '^\s*[0-9a-f]'
       - cmd: shell
         name: Get Temperature Reading (0x2c 0x10) - inlet air entity
         transport: *local
@@ -99,7 +99,7 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x2c 0x03 0xdc 0x00 0x00
           expect:
-            - regex: '^[0-9a-f]{2}'
+            - regex: '^\s*[0-9a-f]{2}'
 
   - name: DCMI Configuration
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
@@ -255,10 +255,6 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x46 0x02
           expect:
-            # ipmitool raw prints " %2.2x" per byte, so the line has a leading
-            # space -- ^ must allow it. All 16 name bytes must be zero: an 8-char
-            # name is null-padded to 16, so a short pattern would also match a
-            # populated slot.
             - regex: '^\s*(?:00\s+){15}00\s*$'
 
       - cmd: shell
@@ -389,10 +385,6 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x46 0x02
           expect:
-            # ipmitool raw prints " %2.2x" per byte, so the line has a leading
-            # space -- ^ must allow it. All 16 name bytes must be zero: an 8-char
-            # name is null-padded to 16, so a short pattern would also match a
-            # populated slot.
             - regex: '^\s*(?:00\s+){15}00\s*$'
 
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
@@ -255,7 +255,11 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x46 0x02
           expect:
-            - regex: '^(00 ?){8}'
+            # ipmitool raw prints " %2.2x" per byte, so the line has a leading
+            # space -- ^ must allow it. All 16 name bytes must be zero: an 8-char
+            # name is null-padded to 16, so a short pattern would also match a
+            # populated slot.
+            - regex: '^\s*(?:00\s+){15}00\s*$'
 
       - cmd: shell
         name: Get User Access slot 2, ch1 should have no access
@@ -385,7 +389,11 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x46 0x02
           expect:
-            - regex: '^(00 ?){8}'
+            # ipmitool raw prints " %2.2x" per byte, so the line has a leading
+            # space -- ^ must allow it. All 16 name bytes must be zero: an 8-char
+            # name is null-padded to 16, so a short pattern would also match a
+            # populated slot.
+            - regex: '^\s*(?:00\s+){15}00\s*$'
 
       - cmd: shell
         name: Login as fwcigap over LAN (slot 3 user is usable)

--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/13-chassis-power-cycle.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/13-chassis-power-cycle.yaml
@@ -1,9 +1,9 @@
 name: "IPMI: Chassis Power Cycle"
 description: >-
-  Validate chassis power cycle via IPMI. Verifies the host is initially on,
+  Validate chassis power cycle via IPMI. Ensures the host is on to begin with,
   sets the restore policy to always-on (0x02), powers the host off, confirms
   it is off, powers it back on, then polls chassis status until bit 0 is set
-  again. Run this test last as it disrupts the host.
+  again.
 
 defaults:
   transport: &local
@@ -13,17 +13,28 @@ stages:
   - name: Pre-condition Checks
     steps:
       - cmd: shell
-        name: Verify host is currently powered on (bit 0 of byte 0)
+        name: Chassis power on (no-op if already on)
         transport: *local
         options:
-          timeout: "30s"
+          timeout: "1m"
+          on-error: continue
         parameters:
           command: >-
-            S=$(ipmitool -I lanplus -H [[attributes.BMC]]
+            ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x00 0x01 | awk '{print $1}');
-            echo "power byte: 0x$S";
-            test $(( 0x$S & 1 )) -eq 1
+            chassis power on
+      - cmd: shell
+        name: Poll chassis status until host is on
+        transport: *local
+        options:
+          timeout: "8m"
+        parameters:
+          command: >-
+            while true; do
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x00 0x01 2>/dev/null | awk '{print $1}');
+            [ -n "$S" ] && [ $(( 0x$S & 1 )) -eq 1 ] && echo "host on (0x$S)" && exit 0;
+            sleep 5;
+            done
 
   - name: Set Restore Policy
     steps:
@@ -51,12 +62,17 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x00 0x02 0x00
       - cmd: shell
-        name: Wait for host to power down
+        name: Poll chassis status until power-on bit is clear
         transport: *local
         options:
-          timeout: "35s"
+          timeout: "1m"
         parameters:
-          command: sleep 30
+          command: >-
+            while true; do
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x00 0x01 2>/dev/null | awk '{print $1}');
+            [ -n "$S" ] && [ $(( 0x$S & 1 )) -eq 0 ] && echo "host off (0x$S)" && exit 0;
+            sleep 5;
+            done
       - cmd: shell
         name: Verify host is powered off (bit 0 of byte 0 clear)
         transport: *local
@@ -74,6 +90,13 @@ stages:
   - name: Power On
     steps:
       - cmd: shell
+        name: Settle before powering on
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: sleep 20
+      - cmd: shell
         name: Chassis Control - Power on (0x00 0x02 0x01)
         transport: *local
         options:
@@ -87,17 +110,17 @@ stages:
   - name: Wait for Host to Come On
     steps:
       - cmd: shell
-        name: Poll chassis status until power-on bit is set (3 min timeout)
+        name: Poll chassis status until power-on bit is set
         transport: *local
         options:
-          timeout: "4m"
+          timeout: "8m"
         parameters:
           command: >-
-            for i in $(seq 36); do
-            S=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x00 0x01 2>/dev/null | awk '{print $1}');
+            while true; do
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x00 0x01 | awk '{print $1}');
             [ -n "$S" ] && [ $(( 0x$S & 1 )) -eq 1 ] && echo "host on (0x$S)" && exit 0;
             sleep 5;
-            done; echo "timeout: host not on after 3 minutes"; exit 1
+            done
 
   - name: Verify Host Is On
     steps:
@@ -108,8 +131,6 @@ stages:
           timeout: "30s"
         parameters:
           command: >-
-            S=$(ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x00 0x01 | awk '{print $1}');
+            S=$(ipmitool -I lanplus -H [[attributes.BMC]] -U root -P [[attributes.BMCPassword]] -C 17 raw 0x00 0x01 | awk '{print $1}');
             echo "power byte: 0x$S";
             test $(( 0x$S & 1 )) -eq 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,8 @@ jobs:
           if [[ "${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref_type == 'tag' }}" == "true" ]]; then
             workflow=$(jq -cn '[
               "main",
-              "ci"
+              "ci",
+              "ipmi"
             ]')
           else
             workflow=$(jq -cn '[

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl110g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl110g11_baseboard.json
@@ -113,7 +113,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl145g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl145g11_baseboard.json
@@ -32,7 +32,9 @@
                     "Value": 0
                 }
             ],
-            "Type": "EMC1412"
+            "Type": "EMC1412",
+            "EntityId": "0x42",
+            "EntityInstance": 2
         },
         {
             "Connector": {
@@ -135,7 +137,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
@@ -113,7 +113,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl325g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl325g11_baseboard.json
@@ -32,7 +32,9 @@
                     "Value": 0
                 }
             ],
-            "Type": "EMC1412"
+            "Type": "EMC1412",
+            "EntityId": "0x42",
+            "EntityInstance": 2
         },
         {
             "Connector": {
@@ -147,7 +149,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl345g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl345g11_baseboard.json
@@ -32,7 +32,9 @@
                     "Value": 0
                 }
             ],
-            "Type": "EMC1412"
+            "Type": "EMC1412",
+            "EntityId": "0x42",
+            "EntityInstance": 2
         },
         {
             "Connector": {
@@ -135,7 +137,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
@@ -113,7 +113,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
@@ -32,7 +32,9 @@
                     "Value": 0
                 }
             ],
-            "Type": "EMC1412"
+            "Type": "EMC1412",
+            "EntityId": "0x42",
+            "EntityInstance": 2
         },
         {
             "Address": "0x4c",
@@ -203,7 +205,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380ag11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380ag11_baseboard.json
@@ -113,7 +113,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380g11_baseboard.json
@@ -113,7 +113,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl385g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl385g11_baseboard.json
@@ -32,7 +32,9 @@
                     "Value": 0
                 }
             ],
-            "Type": "EMC1412"
+            "Type": "EMC1412",
+            "EntityId": "0x42",
+            "EntityInstance": 2
         },
         {
             "Connector": {
@@ -135,7 +137,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl560g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl560g11_baseboard.json
@@ -113,7 +113,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/rl300g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/rl300g11_baseboard.json
@@ -113,7 +113,9 @@
                 }
             ],
             "Type": "GxpTempSensor",
-            "DeviceName": "coretemp"
+            "DeviceName": "coretemp",
+            "EntityId": "0x42",
+            "EntityInstance": 1
         },
         {
             "MaxValue": 2000,

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-config/dcmi_cap.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-config/dcmi_cap.json
@@ -1,0 +1,17 @@
+{
+    "PowerManagement": 1,
+    "OOBSecondaryLan": 0,
+    "SerialTMODE": 0,
+    "InBandSystemInterfaceChannel": 1,
+    "SELAutoRollOver": 1,
+    "FlushEntireSELUponRollOver": 0,
+    "RecordLevelSELFlushUponRollOver": 0,
+    "NumberOfSELEntries": 200,
+    "TempMonitoringSamplingFreq": 0,
+    "PowerMgmtDeviceSlaveAddress": 0,
+    "BMCChannelNumber": 1,
+    "DeviceRivision": 0,
+    "MandatoryPrimaryLanOOBSupport": 1,
+    "OptionalSecondaryLanOOBSupport": 255,
+    "OptionalSerialOOBMTMODECapability": 255
+}

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager/chassis_capabilities.override.yml
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager/chassis_capabilities.override.yml
@@ -1,0 +1,23 @@
+/xyz/openbmc_project/control/chassis_capabilities:
+    - Interface: xyz.openbmc_project.Control.ChassisCapabilities
+      Properties:
+          CapabilitiesFlags:
+              Default: 0
+          ChassisIntrusionEnabled:
+              Default: 'false'
+          ChassisFrontPanelLockoutEnabled:
+              Default: 'false'
+          ChassisNMIEnabled:
+              Default: 'false'
+          ChassisPowerInterlockEnabled:
+              Default: 'false'
+          FRUDeviceAddress:
+              Default: 32
+          SDRDeviceAddress:
+              Default: 32
+          SELDeviceAddress:
+              Default: 32
+          SMDeviceAddress:
+              Default: 32
+          BridgeDeviceAddress:
+              Default: 32

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager/power_on_hours.override.yml
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager/power_on_hours.override.yml
@@ -1,0 +1,5 @@
+/xyz/openbmc_project/state/chassis0:
+    - Interface: xyz.openbmc_project.State.PowerOnHours
+      Properties:
+          POHCounter:
+              Default: 0

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
@@ -1,2 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " file://power_settings.override.yml"
+SRC_URI:append = " file://chassis_capabilities.override.yml"

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " file://power_settings.override.yml"
 SRC_URI:append = " file://chassis_capabilities.override.yml"
+SRC_URI:append = " file://power_on_hours.override.yml"


### PR DESCRIPTION
The `hpe-dl320-g11-ipmi` FirmwareCI workflow was never scheduled and most of its steps carried `on-error: continue`, so it passed unconditionally and was not informative. This enables it on `main` and tags and replaces every `on-error: continue` with an explicit assertion allowing to pass.

Tests that were malformed (wrong request bytes, missing preconditions, regexes that didn't match `ipmitool raw` output) are fixed. Commands that are unimplemented on this platform or upstream now assert their exact completion code with a comment on what is missing, so both a regression and an accidental fix show up as a diff. SEL commands is one of those cases, tracked in #232.

Two settings-manager overrides under `meta-hpe` fix Get/Set Chassis Capabilities and Get POH Counter, which returned `0xFF` because nothing in the image implemented the D-Bus interfaces ipmid looks up.

Verified FWCI DL320.