### PR TITLE
HPE ProLiant Gen11: Firmware CI fixes

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/post.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/post.yaml
@@ -12,6 +12,25 @@ post-stage:
         -o /dev/null -w '%{http_code}'
         https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset || true
 
+  - cmd: copy
+    name: Copy original NVRAM to DUT
+    transport: &bmc_ssh
+      proto: ssh
+      options:
+        host: "[[attributes.BMC]]"
+        user: "root"
+        password: "[[attributes.BMCPassword]]"
+    parameters:
+      source: "[[storage.dl320g11_nvram]]"
+      destination: /tmp
+      recursive: true
+
+  - cmd: shell
+    name: Flash original NVRAM to DUT
+    transport: *bmc_ssh
+    parameters:
+      command: "flashcp -v /tmp/[[storage.dl320g11_nvram.rom]] /dev/mtd/host-reserved"
+
   - cmd: dutctl
     name: Power off DUT
     parameters:

--- a/.firmwareci/storage/dl320g11_nvram/storage.yaml
+++ b/.firmwareci/storage/dl320g11_nvram/storage.yaml
@@ -1,4 +1,5 @@
 name: dl320g11_nvram
 paths:
   rom: dl320g11_host_reserved_original.bin
+  evs: dl320g11_evs_original.dat
 uri: fwci://dl320g11_nvram

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/bios-config.yaml
@@ -18,42 +18,6 @@ defaults:
       user: "root"
       password: "[[attributes.BMCPassword]]"
 
-post-stage:
-  # Allowed to fail
-  - cmd: shell
-    name: Power off host via Redfish
-    transport:
-      proto: local
-    parameters:
-      command: >-
-        curl -sk -u root:[[attributes.BMCPassword]]
-        -X POST -H 'Content-Type: application/json'
-        -d '{"ResetType":"ForceOff"}'
-        -o /dev/null -w '%{http_code}'
-        https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset || true
-
-  - cmd: copy
-    name: Copy original NVRAM to DUT
-    transport: *bmc_ssh
-    parameters:
-      source: "[[storage.dl320g11_nvram]]"
-      destination: /tmp
-      recursive: true
-
-  - cmd: shell
-    name: Flash original NVRAM to DUT
-    transport: *bmc_ssh
-    parameters:
-      command: "flashcp /tmp/[[storage.dl320g11_nvram.rom]] /dev/mtd/host-reserved"
-
-  - cmd: dutctl
-    name: Power off DUT
-    parameters:
-      agent: "[[attributes.Agent]]"
-      device: "[[attributes.Device]]"
-      command: power
-      args: ["off"]
-
 stages:
   - name: Reset NVRAM before power on
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/boot-override.yaml
@@ -19,42 +19,6 @@ defaults:
       user: "root"
       password: "[[attributes.BMCPassword]]"
 
-post-stage:
-  # Allowed to fail
-  - cmd: shell
-    name: Power off host via Redfish
-    transport:
-      proto: local
-    parameters:
-      command: >-
-        curl -sk -u root:[[attributes.BMCPassword]]
-        -X POST -H 'Content-Type: application/json'
-        -d '{"ResetType":"ForceOff"}'
-        -o /dev/null -w '%{http_code}'
-        https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset || true
-
-  - cmd: copy
-    name: Copy original NVRAM to DUT
-    transport: *bmc_ssh
-    parameters:
-      source: "[[storage.dl320g11_nvram]]"
-      destination: /tmp
-      recursive: true
-
-  - cmd: shell
-    name: Flash original NVRAM to DUT
-    transport: *bmc_ssh
-    parameters:
-      command: "flashcp /tmp/[[storage.dl320g11_nvram.rom]] /dev/mtd/host-reserved"
-
-  - cmd: dutctl
-    name: Power off DUT
-    parameters:
-      agent: "[[attributes.Agent]]"
-      device: "[[attributes.Device]]"
-      command: power
-      args: ["off"]
-
 stages:
   - name: Reset NVRAM before power on
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
@@ -85,61 +85,61 @@ stages:
             - "-c"
             - "MEMBERS=$(curl -sk -u root:[[attributes.BMCPassword]] https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory | grep -o '\"@odata.id\": *\"/redfish/v1/Systems/system/Memory/[^\"]*\"' | grep -o '/redfish/v1/Systems/system/Memory/[^\"]*'); ABSENT=0; for M in $MEMBERS; do curl -sk -u root:[[attributes.BMCPassword]] https://[[attributes.BMC]]$M 2>/dev/null | grep -q '\"State\": *\"Absent\"' && ABSENT=$((ABSENT+1)); done; echo \"Absent DIMMs: $ABSENT\"; test \"$ABSENT\" -ge 1"
 
-  - name: DIMM6 Attributes
+  - name: DIMM2 Attributes
     steps:
       - cmd: cmd
-        name: dimm6 is Enabled
+        name: dimm2 is Enabled
         transport: *local
         options:
           timeout: 30s
           on-error: continue
         parameters:
           executable: curl
