### PR TITLE
demo/osfc2026

### DIFF
--- a/.firmwareci/duts/dut-hpe-dl320/dut.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/dut.yaml
@@ -1,10 +1,10 @@
 name: HPE-DL320
 label: hpe-dl320
 attributes:
-  BMC: dl320g11-bmc-fwci.lab.9e.network
+  BMC: bmc.demo.firmware-ci.com
   BMCPassword: 0penBmc
-  Agent: worker102.lab.9e.network:1024
-  Device: dl320
-  Host: dl320g11-1.lab.9e.network
+  Agent: worker108.demo.firmware-ci.com:1024
+  Device: hpe-dl320-bmc
+  Host: host.demo.firmware-ci.com
   HostUser: oscar
 reservation-system: dutctl

--- a/.firmwareci/duts/dut-hpe-dl320/post.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/post.yaml
@@ -40,5 +40,4 @@ post-stage:
     parameters:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
-      command: power
-      args: ["off"]
+      command: power-off

--- a/.firmwareci/duts/dut-hpe-dl320/pre.yaml
+++ b/.firmwareci/duts/dut-hpe-dl320/pre.yaml
@@ -4,15 +4,16 @@ pre-stage:
     parameters:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
-      command: power
-      args: ["off"]
+      command: power-off
 
   - cmd: dutctl
     name: Emulate Flash
+    options:
+      timeout: 15m
     parameters:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
-      command: emulate-bmc
+      command: flash
       args: ["[[input.firmware]]"]
 
   - cmd: dutctl
@@ -20,8 +21,7 @@ pre-stage:
     parameters:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
-      command: power
-      args: ["on"]
+      command: power-on
 
   - cmd: cmd
     name: Setup Tools

--- a/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-ci/tests/inventory-memory.yaml
@@ -132,7 +132,7 @@ stages:
           expect:
             - regex: '"PartNumber": "HMCG88AGBRA619N"'
       - cmd: cmd
-        name: dimm2 SerialNumber is E3712D7D
+        name: dimm2 SerialNumber is E3712D56
         transport: *local
         options:
           timeout: 30s
@@ -141,7 +141,7 @@ stages:
           executable: curl
           args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm2"]
           expect:
-            - regex: '"SerialNumber": "E3712D7D"'
+            - regex: '"SerialNumber": "E3712D56"'
 
   - name: DIMM9 Attributes
     steps:
@@ -190,7 +190,7 @@ stages:
           expect:
             - regex: '"PartNumber": "HMCG88AGBRA619N"'
       - cmd: cmd
-        name: dimm9 SerialNumber is E3712D3E
+        name: dimm9 SerialNumber is E3712D81
         transport: *local
         options:
           timeout: 30s
@@ -199,7 +199,7 @@ stages:
           executable: curl
           args: [-sk, -u, "root:[[attributes.BMCPassword]]", "https://[[attributes.BMC]]/redfish/v1/Systems/system/Memory/dimm9"]
           expect:
-            - regex: '"SerialNumber": "E3712D3E"'
+            - regex: '"SerialNumber": "E3712D81"'
 
   - name: System Memory Summary
     steps:

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/boot-time.yaml
@@ -10,15 +10,16 @@ pre-stage:
     parameters:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
-      command: power
-      args: ["off"]
+      command: power-off
 
   - cmd: dutctl
     name: Emulate Flash
+    options:
+      timeout: 15m
     parameters:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
-      command: emulate-bmc
+      command: flash
       args: ["[[input.firmware]]"]
 
   - cmd: dutctl
@@ -26,8 +27,7 @@ pre-stage:
     parameters:
       agent: "[[attributes.Agent]]"
       device: "[[attributes.Device]]"
-      command: power
-      args: ["on"]
+      command: power-on
 
   - cmd: dutctl
     name: Boot banner within 80s

--- a/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
+++ b/.firmwareci/workflows/hpe-dl320-g11-main/tests/user-persistence.yaml
@@ -60,8 +60,7 @@ stages:
         parameters:
           agent: "[[attributes.Agent]]"
           device: "[[attributes.Device]]"
-          command: power
-          args: ["off"]
+          command: power-off
       - cmd: cmd
         name: Wait for BMC to power down
         transport: *local
@@ -73,8 +72,7 @@ stages:
         parameters:
           agent: "[[attributes.Agent]]"
           device: "[[attributes.Device]]"
-          command: power
-          args: ["on"]
+          command: power-on
       - cmd: dutctl
         name: Wait for boot banner on serial
         options:


### PR DESCRIPTION
The board now runs on worker108 behind the travel router, so the DUT addresses it by demo hostname and the dutctl steps use that agent's command names (power-on/power-off/flash instead of power on|off and emulate-bmc).