### PR TITLE
FirmwareCI: dl320g11: add host firmware update test

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/post.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/post.yaml
@@ -42,3 +42,11 @@ post-stage:
       device: "[[attributes.Device]]"
       command: power
       args: ["off"]
+
+  - cmd: dutctl
+    name: Reload golden image to host
+    parameters:
+      agent: "[[attributes.Agent]]"
+      device: "[[attributes.Device]]"
+      command: emulate-host
+      args: ["[[storage.dl320g11_bios_update]]/[[storage.dl320g11_bios_update.golden_image]]"]

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -16,6 +16,14 @@ pre-stage:
       args: ["[[input.firmware]]"]
 
   - cmd: dutctl
+    name: Emulate BIOS Flash with golden image
+    parameters:
+      agent: "[[attributes.Agent]]"
+      device: "[[attributes.Device]]"
+      command: emulate-host
+      args: ["[[storage.dl320g11_bios_update]]/[[storage.dl320g11_bios_update.golden_image]]"]
+
+  - cmd: dutctl
     name: Power on DUT
     parameters:
       agent: "[[attributes.Agent]]"

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -70,3 +70,23 @@ pre-stage:
       timeout: 2m
     parameters:
       command: "journalctl -t phosphor-bmc-state-manager -f | grep -m 1 BMC_READY"
+
+  - cmd: copy
+    name: Copy original NVRAM to DUT
+    transport: *bmc_ssh
+    parameters:
+      source: "[[storage.dl320g11_nvram]]"
+      destination: /tmp
+      recursive: true
+
+  - cmd: shell
+    name: Copy EVs to CHIF path
+    transport: *bmc_ssh
+    parameters:
+      command: "cp /tmp/[[storage.dl320g11_nvram.evs]] /var/lib/chif/evs.dat"
+
+  - cmd: shell
+    name: Restart CHIF service
+    transport: *bmc_ssh
+    parameters:
+      command: "systemctl restart xyz.openbmc_project.GxpChif.service"

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -58,12 +58,15 @@ pre-stage:
     parameters:
       host: "[[attributes.BMC]]"
 
-  - cmd: cmd
-    name: Wait for BMC services
-    transport: &local
-      proto: local
+  - cmd: shell
+    name: Wait for BMC ready
+    transport: &bmc_ssh
+      proto: ssh
+      options:
+        host: "[[attributes.BMC]]"
+        user: root
+        password: "[[attributes.BMCPassword]]"
     options:
       timeout: 2m
     parameters:
-      executable: sleep
-      args: ["45"]
+      command: "journalctl -t phosphor-bmc-state-manager -f | grep -m 1 BMC_READY"

--- a/.firmwareci/storage/dl320g11_bios_update/storage.yaml
+++ b/.firmwareci/storage/dl320g11_bios_update/storage.yaml
@@ -1,0 +1,7 @@
+name: dl320g11_bios_update
+paths:
+  pldm: U63-bios-2.92.pldm
+  old_pldm: U63-bios-2.72.pldm
+  wrong_pldm: U54-bios-2.92.pldm
+  golden_image: dl320_ci_sysrom.rom # whole flash - 64M
+uri: fwci://dl320g11_bios_update

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/host-firmware-update.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/host-firmware-update.yaml
@@ -24,28 +24,6 @@ variables:
   UpdateTriggerOutput: null
 
 stages:
