### PR TITLE
HPE ProLiant Gen11: User Lifecycle Management test fix

### DIFF
--- a/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ipmi/tests/12-user-management.yaml
@@ -4,8 +4,7 @@ description: >-
   visible/manageable in Redfish as an Administrator, then delete it and confirm
   it is gone from both. Also regression-tests a non-contiguous slot (user in
   slot 3 while slot 2 is empty), which previously left the user unusable and
-  unmanageable in Redfish. Note: IPMI-created users are listed and manageable
-  in Redfish but cannot log in over Redfish, so usability is checked over IPMI.
+  unmanageable in Redfish.
 
 defaults:
   transport: &local
@@ -41,6 +40,17 @@ stages:
             0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
 
       - cmd: shell
+        name: Set User Access, slot 2, ch1, Administrator, IPMI msg
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x43 0xB1 0x02 0x04 0x00
+
+      - cmd: shell
         name: Enable User - slot 2
         transport: *local
         options:
@@ -50,39 +60,6 @@ stages:
             ipmitool -I lanplus -H [[attributes.BMC]]
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x47 0x82 0x01
-
-      - cmd: shell
-        name: Set User Access, slot 2, ch1, Administrator, IPMI msg
-        transport: *local
-        options:
-          timeout: "30s"
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x06 0x43 0xe1 0x02 0x04 0x00
-
-      - cmd: shell
-        name: Set User Privilege
-        transport: *local
-        options:
-          timeout: "30s"
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            user priv 2 0x03
-
-      - cmd: shell
-        name: Enable IPMI messaging for slot 2, ch1, administrator
-        transport: *local
-        options:
-          timeout: "30s"
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            channel setaccess 1 2 link=off callin=off ipmi=on privilege=0x4
 
   - name: Verify User Exists
     steps:
@@ -100,7 +77,7 @@ stages:
             - regex: '66 77 63 69 74 65 73 74'
 
       - cmd: shell
-        name: Get User Access  - slot 2, ch1
+        name: Get User Access - slot 2, ch1
         transport: *local
         options:
           timeout: "30s"
@@ -117,43 +94,32 @@ stages:
           timeout: "30s"
         parameters:
           command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            user list 1
-          expect:
-            - regex: 'fwcitest'
-            - regex: 'ADMINISTRATOR'
+            OUT=$(ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17 user list 1);
+            echo "$OUT";
+            echo "$OUT" | awk '$1 == "2" && $2 == "fwcitest" && /ADMINISTRATOR/ {f=1} END {exit !f}'
 
-  - name: Verify Authentication
-    steps:
       - cmd: shell
-        name: Login as fwcitest and run mc info
-        transport: *local
+        name: fwcitest on D-Bus with priv-admin and ipmi group
+        transport: &bmc_ssh
+          proto: ssh
+          options:
+            host: "[[attributes.BMC]]"
+            user: "root"
+            password: "[[attributes.BMCPassword]]"
         options:
           timeout: "30s"
         parameters:
           command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U fwcitest -P Testpass123 -C 17 -L Administrator
-            mc info
+            busctl get-property xyz.openbmc_project.User.Manager
+            /xyz/openbmc_project/user/fwcitest
+            xyz.openbmc_project.User.Attributes
+            UserPrivilege UserEnabled UserGroups
           expect:
-            - regex: 'Device ID\s*: [0-9]{2}'
+            - regex: 's "priv-admin"'
+            - regex: 'b true'
+            - regex: '"ipmi"'
 
-      - cmd: shell
-        name: Login as fwcitest at User privilege and run Get Device ID
-        transport: *local
-        options:
-          timeout: "30s"
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U fwcitest -P Testpass123 -C 17 -L Administrator
-            raw 0x06 0x01
-          expect:
-            - regex: '[0-9a-f]{2}'
-
-  - name: Verify User in Redfish
-    steps:
       - cmd: shell
         name: Account fwcitest visible in Redfish AccountService
         transport: *local