-          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm6"]
+          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm2"]
           expect:
             - regex: '"State": "Enabled"'
       - cmd: cmd
-        name: dimm6 is DDR5
+        name: dimm2 is DDR5
         transport: *local
         options:
           timeout: 30s
           on-error: continue
         parameters:
           executable: curl
-          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm6"]
+          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm2"]
           expect:
             - regex: '"MemoryDeviceType": "DDR5"'
       - cmd: cmd
-        name: dimm6 Manufacturer is Hynix
+        name: dimm2 Manufacturer is Hynix
         transport: *local
         options:
           timeout: 30s
           on-error: continue
         parameters:
           executable: curl
-          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm6"]
+          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm2"]
           expect:
             - regex: '"Manufacturer": "Hynix"'
       - cmd: cmd
-        name: dimm6 PartNumber is HMCG88AGBRA619N
+        name: dimm2 PartNumber is HMCG88AGBRA619N
         transport: *local
         options:
           timeout: 30s
           on-error: continue
         parameters:
           executable: curl
-          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm6"]
+          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm2"]
           expect:
             - regex: '"PartNumber": "HMCG88AGBRA619N"'
       - cmd: cmd
-        name: dimm6 SerialNumber is E3712D7D
+        name: dimm2 SerialNumber is E3712D7D
         transport: *local
         options:
           timeout: 30s
           on-error: continue
         parameters:
           executable: curl
-          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm6"]
+          args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm2"]
           expect:
             - regex: '"SerialNumber": "E3712D7D"'
 

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
@@ -16,11 +16,33 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
+  - name: Deploy NVRAM-specific EVs
+    steps:
+      - cmd: copy
+        name: Copy original NVRAM to DUT
+        transport: *bmc_ssh
+        parameters:
+          source: "[[storage.dl320g11_nvram]]"
+          destination: /tmp
+          recursive: true
+
+      - cmd: shell
+        name: Copy EVs to CHIF path
+        transport: *bmc_ssh
+        parameters:
+          command: "cp /tmp/[[storage.dl320g11_nvram.evs]] /var/lib/chif/evs.dat"
+
+      - cmd: shell
+        name: Restart CHIF service
+        transport: *bmc_ssh
+        parameters:
+          command: "systemctl restart xyz.openbmc_project.GxpChif.service"
+
   - name: Reboot Cycle 1
     steps:
       - cmd: shell
         name: Power on host
-        transport:
+        transport: &local
           proto: local
         parameters:
           command: >-
@@ -32,10 +54,24 @@ stages:
           expect:
             - regex: "^(200|204)$"
 
+      - cmd: shell
+        name: Wait for SMBIOS transfer (host POST complete)
+        transport: *bmc_ssh
+        options:
+          timeout: 15m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+
       - cmd: ping
         name: Wait for host OS
         options:
-          timeout: 10m
+          timeout: 5m
         parameters:
           host: "[[attributes.Host]]"
 
@@ -67,8 +103,7 @@ stages:
 
       - cmd: shell
         name: Reboot host via Redfish
-        transport:
-          proto: local
+        transport: *local
         parameters:
           command: >-
             curl -sk -u root:[[attributes.BMCPassword]]
@@ -79,12 +114,32 @@ stages:
           expect:
             - regex: "^(200|204)$"
 
+      - cmd: shell
+        name: Clear stale SMBIOS data
+        transport: *bmc_ssh
+        parameters:
+          command: "rm -f /var/lib/smbios/smbios2"
+
   - name: Reboot Cycle 2
     steps:
+      - cmd: shell
+        name: Wait for SMBIOS transfer
+        transport: *bmc_ssh
+        options:
+          timeout: 5m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+
       - cmd: ping
         name: Wait for host OS
         options:
-          timeout: 10m
+          timeout: 5m
         parameters:
           host: "[[attributes.Host]]"
 
@@ -116,8 +171,7 @@ stages:
 
       - cmd: shell
         name: Reboot host via Redfish
-        transport:
-          proto: local
+        transport: *local
         parameters:
           command: >-
             curl -sk -u root:[[attributes.BMCPassword]]
@@ -128,12 +182,32 @@ stages:
           expect:
             - regex: "^(200|204)$"
 
+      - cmd: shell
+        name: Clear stale SMBIOS data
+        transport: *bmc_ssh
+        parameters:
+          command: "rm -f /var/lib/smbios/smbios2"
+
   - name: Reboot Cycle 3
     steps:
+      - cmd: shell
+        name: Wait for SMBIOS transfer
+        transport: *bmc_ssh
+        options:
+          timeout: 5m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+
       - cmd: ping
         name: Wait for host OS
         options:
-          timeout: 10m
+          timeout: 5m
         parameters:
           host: "[[attributes.Host]]"
 


### PR DESCRIPTION
This PR fixes observed issues in our Firmware CI environment.
- Fix the DIMM location in the memory inventory test (physically moved as it was not populated correctly)
- Move the NVRAM restore to the post stage to prevent altering from other tests
- Fix the Reboot stability test by waiting for SMBIOS transfer and restoring the EVs from FWCI storage too.