### PR TITLE
firmwareci: hpe-dl320: continue if nvram flash failed in post-stage

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/post.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/post.yaml
@@ -14,6 +14,8 @@ post-stage:
 
   - cmd: copy
     name: Copy original NVRAM to DUT
+    options:
+      on-error: continue
     transport: &bmc_ssh
       proto: ssh
       options:
@@ -27,6 +29,8 @@ post-stage:
 
   - cmd: shell
     name: Flash original NVRAM to DUT
+    options:
+      on-error: continue
     transport: *bmc_ssh
     parameters:
       command: "flashcp -v /tmp/[[storage.dl320g11_nvram.rom]] /dev/mtd/host-reserved"


### PR DESCRIPTION
If the NVRAM can not be flashed, then it should still continue to the point where it powers the system off.

Noticed in the referenced FWCI job.

Link: https://app.firmware-ci.com/canopy/jobs/01M003J5WY4VAX1029EFGH7Q65
Fixes: fd7b1201 ("firmwareci: hpe-dl320: power off via Redfish before turning the DUT off")