-  - name: Prepare NVRAM # TODO this shouldn't be needed, investigate
-    steps:
-      - cmd: copy
-        name: Copy original NVRAM to DUT
-        transport: *bmc_ssh
-        parameters:
-          source: "[[storage.dl320g11_nvram]]"
-          destination: /tmp
-          recursive: true
-
-      - cmd: shell
-        name: Copy EVs to CHIF path
-        transport: *bmc_ssh
-        parameters:
-          command: "cp /tmp/[[storage.dl320g11_nvram.evs]] /var/lib/chif/evs.dat"
-
-      - cmd: shell
-        name: Restart CHIF service
-        transport: *bmc_ssh
-        parameters:
-          command: "systemctl restart xyz.openbmc_project.GxpChif.service"
-
   - name: Host on, OS Booting
     steps:
       - cmd: shell

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/host-firmware-update.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/host-firmware-update.yaml
@@ -1,0 +1,228 @@
+name: "Host Firmware: Update"
+description: >-
+  Update the host firmware (aka BIOS) via Redfish and verify it is booting the
+  new one.
+
+  For HPE some magic firmware preparation is needed beforehand to get a correct
+  PLDM package.
+
+  If flashing takes to long the Redfish task is running in a timeout and therefore
+  gets cancelled. The flash operation is however uneffected by this, so we don't
+  error out. "Cancelled" = timeout, "Exception" = error in the update process.
+  Possible errors are captured in the following step through systemd-journal.
+
+defaults:
+  transport: &bmc_ssh
+    proto: ssh
+    options:
+      host: "[[attributes.BMC]]"
+      user: root
+      password: "[[attributes.BMCPassword]]"
+
+variables:
+  UpdateTarget: null
+  UpdateTriggerOutput: null
+
+stages:
+  - name: Prepare NVRAM # TODO this shouldn't be needed, investigate
+    steps:
+      - cmd: copy
+        name: Copy original NVRAM to DUT
+        transport: *bmc_ssh
+        parameters:
+          source: "[[storage.dl320g11_nvram]]"
+          destination: /tmp
+          recursive: true
+
+      - cmd: shell
+        name: Copy EVs to CHIF path
+        transport: *bmc_ssh
+        parameters:
+          command: "cp /tmp/[[storage.dl320g11_nvram.evs]] /var/lib/chif/evs.dat"
+
+      - cmd: shell
+        name: Restart CHIF service
+        transport: *bmc_ssh
+        parameters:
+          command: "systemctl restart xyz.openbmc_project.GxpChif.service"
+
+  - name: Host on, OS Booting
+    steps:
+      - cmd: shell
+        name: Power on host
+        transport:
+          proto: local
+        parameters:
+          command: >-
+            curl -sk -u root:[[attributes.BMCPassword]]
+            -X POST -H 'Content-Type: application/json'
+            -d '{"ResetType":"On"}'
+            -o /dev/null -w '%{http_code}'
+            https://[[attributes.BMC]]/redfish/v1/Systems/system/Actions/ComputerSystem.Reset
+          expect:
+            - regex: "^(200|204)$"
+
+      - cmd: shell
+        name: Wait for SMBIOS transfer (host POST complete)
+        transport: *bmc_ssh
+        options:
+          timeout: 10m
+        parameters:
+          command: >-
+            while [ ! -f /var/lib/smbios/smbios2 ] ||
+                  [ $(stat -c %s /var/lib/smbios/smbios2 2>/dev/null || echo 0) -le 1000 ];
+            do sleep 1; done;
+            echo "SMBIOS ready: $(stat -c %s /var/lib/smbios/smbios2) bytes"
+          expect:
+            - regex: "SMBIOS ready"
+
+      - cmd: ping
+        name: Wait for host OS
+        options:
+          timeout: 3m
+        parameters:
+          host: "[[attributes.Host]]"
+
+      - cmd: redfish
+        name: Current BiosVersion
+        options:
+          timeout: 10s
+        transport: &local
+          proto: local
+        parameters:
+          host: "[[attributes.BMC]]"
+          auth:
+            user: root
+            password: "[[attributes.BMCPassword]]"
+          validate: inventory
+          inventory:
+            rules:
+              - path: /redfish/v1/Systems/system
+                prop: BiosVersion
+                op: matches
+                value: \d+\.\d+
+
+  - name: Firmware update to 2.92
+    steps:
+      - cmd: shell
+        name: Get update endpoint
+        options:
+          timeout: 30s
+        transport: *local
+        parameters:
+          command: |
+            curl -sk --user root:[[attributes.BMCPassword]] \
+              https://[[attributes.BMC]]/redfish/v1/UpdateService/FirmwareInventory \
+              | grep -Eo UEFIPrimary_[0-9]+
+          expect:
+            - regex: 'UEFIPrimary_\d+'
+          variable: UpdateTarget
+
+      - cmd: redfish
+        name: Is updateable?
+        options:
+          timeout: 30s
+        transport: *local
+        parameters:
+          host: "[[attributes.BMC]]"
+          auth:
+            user: root
+            password: "[[attributes.BMCPassword]]"
+          validate: inventory
+          inventory:
+            rules:
+              - path: /redfish/v1/UpdateService/FirmwareInventory/{{ UpdateTarget }}
+                prop: Updateable
+                op: eq
+                value: "true"
+
+      - cmd: shell
+        name: Trigger update
+        options:
+          timeout: 5m
+        transport: *local
+        parameters:
+          command: >-
+            curl -sk --user root:[[attributes.BMCPassword]]
+            -X POST -H Content-Type:multipart/form-data
+            -F 'UpdateParameters={"Targets":["/redfish/v1/UpdateService/FirmwareInventory/{{ UpdateTarget }}"],"@Redfish.OperationApplyTime":"Immediate"};type=application/json'
+            -F 'UpdateFile=@[[storage.dl320g11_bios_update]]/[[storage.dl320g11_bios_update.pldm]];type=application/octet-stream'
+            https://[[attributes.BMC]]/redfish/v1/UpdateService/update-multipart
+          expect:
+            - regex: TaskStarted
+          variable: UpdateTriggerOutput
+
+      - cmd: shell
+        name: Wait for update finish (Redfish)
+        # fails when update is too slow
+        transport: *local
+        options:
+          timeout: 10m
+          on-error: continue
+        parameters:
+          command: |
+            Task=$(echo {{ UpdateTriggerOutput }} | grep -Eo "/redfish/v1/TaskService/Tasks/[0-9]+" );
+            TaskState="Running";
+            while [ "$TaskState" = "Running" ]; do
+              sleep 2;
+              TaskState=$(curl -sk --user root:[[attributes.BMCPassword]] https://[[attributes.BMC]]${Task} | grep TaskState | sed -E 's/.*"(.*)",$/\1/');
+            done;
+            echo "$TaskState"
+          expect:
+            - regex: Completed
+
+      - cmd: shell
+        name: Wait for update finish (systemd-journal)
+        options:
+          timeout: 5m
+        transport: *bmc_ssh
+        parameters:
+          command: |
+            journalctl -n 5 -t phosphor-bios-software-update -t power-control -f \
+              | awk '{print} /UpdateSuccessful|ActivateFailed|UpdateNotApplicable/{exit}'
+          expect:
+            - regex: UpdateSuccessful
+
+      - cmd: shell
+        name: Check for updated inventory
+        options:
+          timeout: 30s
+          on-error: continue
+        transport: *local
+        parameters:
+          command: |
+            NEWTARGET=$(curl -sk --user root:[[attributes.BMCPassword]] \
+            https://[[attributes.BMC]]/redfish/v1/UpdateService/FirmwareInventory \
+            | grep -Eo "UEFIPrimary_[0-9]+")
+            if [ "{{ UpdateTarget }}" != "$NEWTARGET" ]; then
+              echo "$NEWTARGET";
+            fi;
+          expect:
+            - regex: 'UEFIPrimary_\d+'
+
+      - cmd: ping
+        name: Wait for host OS
+        options:
+          timeout: 10m
+          on-error: continue
+        parameters:
+          host: "[[attributes.Host]]"
+
+      - cmd: redfish
+        name: Approve updated BiosVersion
+        options:
+          timeout: 10s
+        transport: &local
+          proto: local
+        parameters:
+          host: "[[attributes.BMC]]"
+          auth:
+            user: root
+            password: "[[attributes.BMCPassword]]"
+          validate: inventory
+          inventory:
+            rules:
+              - path: /redfish/v1/Systems/system
+                prop: BiosVersion
+                op: matches
+                value: 2\.92

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/chif-stability.yaml
@@ -16,28 +16,6 @@ defaults:
       password: "[[attributes.BMCPassword]]"
 
 stages:
-  - name: Deploy NVRAM-specific EVs
-    steps:
-      - cmd: copy
-        name: Copy original NVRAM to DUT
-        transport: *bmc_ssh
-        parameters:
-          source: "[[storage.dl320g11_nvram]]"
-          destination: /tmp
-          recursive: true
-
-      - cmd: shell
-        name: Copy EVs to CHIF path
-        transport: *bmc_ssh
-        parameters:
-          command: "cp /tmp/[[storage.dl320g11_nvram.evs]] /var/lib/chif/evs.dat"
-
-      - cmd: shell
-        name: Restart CHIF service
-        transport: *bmc_ssh
-        parameters:
-          command: "systemctl restart xyz.openbmc_project.GxpChif.service"
-
   - name: Reboot Cycle 1
     steps:
       - cmd: shell


### PR DESCRIPTION
Testing the update feature added in #210 

- should we also test a downgrade?
- golden image currently on 2.72
- without the "prepare NVRAM" stage it currently fails to boot the OS (reset loop)

Latest run: https://app.firmware-ci.com/canopy/jobs/01KZXCCXNS2J7TRM7694G33SW4?projectID=01KKGTVRZ3XK1ZDSAETKB1624Y

Closes #242 