@@ -202,10 +168,25 @@ stages:
           expect:
             - regex: '^(200|204)$'
 
+  - name: Verify User Login
+    steps:
+      - cmd: shell
+        name: Check user login
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U fwcitest -P Testpass123 -C 17
+            -L Administrator mc info
+          expect:
+            - regex: 'Device ID\s*: [0-9]{2}'
+
   - name: Delete User
     steps:
       - cmd: shell
-        name: Disable User  - slot 2
+        name: Disable User - slot 2
         transport: *local
         options:
           timeout: "30s"
@@ -225,7 +206,7 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x43 0x81 0x02 0x02 0x00
       - cmd: shell
-        name: Clear User Name  - slot 2, 16 null bytes
+        name: Clear User Name - slot 2, 16 null bytes
         transport: *local
         options:
           timeout: "30s"
@@ -313,6 +294,17 @@ stages:
             0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
 
       - cmd: shell
+        name: Set User Access, slot 3, ch1, Administrator, IPMI msg
+        transport: *local
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            ipmitool -I lanplus -H [[attributes.BMC]]
+            -U root -P [[attributes.BMCPassword]] -C 17
+            raw 0x06 0x43 0xB1 0x03 0x04 0x00
+
+      - cmd: shell
         name: Enable User - slot 3
         transport: *local
         options:
@@ -323,38 +315,6 @@ stages:
             -U root -P [[attributes.BMCPassword]] -C 17
             raw 0x06 0x47 0x83 0x01
 
-      - cmd: shell
-        name: Set User Access, slot 3, ch1, Administrator, IPMI msg
-        transport: *local
-        options:
-          timeout: "30s"
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            raw 0x06 0x43 0xe1 0x03 0x04 0x00
-
-      - cmd: shell
-        name: Set User Privilege - slot 3
-        transport: *local
-        options:
-          timeout: "30s"
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            user priv 3 0x03
-
-      - cmd: shell
-        name: Enable IPMI messaging for slot 3, ch1, administrator
-        transport: *local
-        options:
-          timeout: "30s"
-        parameters:
-          command: >-
-            ipmitool -I lanplus -H [[attributes.BMC]]
-            -U root -P [[attributes.BMCPassword]] -C 17
-            channel setaccess 1 3 link=off callin=off ipmi=on privilege=0x4
 
   - name: Non-Contiguous Slot - Verify on BMC (IPMI)
     steps:
@@ -415,6 +375,22 @@ stages:
             done;
             echo "$OUT";
             echo "$OUT" | awk '$1 == "3" && $2 == "fwcigap" && /ADMINISTRATOR/ {f=1} END {exit !f}'
