### PR TITLE
meta-hpe: em: Rename SPIFlash to HostSPIFlash

### DIFF
--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl320g11_baseboard.json
@@ -276,7 +276,7 @@
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
             "Partition": "host-second",
-            "Type": "SPIFlash"
+            "Type": "HostSPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl345g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl345g11_baseboard.json
@@ -464,7 +464,7 @@
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
             "Partition": "host-second",
-            "Type": "SPIFlash"
+            "Type": "HostSPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl360g11_baseboard.json
@@ -335,7 +335,7 @@
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
             "Partition": "host-second",
-            "Type": "SPIFlash"
+            "Type": "HostSPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl365g11_baseboard.json
@@ -936,7 +936,7 @@
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
             "Partition": "host-second",
-            "Type": "SPIFlash"
+            "Type": "HostSPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380ag11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380ag11_baseboard.json
@@ -371,7 +371,7 @@
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
             "Partition": "host-second",
-            "Type": "SPIFlash"
+            "Type": "HostSPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl380g11_baseboard.json
@@ -371,7 +371,7 @@
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
             "Partition": "host-second",
-            "Type": "SPIFlash"
+            "Type": "HostSPIFlash"
         }
     ],
     "Name": "chassis",

--- a/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl385g11_baseboard.json
+++ b/meta-canopy/meta-hpe/meta-common/recipes-phosphor/configuration/entity-manager/dl385g11_baseboard.json
@@ -519,7 +519,7 @@
             "SPIControllerIndex": 1,
             "SPIDeviceIndex": 1,
             "Partition": "host-second",
-            "Type": "SPIFlash"
+            "Type": "HostSPIFlash"
         }
     ],
     "Name": "chassis",


### PR DESCRIPTION
Upstream introduced clearer naming [1], so we're changing it accordingly [2]. Tested it on the DL320 [3],[4]

[1] https://gerrit.openbmc.org/c/openbmc/phosphor-bmc-code-mgmt/+/93036
[2] https://gerrit.openbmc.org/c/openbmc/entity-manager/+/92050
[3] https://app.firmware-ci.com/canopy/jobs/01M0J26P5105V0Z3X13ST9RVWQ?projectID=01KKGTVRZ3XK1ZDSAETKB1624Y
[4] https://app.firmware-ci.com/canopy/jobs/01M0J2MZ2TVNJ05XM64K4W28NR?projectID=01KKGTVRZ3XK1ZDSAETKB1624Y