+
+      - cmd: shell
+        name: fwcigap on D-Bus with priv-admin and ipmi group
+        transport: *bmc_ssh
+        options:
+          timeout: "30s"
+        parameters:
+          command: >-
+            busctl get-property xyz.openbmc_project.User.Manager
+            /xyz/openbmc_project/user/fwcigap
+            xyz.openbmc_project.User.Attributes
+            UserPrivilege UserEnabled UserGroups
+          expect:
+            - regex: 's "priv-admin"'
+            - regex: 'b true'
+            - regex: '"ipmi"'
 
       - cmd: shell
         name: Login as fwcigap over LAN (slot 3 user is usable)

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host/0002-user_channel-detect-user-data-file-changes-by-inode.patch
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host/0002-user_channel-detect-user-data-file-changes-by-inode.patch
@@ -1,0 +1,170 @@
+From 618e3a246f6612bb34578a8b0b4c0c72c9bcbb21 Mon Sep 17 00:00:00 2001
+From: Pedro Maione <pedro.maione@9elements.com>
+Date: Fri, 21 Aug 2026 19:26:19 +0200
+Subject: [PATCH] user_channel: detect user data file changes by inode
+
+ipmid and netipmid each keep a full in-memory copy of the IPMI user
+table that synchronise through `/var/lib/ipmi/ipmi_user.json` file.
+A copy is considered stale by comparing the file's mtime, seconds and
+nanoseconds, against the value recorded at the last read or write. A
+filesystem such as a read-write overlay in JFFS2 stores inode times with
+whole-second resolution, so tv_nsec is always zero. Two updates within
+the same second therefore produce an identical mtime and the reload is
+skipped.
+
+This patch fixes that installing new content by renaming a temporary
+file over the target, so every update allocates a new inode. So a copy
+of the file data is considered stale based on the file identity, inode
+plus size plus mtime, instead of the timestamp alone.  That detects
+every update regardless of the filesystem's timestamp resolution.
+
+When reading the user data file, sample the identity before parsing
+rather than after.  Recording it afterwards may cause the update to be
+skipped if a write landed during a read.
+
+Upstream-Status: Pending
+
+Signed-off-by: Pedro Maione <pedro.maione@9elements.com>
+---
+ user_channel/user_mgmt.cpp | 25 +++++++++++++------------
+ user_channel/user_mgmt.hpp | 35 +++++++++++++++++++++++++++++++----
+ 2 files changed, 44 insertions(+), 16 deletions(-)
+
+diff --git a/user_channel/user_mgmt.cpp b/user_channel/user_mgmt.cpp
+index 65eea1b9..bf06f802 100644
+--- a/user_channel/user_mgmt.cpp
++++ b/user_channel/user_mgmt.cpp
+@@ -1107,6 +1107,8 @@ void UserAccess::readUserData()
+     boost::interprocess::scoped_lock<boost::interprocess::named_recursive_mutex>
+         userLock{*userMutex};
+ 
++    UserDataFileId readFileId = getUserDataFileId();
++
+     std::ifstream iUsrData(ipmiUserDataFile, std::ios::in | std::ios::binary);
+     if (!iUsrData.good())
+     {
+@@ -1233,8 +1235,8 @@ void UserAccess::readUserData()
+ 
+     lg2::debug("User data read from IPMI data file");
+     iUsrData.close();
+-    // Update the timestamp
+-    fileLastUpdatedTime = getUpdatedFileTime();
++
++    fileLastUpdatedId = readFileId;
+     return;
+ }
+ 
+@@ -1314,8 +1316,8 @@ void UserAccess::writeUserData()
+         lg2::error("Error in renaming temporary IPMI user data file");
+         throw std::runtime_error("Error in renaming IPMI user data file");
+     }
+-    // Update the timestamp
+-    fileLastUpdatedTime = getUpdatedFileTime();
++
++    fileLastUpdatedId = getUserDataFileId();
+     return;
+ }
+ 
+@@ -1391,10 +1393,9 @@ void UserAccess::deleteUserIndex(const size_t& usrIdx)
+ 
+ void UserAccess::checkAndReloadUserData()
+ {
+-    std::timespec updateTime = getUpdatedFileTime();
+-    if ((updateTime.tv_sec != fileLastUpdatedTime.tv_sec ||
+-         updateTime.tv_nsec != fileLastUpdatedTime.tv_nsec) ||
+-        (updateTime.tv_sec == 0 && updateTime.tv_nsec == 0))
++    UserDataFileId currentFileId = getUserDataFileId();
++
++    if (!(currentFileId.valid() && currentFileId == fileLastUpdatedId))
+     {
+         try
+         {
+@@ -1463,15 +1464,15 @@ void UserAccess::getSystemPrivAndGroups()
+     return;
+ }
+ 
+-std::timespec UserAccess::getUpdatedFileTime()
++UserDataFileId UserAccess::getUserDataFileId()
+ {
+     struct stat fileStat;
+     if (stat(ipmiUserDataFile, &fileStat) != 0)
+     {
+-        lg2::debug("Error in getting last updated time stamp");
+-        return std::timespec{0, 0};
++        lg2::debug("Error in getting user data file identity");
++        return UserDataFileId{};
+     }
+-    return fileStat.st_mtim;
++    return UserDataFileId{fileStat.st_ino, fileStat.st_size, fileStat.st_mtim};
+ }
+ 
+ void UserAccess::getUserProperties(const DbusUserObjProperties& properties,
+diff --git a/user_channel/user_mgmt.hpp b/user_channel/user_mgmt.hpp
+index 09de779a..05a48c92 100644
+--- a/user_channel/user_mgmt.hpp
++++ b/user_channel/user_mgmt.hpp
+@@ -16,6 +16,8 @@
+ #pragma once
+ #include "user_layer.hpp"
+ 
++#include <sys/types.h>
++
+ #include <boost/interprocess/sync/file_lock.hpp>
+ #include <boost/interprocess/sync/named_recursive_mutex.hpp>
+ #include <ipmid/api.hpp>
+@@ -174,6 +176,30 @@ struct UsersTbl
+     UserInfo user[ipmiMaxUsers + 1];
+ };
+ 
++/** @struct UserDataFileId
++ *
++ *  Struct for user data file identity
++ */
++struct UserDataFileId
++{
++    ino_t inode = 0;
++    off_t size = 0;
++    std::timespec mtime = {0, 0};
++
++    bool operator==(const UserDataFileId& rhs) const
++    {
++        return inode == rhs.inode && size == rhs.size &&
++               mtime.tv_sec == rhs.mtime.tv_sec &&
++               mtime.tv_nsec == rhs.mtime.tv_nsec;
++    }
++
++    /** @brief a zero inode means the file could not be stat()'ed */
++    bool valid() const
++    {
++        return inode != 0;
++    }
++};
++
+ /** @brief PAM User Authentication check
+  *
+  *  @param[in] username - username in string
+@@ -471,16 +497,17 @@ class UserAccess
+     std::vector<std::string> availablePrivileges;
+     std::vector<std::string> availableGroups;
+     sdbusplus::bus_t bus;
+-    std::timespec fileLastUpdatedTime;
++    UserDataFileId fileLastUpdatedId;
+     bool signalHndlrObject = false;
+     boost::interprocess::file_lock sigHndlrLock;
+     boost::interprocess::file_lock mutexCleanupLock;
+ 
+-    /** @brief function to get user configuration file timestamp
++    /** @brief function to get the user configuration file identity
+      *
+-     *  @return time stamp or -EIO for failure
++     *  @return file identity, or a default-constructed (invalid) value on
++     *          failure to stat the file
+      */
+-    std::timespec getUpdatedFileTime();
++    UserDataFileId getUserDataFileId();
+ 
+     /** @brief function to available system privileges and groups
+      *
+-- 
+2.39.5
+

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -3,3 +3,4 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 PACKAGECONFIG:append = " dynamic-sensors"
 
 SRC_URI:append = " file://0001-apphandler-fall-back-to-ObjectMapper-when-settings-U.patch"
+SRC_URI:append = " file://0002-user_channel-detect-user-data-file-changes-by-inode.patch"


### PR DESCRIPTION
Fix a issue were the user created does not have privilege to login.

```
**Stderr** (3 lines):
Set Session Privilege Level to ADMINISTRATOR failed: Insufficient privilege level
Error: Unable to establish IPMI v2 / RMCP+ session
Close Session command failed: Insufficient privilege level
error executing command: process exited with non-zero code: 1
```

Closes https://github.com/canopybmc/canopybmc/issues/259

---

Bug found.

`ipmid` and `netipmid` each cache the full IPMI user table and detect each other's updates only by the `mtime` of `/var/lib/ipmi/ipmi_user.json` (the overlay is JFFS2 and has whole-second timestamps). If the user creation and enabling commands landed on the same second, `netipmid` served a stale, pre-enable copy, which it then rejects at RAKP-1 with `INACTIVE_ROLE` ("invalid role").
